### PR TITLE
Fix: Security Multitenancy "Show Dashboard" button should redirect users to the dashboards page

### DIFF
--- a/public/apps/multitenancy/multitenancy.js
+++ b/public/apps/multitenancy/multitenancy.js
@@ -205,8 +205,8 @@ uiModules
                         if (appsToReset.indexOf(navLink.id) > -1) {
                             chromeWrapper.resetLastSubUrl(navLink.id);
                         }
-                    });  
-                    
+                    });
+
                     if(chrome.getInjected("timelion.ui.enabled")) {
                         chromeWrapper.getNavLinkById("timelion").lastSubUrl = chromeWrapper.getNavLinkById("timelion").url;
                     }
@@ -227,10 +227,10 @@ uiModules
                     // redirect to either Visualize or Dashboard depending on user selection.
                     if(redirect) {
                         if (redirect == 'vis') {
-                            $window.location.href = chromeWrapper.getNavLinkById("kibana:visualize").url;
+                            $window.location.href = chromeWrapper.getNavLinkById("kibana:visualize").baseUrl;
                         }
                         if (redirect == 'dash') {
-                            $window.location.href = chromeWrapper.getNavLinkById("kibana:dashboard").url;
+                            $window.location.href = chromeWrapper.getNavLinkById("kibana:dashboard").baseUrl;
                         }
                     } else {
                         toastNotifications.addSuccess({


### PR DESCRIPTION
Tested changes locally. 

Clicking on "Show Dashboard" button re-directs user to the /dashboards/ page.