### PR TITLE
Add check for api access and update accessState

### DIFF
--- a/public/apps/configuration/base_controller.js
+++ b/public/apps/configuration/base_controller.js
@@ -81,7 +81,11 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
     $scope.initialiseStates = () => {
         $scope.complianceFeaturesEnabled = systemstate.complianceFeaturesEnabled();
         systemstate.loadRestInfo().then(function(){
-            $scope.accessState = "ok";
+            if (systemstate.getRestApiInfo().has_api_access) {
+                $scope.accessState = "ok";
+            } else {
+                $scope.accessState = "forbidden";
+            }
             $scope.loadActionGroups();
             $scope.loadRoles();
             $scope.currentuser = systemstate.getRestApiInfo().user_name;


### PR DESCRIPTION
This PR adds a check in intialiseStates for accessState variable, as it was always ok and the UI doesn't look good for the user not having the security permission.

![image](https://user-images.githubusercontent.com/29499601/65662372-c98dd880-e051-11e9-83ed-290af7d71108.png)


If a user does not have permission it should be this: 

![image](https://user-images.githubusercontent.com/29499601/65662608-50db4c00-e052-11e9-8197-324f579110c5.png)



Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>