### PR TITLE
Fixed Backend Role button

### DIFF
--- a/public/apps/configuration/sections/internalusers/views/edit.html
+++ b/public/apps/configuration/sections/internalusers/views/edit.html
@@ -80,7 +80,7 @@
                                         <td class="kuiTableRowCell cellAlignTop actions">
                                             <button type="button"
                                                     id="opendistro_security.button.backendroles.add"
-                                                    ng-click="addArrayEntry(resource, 'roles', '')"
+                                                    ng-click="addArrayEntry(resource, 'backend_roles', '')"
                                                     ng-disabled="lastArrayEntryEmpty(resource.backend_roles)"
                                                     class="kuiButton kuiButton--primary kuiButton--iconText ">
                                                 <span class="kuiButton__icon kuiIcon fa-plus"></span>


### PR DESCRIPTION
# Summary

## Changes
- Fixed typo in parameter name that caused a UI error that prevented backend roles to added to internal users

## Test
- Sanity tested this feature