### PR TITLE
add the ability to configure logout_url for 1.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ export default function (kibana) {
                     type: Joi.string().valid(['', 'basicauth', 'jwt', 'openid', 'saml', 'proxy', 'kerberos', 'proxycache']).default(''),
                     anonymous_auth_enabled: Joi.boolean().default(false),
                     unauthenticated_routes: Joi.array().default(["/api/status"]),
+                    logout_url: Joi.string().allow('').default(''),
                 }).default(),
                 basicauth: Joi.object().keys({
                     enabled: Joi.boolean().default(true),


### PR DESCRIPTION
We need to allow the logout_url parameter to be read as a part of the auth config from inside kibana.yml ... This change allows for that. This change was part of a cherry-pick that wasn't done correctly. This is specific to master branch, we will need a different pull request for 1.1 and 1.0. 