### PR TITLE
Fix router warning

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -60,20 +60,20 @@ const RoutesList = [
 export function AppRouter(props: AppDependencies) {
   return (
     <Router basename={props.params.appBasePath}>
-      <Switch>
-        <EuiPage>
+      <EuiPage>
           <Route path={`(${RoutesList.map(r => r.href).join('|')})`} exact={true}>
             <EuiPageSideBar>
               <NavPanel items={RoutesList} />
             </EuiPageSideBar>
           </Route>
           <EuiPageBody>
-            <Route path={RoutesMap.roles.href}>
-              <RoleList />
-            </Route>
+            <Switch>
+              <Route path={RoutesMap.roles.href}>
+                <RoleList />
+              </Route>
+            </Switch>
           </EuiPageBody>
-        </EuiPage>
-      </Switch>
+      </EuiPage>
     </Router>
   );
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix warning "React does not recognize the `computedMatch` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `computedmatch` instead. If you accidentally passed it from a parent component, remove it from the DOM element."  

It is due to that `Switch` will compare the component that not work for `<div>` so it should not have child `<div>` and `EuiPage` is creating a `<div>`. Moving `EuiPage` outside of `Switch` solves it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
