### PR TITLE
AuthType Session Fix

### DIFF
--- a/public/chrome/configuration/enable_configuration.js
+++ b/public/chrome/configuration/enable_configuration.js
@@ -78,9 +78,17 @@ app.factory('errorInterceptor', function ($q, $window) {
 
     return {
         responseError: function (response) {
-
             // Handles 401s, but only if we've explicitly set the redirect property on the response.
-            if (response.status == 401 && response.data && response.data.redirectTo === 'login') {
+            // Fix for https://github.com/angular/angular/issues/19888
+            var data = null;
+            if (response.data) {
+                try { // Security plugin returns real json data. If its real json.parse fails and it sets data as the response
+                    data = JSON.parse(response.data);
+                } catch (error) {
+                    data = response.data;
+                }
+            }
+            if (response.status == 401 && data && data.redirectTo === 'login') {
                 redirectOnSessionTimeout($window);
             }
 


### PR DESCRIPTION
This pull request resolves issues with session timeouts and ajax requests for a openid connect endpoint resulting in CORS issues.

Tracking the fix to https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/68

Amazon has fixed most of the changes related to session timeouts and redirects. The only thing that does not work is XHR requests currently once the session has expired. To replicate the issue:

1. Go to search
2. Wait for session to expire
3. Press refresh

It will then throw an exception related to authentication (as of ODFE 1.3.0). This is due to an angular bug which is addressed in this PR.