### PR TITLE
Fix ace_aditor css scope to only apply kibana security plugin

### DIFF
--- a/public/apps/configuration/configuration.less
+++ b/public/apps/configuration/configuration.less
@@ -197,7 +197,7 @@ h5 {
   font-size: 14px;
 }
 
-.ace_editor {
+.security .ace_editor {
   min-height: 300px;
   border: 1px solid #f0f0f0;
 }


### PR DESCRIPTION
This was the bug that's causing alerting "run" button to be covered up.

Manually tested.