### PR TITLE
Add ability to configure logout url for 1.1 and 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ export default function (kibana) {
                     type: Joi.string().valid(['', 'basicauth', 'jwt', 'openid', 'saml', 'proxy', 'kerberos', 'proxycache']).default(''),
                     anonymous_auth_enabled: Joi.boolean().default(false),
                     unauthenticated_routes: Joi.array().default(["/api/status"]),
+                    logout_url: Joi.string().allow('').default(''),
                 }).default(),
                 basicauth: Joi.object().keys({
                     enabled: Joi.boolean().default(true),

--- a/public/services/access_control.js
+++ b/public/services/access_control.js
@@ -41,6 +41,7 @@ uiModules
 
   const authConfig = chrome.getInjected('auth');
   const authType = authConfig.type || null;
+  const logoutUrl = authConfig.logout_url || null;
 
   class SecurityControlService {
 
@@ -57,7 +58,11 @@ uiModules
                     $window.location.href = `${APP_ROOT}/customerror`;
                 }
             } else {
-                $window.location.href = `${APP_ROOT}/login?type=${authType || ''}Logout`;
+                if (logoutUrl && logoutUrl.length > 0) {
+                    $window.location.href = logoutUrl;
+                } else {
+                    $window.location.href = `${APP_ROOT}/login?type=${authType || ''}Logout`;
+                }
             }
           },
           (error) =>


### PR DESCRIPTION
We need this checkin to allow the logout url to be configurable. This commit was a part of ODFE 0.8,0.9, but is missing from 1.1 and 1.0. There is a separate PR for master. 