### PR TITLE
Fix build scripts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,13 +13,18 @@ jobs:
 
     - name: Checkout security kibana
       uses: actions/checkout@v1
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11.0.x
       
     - name: Test and Build
       run: |
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
         export NVM_HOME="$HOME/.nvm"
         ./build.sh
-        artifact_path=`ls $(pwd)/plugins/opendistro_security-*.zip`
+        artifact_path=`ls $(pwd)/target/releases/opendistro_security_kibana_plugin-*.zip`
         artifact_name=`basename $artifact_path`
         echo ::set-env name=ARTIFACT_PATH::$artifact_path
         echo ::set-env name=ARTIFACT_NAME::$artifact_name
@@ -35,7 +40,7 @@ jobs:
     - name: Upload Artifacts to S3
       run: |
         s3_path=s3://open-distro-artifacts/downloads
-        aws s3 cp plugins/*.zip $s3_path/kibana-plugins/opendistro-security/
+        aws s3 cp ${{ env.ARTIFACT_PATH }} $s3_path/kibana-plugins/opendistro-security/
         aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
 
     - name: Create Github Draft Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,18 @@ jobs:
 
     - name: Checkout security kibana
       uses: actions/checkout@v1
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11.0.x
       
     - name: Test and Build
       run: |
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
         export NVM_HOME="$HOME/.nvm"
         ./build.sh
-        artifact_path=`ls $(pwd)/plugins/opendistro_security-*.zip`
+        artifact_path=`ls $(pwd)/target/releases/opendistro_security_kibana_plugin-*.zip`
         artifact_name=`basename $artifact_path`
         echo ::set-env name=ARTIFACT_PATH::$artifact_path
         echo ::set-env name=ARTIFACT_NAME::$artifact_name

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,5 @@ jspm_packages
 .node_repl_history
 
 .DS_Store
-/pom.xml
 
 *.iml

--- a/clean.sh
+++ b/clean.sh
@@ -7,5 +7,4 @@ rm -rf ./target
 rm -rf ./releases
 rm -rf ./node_modules
 rm -rf ./build
-rm -rf ./plugins
 rm -f *.log

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
-    "@kbn/plugin-helpers": "link:../../packages/kbn-plugin-helpers",
     "babel-eslint": "^9.0.0",
     "core-js": "^3.2.1",
     "eslint": "^5.6.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<assembly>
+  <id>plugin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/build</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
+      <useDefaultExcludes>false</useDefaultExcludes>
+      <includes>
+        <include>kibana/**</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- Copyright 2015-2017 floragunn GmbH
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+<!--
+  ~ Portions Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.amazon.opendistroforelasticsearch</groupId>
+    <artifactId>opendistro_security_parent</artifactId>
+    <version>1.3.0.0</version>
+  </parent>
+
+  <groupId>com.amazon.opendistroforelasticsearch</groupId>
+  <artifactId>opendistro_security_kibana_plugin</artifactId>
+  <packaging>pom</packaging>
+  <version>1.5.0.0</version>
+  <name>Open Distro Security for Elasticsearch Kibana Plugin</name>
+  <description>Open Distro Security for Elasticsearch Kibana Plugin</description>
+  <url>https://github.com/opendistro-for-elasticsearch/security-kibana-plugin</url>
+  <inceptionYear>2017</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <plugin.descriptor>${basedir}/plugin.xml</plugin.descriptor>
+  </properties>
+
+  <scm>
+    <url>https://github.com/opendistro-for-elasticsearch/security-kibana-plugin</url>
+    <connection>scm:git:git@github.com:mauve-hedgehog/opendistro-elasticsearch-security-kibana-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:mauve-hedgehog/opendistro-elasticsearch-security-kibana-plugin.git</developerConnection>
+    <tag>v1.5.0.0</tag>
+  </scm>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues</url>
+  </issueManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>plugin</id>
+            <phase>package</phase>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <outputDirectory>${project.build.directory}/releases/</outputDirectory>
+              <descriptors>
+                <descriptor>${plugin.descriptor}</descriptor>
+              </descriptors>
+            </configuration>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Partially reverting back to using security-parent for packaging zip. 
There is a bug in one of the libraries used in Kibana 7.6.1 causing plugin-helpers build to fail. 
