### PR TITLE
Fix issue with migration of index templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,6 +477,7 @@ export default function (kibana) {
                             this.status.green('Open Distro Security plugin version '+ opendistro_security_version + ' initialised.');
                         })
                         .catch((error) => {
+                            server.log(['error', 'Search Guard migration'], error);
                             this.status.yellow('Tenant indices migration failed');
                         });
 

--- a/lib/multitenancy/migrate_tenants.js
+++ b/lib/multitenancy/migrate_tenants.js
@@ -34,10 +34,14 @@ import Boom from 'boom';
 import elasticsearch from 'elasticsearch';
 import wrapElasticsearchError from './../backend/errors/wrap_elasticsearch_error';
 import { KibanaMigrator} from "../../../../src/legacy/server/saved_objects/migrations/kibana";
+import { IndexMigrator } from '../../../../src/legacy/server/saved_objects/migrations/core';
 
 async function migrateTenants (server) {
 
     const backend = server.plugins.opendistro_security.getSecurityBackend();
+    await server.plugins.elasticsearch.waitUntilReady();
+    await server.kibanaMigrator.kbnServer.ready();
+    server.log(['info', 'Search Guard migration'], "Starting tenant migration");
 
     try {
         let tenantInfo = await backend.getTenantInfoWithInternalUser();
@@ -45,7 +49,7 @@ async function migrateTenants (server) {
         if (tenantInfo) {
              let indexNames = Object.keys(tenantInfo);
              for (var index = 0; index < indexNames.length; ++index) {
-                 await migrateTenantIndex(indexNames[index], server);
+                 await runMigration(server, indexNames[index]);
              }
          }
     } catch (error) {
@@ -54,64 +58,23 @@ async function migrateTenants (server) {
     }
 }
 
-async function migrateTenantIndex(tenantIndexName, server) {
-    const {kbnServer} = mockKbnServer(server.kibanaMigrator.kbnServer, server, tenantIndexName);
-    const migrator = new KibanaMigrator({kbnServer});
-    await  migrator.awaitMigration();
-}
+async function runMigration(server, tenantIndexName) {
+    const  kibanaMigrator = server.kibanaMigrator;
+    const config = server.config();
 
-async function migrateTenant(tenantIndexName, force, server) {
-    const backend = server.plugins.opendistro_security.getSecurityBackend();
-    try {
-        let tenantInfo = await backend.getTenantInfoWithInternalUser();
-        if (tenantInfo) {
-            if (tenantInfo[tenantIndexName] || (force == true)) {
-                await migrateTenantIndex(tenantIndexName, server);
-                return {statusCode:200, message: tenantIndexName + " migrated."}
-            } else {
-                return Boom.badRequest('Index ' + tenantIndexName + ' not found or not a tenand index. Force migration: ' + force);
-            }
-        } else {
-            return Boom.badImplementation("Could not fetch tenant info.");
-        }
-    } catch (error) {
-        server.log(['error', 'migration'], error);
-        return wrapElasticsearchError(error);
-    }
-}
+    const indexMigrator = new IndexMigrator({
+        batchSize: config.get('migrations.batchSize'),
+        callCluster: server.plugins.elasticsearch.getCluster('admin').callWithInternalUser,
+        documentMigrator: kibanaMigrator.documentMigrator,
+        index: tenantIndexName,
+        log: kibanaMigrator.log,
+        mappingProperties: kibanaMigrator.mappingProperties,
+        pollInterval: config.get('migrations.pollInterval'),
+        scrollDuration: config.get('migrations.scrollDuration'),
+        serializer: kibanaMigrator.serializer,
+    });
 
-function mockKbnServer(originalKbnServer, server, indexname) {
-
-    const kbnServer = {
-        version: originalKbnServer.version,
-        ready: originalKbnServer.ready,
-        uiExports: originalKbnServer.uiExports,
-        server: {
-            config: () => ({
-                get: ((name) => {
-                    switch (name) {
-                        case 'kibana.index':
-                            return indexname;
-                        case 'migrations.batchSize':
-                            return originalKbnServer.server.config().get("migrations.batchSize");
-                        case 'migrations.pollInterval':
-                            return originalKbnServer.server.config().get("migrations.pollInterval");
-                        case 'migrations.scrollDuration':
-                            return originalKbnServer.server.config().get("migrations.scrollDuration");
-                        default:
-                            throw new Error(`Unexpected config ${name}`);
-                    }
-                })
-            }),
-            log: function (tags, data, timestamp, _internal) {
-                server.log(tags, data, timestamp, _internal);
-            },
-            plugins: originalKbnServer.server.plugins
-        }
-    };
-
-    return { kbnServer };
+    return indexMigrator.migrate();
 }
 
 module.exports.migrateTenants=migrateTenants;
-module.exports.migrateTenant=migrateTenant;


### PR DESCRIPTION
Currently, when we try to migrate from 6.8 to 7.1, we get the following exception when trying to access kibana. 

kibana.log:90:{"type":"error","@timestamp":"2019-09-18T21:16:30Z","tags":["error","migration"],"pid":11656,"level":"error","error":{"message":"[index_template_missing_exception] index_template [kibana_index_template:.kibana] missing","name":"Error","stack":"[index_template_missing_exception] index_template [kibana_index_template:.kibana] missing :: {\"path\":\"/_template/kibana_index_template%3A.kibana\",\"query\":{},\"statusCode\":404,\"response\":\"{\\\"error\\\":{\\\"root_cause\\\":[{\\\"type\\\":\\\"index_template_missing_exception\\\",\\\"reason\\\":\\\"index_template [kibana_index_template:.kibana] missing\\\"}],\\\"type\\\":\\\"index_template_missing_exception\\\",\\\"reason\\\":\\\"index_template [kibana_index_template:.kibana] missing\\\"},\\\"status\\\":404}\"}\n    at respond (/apollo/_env/swift-us-east-1-staging-Kibana_7_1AMI-ES2-156869904486/node_modules/elasticsearch/src/lib/transport.js:308:15)\n    at checkRespForFailure (/apollo/_env/swift-us-east-1-staging-Kibana_7_1AMI-ES2-156869904486/node_modules/elasticsearch/src/lib/transport.js:267:7)\n    at HttpConnector.<anonymous> (/apollo/_env/swift-us-east-1-staging-Kibana_7_1AMI-ES2-156869904486/node_modules/elasticsearch/src/lib/connectors/http.js:166:7)\n    at IncomingMessage.wrapper (/apollo/_env/swift-us-east-1-staging-Kibana_7_1AMI-ES2-156869904486/node_modules/elasticsearch/node_modules/lodash/lodash.js:4935:19)\n    at IncomingMessage.emit (events.js:194:15)\n    at endReadableNT (_stream_readable.js:1103:12)\n    at process._tickCallback (internal/process/next_tick.js:63:19)"},"message":"[index_template_missing_exception] index_template [kibana_index_template:.kibana] missing"}

This results in indices not getting migrated, which in turn results in users seeing: 

{"message":"mapping set to strict, dynamic introduction of [references] within [doc] is not allowed: [strict_dynamic_mapping_exception] mapping set to strict, dynamic introduction of [references] within [doc] is not allowed","statusCode":400,"error":"Bad Request”}