### PR TITLE
Fix Tenant index migration was failing

### DIFF
--- a/lib/multitenancy/migrate_tenants.js
+++ b/lib/multitenancy/migrate_tenants.js
@@ -33,7 +33,7 @@ import _ from 'lodash';
 import Boom from 'boom';
 import elasticsearch from 'elasticsearch';
 import wrapElasticsearchError from './../backend/errors/wrap_elasticsearch_error';
-// import { KibanaMigrator } from '../../../../src/server/saved_objects/migrations';
+import { KibanaMigrator } from '../../../../src/server/saved_objects/migrations';
 
 async function migrateTenants (server) {
 


### PR DESCRIPTION
Tenant index migration was failing because KibanaMigrator import statement was commented. Uncommenting that to resolve this issue.