### PR TITLE
Changing kibana security cluster name to make it work with Kibana Bas…

### DIFF
--- a/lib/backend/opendistro_security.js
+++ b/lib/backend/opendistro_security.js
@@ -44,6 +44,7 @@ export default class SecurityBackend {
     constructor(server, serverConfig, esConfig) {
         // client for authentication and authorization
         const config = Object.assign({ plugins: [SecurityPlugin], auth: true }, server.config().get('elasticsearch'));
+        //Changing the cluster name to make it work with Basic Kibana. Issue link: https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/16
         this._cluster = server.plugins.elasticsearch.createCluster('opendistro_security', config);
 
         // the es config for later use

--- a/lib/backend/opendistro_security.js
+++ b/lib/backend/opendistro_security.js
@@ -44,7 +44,7 @@ export default class SecurityBackend {
     constructor(server, serverConfig, esConfig) {
         // client for authentication and authorization
         const config = Object.assign({ plugins: [SecurityPlugin], auth: true }, server.config().get('elasticsearch'));
-        this._cluster = server.plugins.elasticsearch.createCluster('security', config);
+        this._cluster = server.plugins.elasticsearch.createCluster('opendistro_security', config);
 
         // the es config for later use
         this._esconfig = esConfig;


### PR DESCRIPTION
…ic version

*Issue #, if available: https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/16

*Description of changes:*
This change will make Open distro security kibana plugin to work with Basic Kibana Elastic version. 
The issue and the suggested solution is provided in the issue section.
It would be great if it get's released in the next version of OD plugin's.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
