### PR TITLE
Redirect according to url parameter 'nextUrl' after login

### DIFF
--- a/public/apps/login/login-app.tsx
+++ b/public/apps/login/login-app.tsx
@@ -26,7 +26,6 @@ export function renderApp(
 ) {
   ReactDOM.render(
     <LoginPage
-      appBasePath={params.appBasePath}
       http={coreStart.http}
     />,
     params.element);

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -29,7 +29,6 @@ import {
 import { CoreStart } from '../../../../../src/core/public';
 
 interface LoginPageDeps {
-  appBasePath: string;
   http: CoreStart['http'];
 }
 
@@ -76,7 +75,9 @@ export function LoginPage(props: LoginPageDeps) {
         }),
       });
       // TODO: Parse nextUrl from paras
-      window.location.href = `${props.http.basePath.serverBasePath}/app/kibana`;
+      const urlParams = new URLSearchParams(window.location.search);
+      const nextUrl = urlParams.get('nextUrl') || props.http.basePath.serverBasePath;
+      window.location.href = nextUrl;
     } catch (error) {
       console.log(error);
       setloginFailed(true);

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -74,7 +74,6 @@ export function LoginPage(props: LoginPageDeps) {
           password: password,
         }),
       });
-      // TODO: Parse nextUrl from paras
       const urlParams = new URLSearchParams(window.location.search);
       const nextUrl = urlParams.get('nextUrl') || props.http.basePath.serverBasePath;
       window.location.href = nextUrl;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
On successful login, parse `nextUrl` from url parameters and redirect to that. 

This works together with server behavior: when accessing a page without valid auth info, redirect to login page and put source page url to `nextUrl`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
