### PR TITLE
add auth list page layout

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -21,6 +21,7 @@ import { RouteItem } from './types';
 import { NavPanel } from './panels/nav-panel';
 import { RoleList } from './panels/role-list';
 import { RoleEdit } from './panels/role-edit/role-edit';
+import { AuthView } from './panels/auth-view/auth-view';
 
 const RoutesMap: { [key: string]: RouteItem } = {
   getStarted: {
@@ -75,6 +76,9 @@ export function AppRouter(props: AppDependencies) {
             />
             <Route path={RoutesMap.roles.href}>
               <RoleList {...props} />
+            </Route>
+            <Route path={RoutesMap.auth.href}>
+              <AuthView {...props} />
             </Route>
           </Switch>
         </EuiPageBody>

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -1,0 +1,37 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiButton, EuiPageHeader, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { AuthenticationSequencePanel } from './authentication-sequence-panel';
+import { AuthorizationPanel } from './authorization-panel';
+
+export function AuthView(props: {}) {
+  return (
+    <>
+      <EuiPageHeader>
+        <EuiTitle size="l">
+          <h1>Authentication and authorization</h1>
+        </EuiTitle>
+        <EuiButton iconType="popout" iconSide="right">
+          Manage via config.yml
+        </EuiButton>
+      </EuiPageHeader>
+      <AuthenticationSequencePanel />
+      <EuiSpacer size="m" />
+      <AuthorizationPanel />
+    </>
+  );
+}

--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -1,0 +1,29 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { PanelWithHeader } from '../../utils/panel-with-header';
+
+export function AuthenticationSequencePanel(props: {}) {
+  return (
+    <PanelWithHeader
+      headerText="Authentication sequences"
+      headerSubText="WORKING IN PROGRESS"
+      helpLink="/"
+    >
+      WORKING IN PROGRESS
+    </PanelWithHeader>
+  );
+}

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -1,0 +1,25 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { PanelWithHeader } from '../../utils/panel-with-header';
+
+export function AuthorizationPanel(props: {}) {
+  return (
+    <PanelWithHeader headerText="Authorization" headerSubText="WORKING IN PROGRESS" helpLink="/">
+      WORKING IN PROGRESS
+    </PanelWithHeader>
+  );
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR creates the basic layout of Auth list page. There will be follow up implementations for the details.

This is the screenshot of current implementation.
<img width="2544" alt="Screen Shot 2020-05-19 at 7 09 49 PM" src="https://user-images.githubusercontent.com/60111637/82397203-bd9dbf00-9a04-11ea-8a1d-97d22d9f79ed.png">

This is the screenshot of mockup for reviewers' reference.
<img width="1403" alt="Screen Shot 2020-05-19 at 7 10 16 PM" src="https://user-images.githubusercontent.com/60111637/82397217-c7bfbd80-9a04-11ea-9f2f-ccf72d278cb6.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
