### PR TITLE
fixed backend role button

### DIFF
--- a/public/apps/configuration/sections/internalusers/views/edit.html
+++ b/public/apps/configuration/sections/internalusers/views/edit.html
@@ -80,7 +80,7 @@
                                         <td class="kuiTableRowCell cellAlignTop actions">
                                             <button type="button"
                                                     id="opendistro_security.button.backendroles.add"
-                                                    ng-click="addArrayEntry(resource, 'roles', '')"
+                                                    ng-click="addArrayEntry(resource, 'backend_roles', '')"
                                                     ng-disabled="lastArrayEntryEmpty(resource.backend_roles)"
                                                     class="kuiButton kuiButton--primary kuiButton--iconText ">
                                                 <span class="kuiButton__icon kuiIcon fa-plus"></span>


### PR DESCRIPTION
Previous fix that's missing in 1.1.

More detail see [here](https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/pull/44).