### PR TITLE
Expose login page configurations to browser app

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -36,10 +36,12 @@ export const configSchema = schema.object({
             if (value === 'Strict' || value === 'Lax') {
               return `Allowed values of 'isSameSite' are ['Strict, 'Lax', true, false]`;
             }
-          }
+          },
         }),
-        schema.boolean()
-      ], { defaultValue: true }),
+        schema.boolean(),
+      ],
+      { defaultValue: true }
+    ),
   }),
   session: schema.object({
     ttl: schema.number({ defaultValue: 60 * 60 * 1000 }),
@@ -52,16 +54,16 @@ export const configSchema = schema.object({
         if (!['', 'basicauth', 'jwt', 'openid', 'saml', 'proxy', 'kerberos', 'proxycache'].includes(value)) {
           return `allowed auth.type are ['', 'basicauth', 'jwt', 'openid', 'saml', 'proxy', 'kerberos', 'proxycache']`;
         }
-      }
+      },
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ["/api/status"] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status'] }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),
   basicauth: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ["/api/status"] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status'] }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     header_trumps_session: schema.boolean({ defaultValue: false }),
     alternative_login: schema.object({
@@ -80,60 +82,92 @@ export const configSchema = schema.object({
       buttonstyle: schema.string({ defaultValue: '' }),
     }),
   }),
-  multitenancy: schema.maybe(schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
-    show_roles: schema.boolean({ defaultValue: false }),
-    enable_filter: schema.boolean({ defaultValue: false }),
-    debug: schema.boolean({ defaultValue: false }),
-    tenants: schema.object({
-      enable_private: schema.boolean({ defaultValue: true }),
-      enable_global: schema.boolean({ defaultValue: true }),
-      preferred: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  multitenancy: schema.maybe(
+    schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+      show_roles: schema.boolean({ defaultValue: false }),
+      enable_filter: schema.boolean({ defaultValue: false }),
+      debug: schema.boolean({ defaultValue: false }),
+      tenants: schema.object({
+        enable_private: schema.boolean({ defaultValue: true }),
+        enable_global: schema.boolean({ defaultValue: true }),
+        preferred: schema.arrayOf(schema.string(), { defaultValue: [] }),
+      }),
+    })
+  ),
+  configuration: schema.maybe(
+    schema.object({
+      enabled: schema.boolean({ defaultValue: true }),
+    })
+  ),
+  accountinfo: schema.maybe(
+    schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+    })
+  ),
+  openid: schema.maybe(
+    schema.object({
+      connect_url: schema.maybe(schema.string()),
+      header: schema.string({ defaultValue: 'Authorization' }),
+      // TODO: test if siblingRef() works here
+      // client_id is required when auth.type is openid
+      client_id: schema.conditional(schema.siblingRef('auth.type'), 'openid', schema.string(), schema.maybe(schema.string())),
+      client_secret: schema.string({ defaultValue: '' }),
+      scope: schema.string({ defaultValue: 'openid profile email address phone' }),
+      base_redirect_url: schema.string({ defaultValue: '' }),
+      logout_url: schema.string({ defaultValue: '' }),
+      root_ca: schema.string({ defaultValue: '' }),
+      verify_hostnames: schema.boolean({ defaultValue: true }),
+    })
+  ),
+  proxycache: schema.maybe(
+    schema.object({
+      // when auth.type is proxycache, user_header, roles_header and proxy_header_ip are required
+      user_header: schema.conditional(schema.siblingRef('auth.type'), 'proxycache', schema.string(), schema.maybe(schema.string())),
+      roles_header: schema.conditional(schema.siblingRef('auth.type'), 'proxycache', schema.string(), schema.maybe(schema.string())),
+      proxy_header: schema.maybe(schema.string({ defaultValue: 'x-forwarded-for' })),
+      proxy_header_ip: schema.conditional(schema.siblingRef('auth.type'), 'proxycache', schema.string(), schema.maybe(schema.string())),
+      login_endpoint: schema.maybe(schema.string({ defaultValue: '' })),
+    })
+  ),
+  jwt: schema.maybe(
+    schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+      login_endpoint: schema.maybe(schema.string()),
+      url_param: schema.string({ defaultValue: 'authorization' }),
+      header: schema.string({ defaultValue: 'Authorization' }),
+    })
+  ),
+  ui: schema.object({
+    basicauth: schema.object({
+      // the login config here is the same as old config `opendistro_security.basicauth.login`
+      // Since we are now rendering login page to browser app, so move these config to browser side.
+      login: schema.object({
+        title: schema.string({ defaultValue: 'Please login to Kibana' }),
+        subtitle: schema.string({ defaultValue: 'If you have forgotten your username or password, please ask your system administrator' }),
+        showbrandimage: schema.boolean({ defaultValue: true }),
+        brandimage: schema.string({ defaultValue: '' }),
+        buttonstyle: schema.string({ defaultValue: '' }),
+      }),
     }),
-  })),
-  configuration: schema.maybe(schema.object({
-    enabled: schema.boolean({ defaultValue: true }),
-  })),
-  accountinfo: schema.maybe(schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
-  })),
-  openid: schema.maybe(schema.object({
-    connect_url: schema.maybe(schema.string()),
-    header: schema.string({ defaultValue: 'Authorization' }),
-    // TODO: test if siblingRef() works here
-    // client_id is required when auth.type is openid
-    client_id: schema.conditional(schema.siblingRef('auth.type'), 'openid', schema.string(), schema.maybe(schema.string())),
-    client_secret: schema.string({ defaultValue: '' }),
-    scope: schema.string({ defaultValue: 'openid profile email address phone' }),
-    base_redirect_url: schema.string({ defaultValue: '' }),
-    logout_url: schema.string({ defaultValue: '' }),
-    root_ca: schema.string({ defaultValue: '' }),
-    verify_hostnames: schema.boolean({ defaultValue: true }),
-  })),
-  proxycache: schema.maybe(schema.object({
-    // when auth.type is proxycache, user_header, roles_header and proxy_header_ip are required
-    user_header: schema.conditional(schema.siblingRef('auth.type'), 'proxycache', schema.string(), schema.maybe(schema.string())),
-    roles_header: schema.conditional(schema.siblingRef('auth.type'), 'proxycache', schema.string(), schema.maybe(schema.string())),
-    proxy_header: schema.maybe(schema.string({ defaultValue: 'x-forwarded-for' })),
-    proxy_header_ip: schema.conditional(schema.siblingRef('auth.type'), 'proxycache', schema.string(), schema.maybe(schema.string())),
-    login_endpoint: schema.maybe(schema.string({ defaultValue: '' })),
-  })),
-  jwt: schema.maybe(schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
-    login_endpoint: schema.maybe(schema.string()),
-    url_param: schema.string({ defaultValue: 'authorization' }),
-    header: schema.string({ defaultValue: 'Authorization' }),
-  })),
+  }),
 });
 
 export type SecurityPluginConfigType = TypeOf<typeof configSchema>;
 
-export const config: PluginConfigDescriptor = {
+export const config: PluginConfigDescriptor<SecurityPluginConfigType> = {
   exposeToBrowser: {
-    cookie: true,
-    auth: true,
+    enabled: true,
+    ui: true,
   },
   schema: configSchema,
+  deprecations: ({ rename, unused }) => [
+    rename('basicauth.login.title', 'ui.basicauth.login.title'),
+    rename('basicauth.login.subtitle', 'ui.basicauth.login.subtitle'),
+    rename('basicauth.login.titshowbrandimagele', 'ui.basicauth.login.showbrandimage'),
+    rename('basicauth.login.brandimage', 'ui.basicauth.login.brandimage'),
+    rename('basicauth.login.buttonstyle', 'ui.basicauth.login.buttonstyle'),
+  ],
 };
 
 //  This exports static code and TypeScript types,


### PR DESCRIPTION
*Description of changes:*
Exposes login page configurations to browser application. on browser side, the plugin can retrieve the configs in the `setup(core)` lifecycle function like:

```
  public setup(core: CoreSetup): OpendistroSecurityPluginSetup {
    const config = this.initializerContext.config.get();
    const enabled: boolean = config.enabled;
    const loginTitle: string = config.ui.login.title;
  }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
