### PR TITLE
Pass whitelisted headers from kibana to elasticsearch (non-basic auth)

### DIFF
--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -102,9 +102,8 @@ export default class BasicAuth extends AuthType {
 
         // A login can happen via a POST request (login form) or when we have request headers with user credentials.
         // We also need to re-authenticate if the credentials (headers) don't match what's in the session.
-        // Passing the whitelisted headers along for logging in .. 
         try {
-            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, this.authHeaderName, credentials.authHeaderValue);
+            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithHeader(this.authHeaderName, credentials.authHeaderValue, whitelistedHeadersAndValues);
             let session = {
                 username: user.username,
                 credentials: credentials,

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -98,13 +98,13 @@ export default class BasicAuth extends AuthType {
         return null;
     }
 
-    async authenticate(credentials, options = {}, whitelistedHeaders) {
+    async authenticate(credentials, options = {}, whitelistedHeadersAndValues) {
 
         // A login can happen via a POST request (login form) or when we have request headers with user credentials.
         // We also need to re-authenticate if the credentials (headers) don't match what's in the session.
         // Passing the whitelisted headers along for logging in .. 
         try {
-            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithHeader(this.authHeaderName, credentials.authHeaderValue, whitelistedHeaders);
+            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, this.authHeaderName);
             let session = {
                 username: user.username,
                 credentials: credentials,

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -98,12 +98,13 @@ export default class BasicAuth extends AuthType {
         return null;
     }
 
-    async authenticate(credentials, options = {}) {
+    async authenticate(credentials, options = {}, whitelistedHeaders) {
 
         // A login can happen via a POST request (login form) or when we have request headers with user credentials.
         // We also need to re-authenticate if the credentials (headers) don't match what's in the session.
+        // Passing the whitelisted headers along for logging in .. 
         try {
-            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithHeader(this.authHeaderName, credentials.authHeaderValue);
+            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithHeader(this.authHeaderName, credentials.authHeaderValue, whitelistedHeaders);
             let session = {
                 username: user.username,
                 credentials: credentials,

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -104,7 +104,7 @@ export default class BasicAuth extends AuthType {
         // We also need to re-authenticate if the credentials (headers) don't match what's in the session.
         // Passing the whitelisted headers along for logging in .. 
         try {
-            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, this.authHeaderName);
+            let user = await this.server.plugins.opendistro_security.getSecurityBackend().authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, this.authHeaderName, credentials.authHeaderValue);
             let session = {
                 username: user.username,
                 credentials: credentials,

--- a/lib/backend/opendistro_security.js
+++ b/lib/backend/opendistro_security.js
@@ -72,7 +72,7 @@ export default class SecurityBackend {
         }
     }
 
-    async authenticateWithHeader(headerName, headerValue) {
+    async authenticateWithHeader(headerName, headerValue, whitelistedHeaders) {
 
         try {
             const credentials = {
@@ -83,8 +83,14 @@ export default class SecurityBackend {
             let headers = {};
 
             // For anonymous auth, we wouldn't have any value here
-            if (headerValue) {
-                headers[headerName] = headerValue
+            // Pass the whitelisted headers, if authorization is non-basic 
+            // Maybe we should make it SIGV4 specific ? 
+	    if (headerValue != undefined && !headerValue.startsWith("Basic")) {
+                headers = whitelistedHeaders;
+            } else  {
+		if (headerValue) {
+                    headers[headerName] = headerValue;
+                }
             }
 
             const response = await this._client.opendistro_security.authinfo({

--- a/lib/backend/opendistro_security.js
+++ b/lib/backend/opendistro_security.js
@@ -71,20 +71,24 @@ export default class SecurityBackend {
             }
         }
     }
-
-    async authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, headerName) {
+    
+    /** This function is for passing all the whitelisted headers ( replacing the authorization header with
+     *  the value from the session credentials instead of the headers )
+     */
+    async authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, headerName, headerValue) {
 
         try {
             const credentials = {
                 headerName: headerName,
-                headerValue: whitelistedHeadersAndValues[headerName]
+                headerValue: headerValue
             };
 
-            let headers = {};
+            let headers = whitelistedHeadersAndValues
 
             // For anonymous auth, we wouldn't have any value here
-	    if (whitelistedHeadersAndValues[headerName])
-                headers = whitelistedHeadersAndValues;
+            // We are also not going to be sending whitelisted headers for anonymous auth. 
+	    if (headerValue) {
+                headers[headerName] = headerValue
             } 
 
             const response = await this._client.opendistro_security.authinfo({

--- a/lib/backend/opendistro_security.js
+++ b/lib/backend/opendistro_security.js
@@ -72,7 +72,36 @@ export default class SecurityBackend {
         }
     }
 
-    async authenticateWithHeader(headerName, headerValue, whitelistedHeaders) {
+    async authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, headerName) {
+
+        try {
+            const credentials = {
+                headerName: headerName,
+                headerValue: whitelistedHeadersAndValues[headerName]
+            };
+
+            let headers = {};
+
+            // For anonymous auth, we wouldn't have any value here
+	    if (whitelistedHeadersAndValues[headerName])
+                headers = whitelistedHeadersAndValues;
+            } 
+
+            const response = await this._client.opendistro_security.authinfo({
+                headers: headers
+            });
+            return new User(response.user_name, credentials, null, response.roles, response.backend_roles, response.tenants, response.user_requested_tenant);
+        } catch(error) {
+            if (error.status == 401) {
+                throw new AuthenticationError("Invalid username or password");
+            } else {
+                throw new Error(error.message);
+            }
+        }
+
+    }
+
+    async authenticateWithHeader(headerName, headerValue) {
 
         try {
             const credentials = {
@@ -83,14 +112,8 @@ export default class SecurityBackend {
             let headers = {};
 
             // For anonymous auth, we wouldn't have any value here
-            // Pass the whitelisted headers, if authorization is non-basic 
-            // Maybe we should make it SIGV4 specific ? 
-	    if (headerValue != undefined && !headerValue.startsWith("Basic")) {
-                headers = whitelistedHeaders;
-            } else  {
-		if (headerValue) {
-                    headers[headerName] = headerValue;
-                }
+            if (headerValue) {
+                headers[headerName] = headerValue
             }
 
             const response = await this._client.opendistro_security.authinfo({

--- a/lib/backend/opendistro_security.js
+++ b/lib/backend/opendistro_security.js
@@ -72,40 +72,7 @@ export default class SecurityBackend {
         }
     }
     
-    /** This function is for passing all the whitelisted headers ( replacing the authorization header with
-     *  the value from the session credentials instead of the headers )
-     */
-    async authenticateWithWhitelistedHeadersAndValues(whitelistedHeadersAndValues, headerName, headerValue) {
-
-        try {
-            const credentials = {
-                headerName: headerName,
-                headerValue: headerValue
-            };
-
-            let headers = whitelistedHeadersAndValues
-
-            // For anonymous auth, we wouldn't have any value here
-            // We are also not going to be sending whitelisted headers for anonymous auth. 
-	    if (headerValue) {
-                headers[headerName] = headerValue
-            } 
-
-            const response = await this._client.opendistro_security.authinfo({
-                headers: headers
-            });
-            return new User(response.user_name, credentials, null, response.roles, response.backend_roles, response.tenants, response.user_requested_tenant);
-        } catch(error) {
-            if (error.status == 401) {
-                throw new AuthenticationError("Invalid username or password");
-            } else {
-                throw new Error(error.message);
-            }
-        }
-
-    }
-
-    async authenticateWithHeader(headerName, headerValue) {
+    async authenticateWithHeader(headerName, headerValue, whitelistedHeadersAndValues) {
 
         try {
             const credentials = {
@@ -118,6 +85,16 @@ export default class SecurityBackend {
             // For anonymous auth, we wouldn't have any value here
             if (headerValue) {
                 headers[headerName] = headerValue
+                if (whitelistedHeadersAndValues != null && whitelistedHeadersAndValues != undefined) {
+                    // Add all whitelisted headers that are not headerName -> i.e. basic auth
+                    // Skipping over the headerName key because we want session credentials, not 
+                    // request credentials. 
+                    for (var key in whitelistedHeadersAndValues) {
+                        if (key != headerName) {
+                            headers[key] = whitelistedHeadersAndValues[key];
+                        }
+                    }
+                }
             }
 
             const response = await this._client.opendistro_security.authinfo({

--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -1,5 +1,6 @@
 import MissingTenantError from "../auth/errors/missing_tenant_error";
 import MissingRoleError from "../auth/errors/missing_role_error";
+import filterAuthHeaders from '../auth/filter_auth_headers';
 
 var Hoek = require('hoek');
 var Joi = require('joi');
@@ -26,6 +27,7 @@ const register = function (server, options) {
     Hoek.assert(!results.error, results.error);
 
     let settings = results.value;
+    let esconfig = server.config().get('elasticsearch');
 
     // @todo Don't register e.g. authenticate() when we have Kerberos or Proxy-Auth?
     server.ext('onPreAuth', function (request, h) {
@@ -39,8 +41,11 @@ const register = function (server, options) {
              */
             authenticate: async function(credentials, options = {}) {
                 try {
+		    
+		    let whitelistedHeaders = filterAuthHeaders(request.headers, esconfig.requestHeadersWhitelist);
+
                     // authResponse is an object with .session and .user
-                    const authResponse = await settings.authenticateFunction(credentials, options);
+                    const authResponse = await settings.authenticateFunction(credentials, options, whitelistedHeaders);
 
                     return this._handleAuthResponse(credentials, authResponse);
                 } catch(error) {

--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -42,10 +42,10 @@ const register = function (server, options) {
             authenticate: async function(credentials, options = {}) {
                 try {
 		    
-		    let whitelistedHeaders = filterAuthHeaders(request.headers, esconfig.requestHeadersWhitelist);
+		    let whitelistedHeadersAndValues = filterAuthHeaders(request.headers, esconfig.requestHeadersWhitelist);
 
                     // authResponse is an object with .session and .user
-                    const authResponse = await settings.authenticateFunction(credentials, options, whitelistedHeaders);
+                    const authResponse = await settings.authenticateFunction(credentials, options, whitelistedHeadersAndValues);
 
                     return this._handleAuthResponse(credentials, authResponse);
                 } catch(error) {


### PR DESCRIPTION
Calls between Kibana and elasticsearch seem to ignore whitelisted headers. This PR is for passing those headers. The same behaviour is kept for a basic auth case. 