### PR TITLE
Specify headers to be stored in session

### DIFF
--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -119,6 +119,7 @@ export default class AuthType {
                 authType: this.type,
                 authHeaderName: this.authHeaderName,
                 allowedHeaders: union(this.requestHeadersWhitelist, this.allowedAdditionalAuthHeaders),
+                headersToStoreInSession: this.allowedAdditionalAuthHeaders,
                 authenticateFunction: this.authenticate.bind(this),
                 validateAvailableTenants: this.validateAvailableTenants
             }

--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -17,6 +17,7 @@ internals.config = Joi.object({
     authType: Joi.string().allow(null),
     authHeaderName: Joi.string(),
     allowedHeaders: Joi.array().default([]),
+    headersToStoreInSession: Joi.array().default([]),
     authenticateFunction: Joi.func(),
     validateAvailableTenants: Joi.boolean().default(true),
     validateAvailableRoles: Joi.boolean().default(true)
@@ -119,7 +120,7 @@ const register = function (server, options) {
                 // If we used any additional auth headers when authenticating, we need to store them in the session
                 authResponse.session.additionalAuthHeaders = null;
                 if (Object.keys(additionalAuthHeaders).length) {
-                    authResponse.session.additionalAuthHeaders = additionalAuthHeaders;
+                    authResponse.session.additionalAuthHeaders = filterAuthHeaders(additionalAuthHeaders, settings.headersToStoreInSession);
                 }
 
                 request.cookieAuth.set(authResponse.session);

--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -117,7 +117,8 @@ const register = function (server, options) {
                     throw new MissingRoleError('No roles available for this user, please contact your system administrator.');
                 }
 
-                // If we used any additional auth headers when authenticating, we need to store them in the session
+                // Store only specified auth headers in the session.
+                // Headers stored in the session are added to every request coming in at AuthType#addAdditionalAuthHeaders .
                 authResponse.session.additionalAuthHeaders = null;
                 if (Object.keys(additionalAuthHeaders).length) {
                     authResponse.session.additionalAuthHeaders = filterAuthHeaders(additionalAuthHeaders, settings.headersToStoreInSession);

--- a/tests/AuthType.test.js
+++ b/tests/AuthType.test.js
@@ -1,17 +1,5 @@
 import AuthType  from "../lib/auth/types/AuthType";
-
-class MockServer {
-    config() {
-        return {
-            get: () => {
-                return null;
-            }
-        }
-    }
-    register(args) {
-        this.registerArgs = args;
-    }
-}
+import { MockServer } from './Mocks'
 
 describe('AuthType tests', () => {
     it('should contain only security_impersonate_as when no additional headers are passed', () => {

--- a/tests/Mocks.js
+++ b/tests/Mocks.js
@@ -1,0 +1,44 @@
+class MockServer {
+    config() {
+        return {
+            get: () => {
+                return null;
+            }
+        }
+    }
+    ext(_, preAuthFunc) {
+        this.preAuthFunc = preAuthFunc;
+    }
+    register(args) {
+        this.registerArgs = args;
+    }
+}
+
+class MockRequest {
+    constructor() {
+        this.auth = {};
+        this.state = {};
+        this.cookieAuth = {
+            set(_) { }
+        };
+    }
+}
+
+class MockAuthResponse {
+    constructor() {
+        this.user = { roles: [""] };
+        this.session = {};
+    }
+}
+
+class MockHapi {
+    state(storageCookieName, storage) {
+    }
+}
+
+export {
+    MockServer,
+    MockRequest,
+    MockAuthResponse,
+    MockHapi
+}

--- a/tests/SessionPlugin.test.js
+++ b/tests/SessionPlugin.test.js
@@ -1,0 +1,57 @@
+import { plugin }  from "../lib/session/sessionPlugin";
+import { MockServer, MockRequest, MockAuthResponse, MockHapi } from './Mocks'
+
+describe('Session Plugin tests', () => {
+    var mockServer = new MockServer();
+    var request = new MockRequest();
+    var h = new MockHapi();
+    var authResponse = new MockAuthResponse();
+    const testHeaderKey1 = "test-header-key-1", testHeaderValue1 = "test-header-value-1";
+    const testHeaderKey2 = "test-header-key-2", testHeaderValue2 = "test-header-value-2";
+    var additionalAuthHeaders = {
+        [testHeaderKey1]: testHeaderValue1,
+        [testHeaderKey2]: testHeaderValue2
+    };
+
+    it('should store only 1 specified header in the session', () => {
+        // arrange
+        plugin.register(mockServer, { headersToStoreInSession:[testHeaderKey1] })
+        mockServer.preAuthFunc(request, h)
+        
+        // act
+        request.auth.securitySessionStorage._handleAuthResponse({}, authResponse, additionalAuthHeaders)
+
+        // assert
+        const storedHeaders = authResponse.session.additionalAuthHeaders;
+        expect(storedHeaders).toHaveProperty(testHeaderKey1, testHeaderValue1);
+        expect(storedHeaders).not.toHaveProperty(testHeaderKey2);
+    });
+
+    it('should store 2 specified headers in the session', () => {
+        // arrange
+        plugin.register(mockServer, { headersToStoreInSession:[testHeaderKey1, testHeaderKey2] })
+        mockServer.preAuthFunc(request, h)
+        
+        // act
+        request.auth.securitySessionStorage._handleAuthResponse({}, authResponse, additionalAuthHeaders)
+
+        // assert
+        const storedHeaders = authResponse.session.additionalAuthHeaders;
+        expect(storedHeaders).toHaveProperty(testHeaderKey1, testHeaderValue1);
+        expect(storedHeaders).toHaveProperty(testHeaderKey2, testHeaderValue2);
+    });
+
+    it('should store no headers in the session', () => {
+        // arrange
+        plugin.register(mockServer, { headersToStoreInSession:[] })
+        mockServer.preAuthFunc(request, h)
+        
+        // act
+        request.auth.securitySessionStorage._handleAuthResponse({}, authResponse, additionalAuthHeaders)
+
+        // assert
+        const storedHeaders = authResponse.session.additionalAuthHeaders;
+        expect(storedHeaders).not.toHaveProperty(testHeaderKey1, testHeaderValue1);
+        expect(storedHeaders).not.toHaveProperty(testHeaderKey2, testHeaderValue2);
+    });
+});


### PR DESCRIPTION
Issue: Currently all headers (whitelisted and additional headers) are stored in session. Any request that comes in, the headers in session are applied to it causing incorrect headers to be passed with the request. Corresponding code is as follows. 

lib/auth/types/AuthType.js
```
addAdditionalAuthHeaders(request, authHeader, session) {
        if (session.additionalAuthHeaders) {
            for (let header in session.additionalAuthHeaders) {
                authHeader[header] = session.additionalAuthHeaders[header];
            }
        }
    }
```

Fix: Specify what headers need to be stored in session  Eg:`security_impersonate_as` 