### PR TITLE
Implement OIDC auth workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /build/
 target
 .eslintcache
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -19,5 +19,7 @@
     "typescript": "3.7.2"
   },
   "dependencies": {
+    "@hapi/wreck": "17.0.0",
+    "@hapi/cryptiles": "5.0.0"
   }
 }

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -30,6 +30,7 @@ import { SecurityClient } from '../../../backend/opendistro_security_client';
 import { BasicAuthRoutes } from './routes';
 import { isMultitenantPath, resolveTenant } from '../../../multitenancy/tenant_resolver';
 
+// TODO: change to interface
 export class AuthConfig {
   constructor(
     public readonly authType: string,
@@ -140,6 +141,8 @@ export class BasicAuthentication {
 
       // add tenant to Elasticsearch request headers
       if (this.config.multitenancy?.enabled && isMultitenantPath(request)) {
+        // FIXME: !!!! when calling authInfo, the request doesn't have a credentials set in the request
+        //             header yet, thus the call will fail, consider moving tenant stuff to post auth
         const authInfo = await this.securityClient.authinfo(request);
         const selectedTenant = resolveTenant(
           request,

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -153,8 +153,8 @@ export class BasicAuthentication {
         );
         Object.assign(headers, { securitytenant: selectedTenant });
 
-        if (selectedTenant !== cookie.tentent) {
-          cookie.tentent = selectedTenant;
+        if (selectedTenant !== cookie.tenant) {
+          cookie.tenant = selectedTenant;
           this.sessionStorageFactory.asScoped(request).set(cookie);
         }
       }

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -35,7 +35,7 @@ export class BasicAuthRoutes {
     private readonly coreSetup: CoreSetup
   ) {}
 
-  public async setupRoutes() {
+  public setupRoutes() {
     const PREFIX = '';
 
     // login using username and password
@@ -107,6 +107,7 @@ export class BasicAuthRoutes {
             },
           });
         }
+
         return response.ok({
           body: {
             username: user.username,

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -41,7 +41,7 @@ export interface OpenIdAuthConfig {
 
 export class OpenIdAuthentication {
   private openIdAuthConfig: OpenIdAuthConfig;
-  private authHaderName: string;
+  private authHeaderName: string;
   private openIdConnectUrl: string;
   private securityClient: SecurityClient;
 
@@ -62,8 +62,8 @@ export class OpenIdAuthentication {
       log.debug(`openId auth 'verify_hostnames' option is on.`);
     }
 
-    this.authHaderName = this.config.openid?.header || '';
-    this.openIdAuthConfig.authHeaderName = this.authHaderName;
+    this.authHeaderName = this.config.openid?.header || '';
+    this.openIdAuthConfig.authHeaderName = this.authHeaderName;
 
     this.openIdConnectUrl = this.config.openid?.connect_url || '';
     this.securityClient = new SecurityClient(this.esClient);
@@ -124,7 +124,7 @@ export class OpenIdAuthentication {
 
       // extract credentials from cookie
     } catch (error) {
-      console.log(error); // FIXME: log and handler properly
+      console.log(error); // FIXME: log and handle properly
     }
     return toolkit.authenticated();
   };

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -1,0 +1,132 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { SecurityPluginConfigType } from '../../..';
+import * as fs from 'fs';
+import wreck from '@hapi/wreck';
+
+import {
+  Logger,
+  AuthenticationHandler,
+  SessionStorageFactory,
+  CoreSetup,
+  IRouter,
+  IClusterClient,
+} from '../../../../../../src/core/server';
+import { SecuritySessionCookie } from '../../../session/security_cookie';
+import { OpenIdAuthRoutes } from './routes';
+import { SecurityClient } from '../../../backend/opendistro_security_client';
+
+export interface OpenIdAuthConfig {
+  ca?: Buffer | undefined;
+  // checkServerIdentity: (host: string, cert: any) => void;
+  authorizationEndpoint?: string;
+  tokenEndpoint?: string;
+  endSessionEndpoint?: string;
+
+  authHeaderName?: string;
+}
+
+export class OpenIdAuthentication {
+  private openIdAuthConfig: OpenIdAuthConfig;
+  private authHaderName: string;
+  private openIdConnectUrl: string;
+  private securityClient: SecurityClient;
+
+  constructor(
+    private readonly config: SecurityPluginConfigType,
+    private readonly sessionStorageFactory: SessionStorageFactory<SecuritySessionCookie>,
+    private readonly router: IRouter,
+    private readonly esClient: IClusterClient,
+    private readonly core: CoreSetup,
+    private readonly log: Logger
+  ) {
+    this.openIdAuthConfig = {};
+
+    if (this.config.openid?.root_ca) {
+      this.openIdAuthConfig.ca = fs.readFileSync(this.config.openid.root_ca);
+    }
+    if (this.config.openid?.verify_hostnames) {
+      log.debug(`openId auth 'verify_hostnames' option is on.`);
+    }
+
+    this.authHaderName = this.config.openid?.header || '';
+    this.openIdAuthConfig.authHeaderName = this.authHaderName;
+
+    this.openIdConnectUrl = this.config.openid?.connect_url || '';
+    this.securityClient = new SecurityClient(this.esClient);
+
+    this.init();
+  }
+
+  private async init() {
+    try {
+      const response = await wreck.get(this.openIdConnectUrl);
+      const payload = JSON.parse(response.payload as string);
+
+      this.openIdAuthConfig.authorizationEndpoint = payload.authorization_endpoint;
+      this.openIdAuthConfig.tokenEndpoint = payload.token_endpoint;
+      this.openIdAuthConfig.endSessionEndpoint = payload.end_session_endpoint || undefined;
+
+      const routes = new OpenIdAuthRoutes(
+        this.router,
+        this.config,
+        this.sessionStorageFactory,
+        this.openIdAuthConfig,
+        this.securityClient,
+        this.core
+      );
+      routes.setupRoutes();
+    } catch (error) {
+      this.log.error(error); // TODO: log more info
+      throw new Error('Failed when trying to obtain the endpoints from your IdP');
+    }
+  }
+
+  public authHandler: AuthenticationHandler = async (request, response, toolkit) => {
+    let cookie: SecuritySessionCookie | null;
+    try {
+      cookie = await this.sessionStorageFactory.asScoped(request).get();
+      if (!cookie) {
+        return response.redirected({
+          headers: {
+            location: `${this.core.http.basePath.serverBasePath}/auth/openid/login`,
+          },
+        });
+      }
+      // TODO: make a call to authinfo (securityClient.authenticateWithHeader) to validate credentials
+      cookie.expiryTime = Date.now() + this.config.cookie.ttl;
+      this.sessionStorageFactory.asScoped(request).set(cookie);
+
+      const headers: any = {};
+      if (cookie.credentials?.authHeaderValue) {
+        const authHeaderName: string = this.config.openid?.header.toLowerCase() || 'authorization';
+        headers[authHeaderName] = cookie.credentials.authHeaderValue;
+        // need to implement token refresh when id token is expired
+        return toolkit.authenticated({
+          requestHeaders: headers
+        });
+      } else {
+        return toolkit.notHandled();
+      }
+
+      // extract credentials from cookie
+    } catch (error) {
+      console.log(error); // FIXME: log and handler properly
+    }
+    return toolkit.authenticated();
+  };
+
+}

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -118,6 +118,7 @@ export class OpenIdAuthRoutes {
           }
 
           const tokenPayload: any = this.parseTokenResponse(tokenResponse.payload as Buffer);
+
           const idToken: string = tokenPayload.id_token;
           const accessToken: string = tokenPayload.access_token;
           const refreshToken: string = tokenPayload.refresh_token;

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -1,0 +1,213 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+import {
+  IRouter,
+  SessionStorageFactory,
+  CoreSetup,
+} from '../../../../../../src/core/server';
+import { SecuritySessionCookie } from '../../../session/security_cookie';
+import { SecurityPluginConfigType } from '../../..';
+import { schema } from '@kbn/config-schema';
+import { randomString } from '@hapi/cryptiles';
+import { parse, stringify } from 'querystring';
+import { OpenIdAuthConfig } from './openid_auth';
+import wreck from '@hapi/wreck';
+import { SecurityClient } from '../../../backend/opendistro_security_client';
+
+export class OpenIdAuthRoutes {
+  constructor(
+    private readonly router: IRouter,
+    private readonly config: SecurityPluginConfigType,
+    private readonly sessionStorageFactory: SessionStorageFactory<SecuritySessionCookie>,
+    private readonly openIdAuthConfig: OpenIdAuthConfig,
+    private readonly securityClient: SecurityClient,
+    private readonly core: CoreSetup
+  ) {}
+
+  public setupRoutes() {
+    this.router.get(
+      {
+        path: `/auth/openid/login`,
+        validate: {
+          query: schema.object({
+            code: schema.maybe(schema.string()),
+            nextUrl: schema.maybe(schema.string()),
+            state: schema.maybe(schema.string()),
+            refresh: schema.maybe(schema.string()),
+          }),
+        },
+        options: {
+          authRequired: false,
+        },
+      },
+      async (context, request, response) => {
+        // implementation refers to https://github.com/hapijs/bell/blob/master/lib/oauth.js
+
+        // Sign-in initialization
+        if (!request.query.code) {
+          const nonce = randomString(22);
+          const query: any = {
+            client_id: this.config.openid?.client_id,
+            response_type: 'code',
+            redirect_uri: `${this.getBaseRedirectUrl()}`, // TODO: generate actual domain name
+            state: nonce,
+          };
+
+          const scope = this.config.openid?.scope || '';
+          if (scope) {
+            query.scope = scope;
+          }
+
+          const queryString = stringify(query);
+          const location = `${this.openIdAuthConfig.authorizationEndpoint}?${queryString}`;
+          const cookie: SecuritySessionCookie = {
+            oidcState: nonce,
+          };
+          this.sessionStorageFactory.asScoped(request).set(cookie);
+          return response.redirected({
+            headers: {
+              location: location,
+            },
+          });
+        }
+
+        // Authentication callback
+        // TODO: figure out a decent way to validate the state from cookie
+        const clientId = this.config.openid?.client_id;
+        const clientSecret = this.config.openid?.client_secret;
+        const query: any = {
+          grant_type: 'authorization_code',
+          code: request.query.code,
+          redirect_uri: `${this.getBaseRedirectUrl()}`,
+          client_id: clientId,
+          client_secret: clientSecret,
+        };
+
+        const requestOptions: any = {
+          payload: stringify(query),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        };
+
+        try {
+          const tokenResponse = await wreck.post(
+            this.openIdAuthConfig.tokenEndpoint as string,
+            requestOptions
+          );
+          if (
+            !tokenResponse.res.statusCode ||
+            tokenResponse.res.statusCode < 200 ||
+            tokenResponse.res.statusCode > 299
+          ) {
+            return response.unauthorized();
+          }
+
+          const tokenPayload: any = this.parseTokenResponse(tokenResponse.payload as Buffer);
+
+          const idToken: string = tokenPayload.id_token;
+          const accessToken: string = tokenPayload.access_token;
+          const refreshToken: string = tokenPayload.refresh_token;
+          const expiresIn: number = tokenPayload.expires_in;
+
+          const user = await this.securityClient.authenticateWithHeader(
+            request,
+            this.openIdAuthConfig.authHeaderName as string,
+            `Bearer ${idToken}`
+          );
+
+          // set to cookie
+          const sessionStorage: SecuritySessionCookie = {
+            username: user.username,
+            credentials: {
+              authHeaderValue: `Bearer ${idToken}`,
+              refresh_token: refreshToken,
+              expires_at: Date.now() + expiresIn * 1000,
+            },
+            authType: 'openid',
+            expiryTime: Date.now() + this.config.cookie.ttl,
+          };
+          this.sessionStorageFactory.asScoped(request).set(sessionStorage);
+          return response.redirected({
+            headers: {
+              location: `${this.core.http.basePath.serverBasePath}/app/kibana`,
+            },
+          });
+        } catch (error) {
+          console.log(error); // TODO: change to logger
+          return response.unauthorized();
+        }
+      }
+    );
+
+    this.router.post(
+      {
+        path: `/auth/logout`,
+        validate: false,
+      },
+      async (context, request, response) => {
+        const cookie = await this.sessionStorageFactory.asScoped(request).get();
+        this.sessionStorageFactory.asScoped(request).clear();
+
+        const token = cookie?.credentials.authHeaderValue.split(' ')[1];
+        let requestQueryParameters = `?post_logout_redirect_uri=${this.getBaseRedirectUrl()}/app/kibana`;
+
+        let endSessionUrl = '/';
+        const customLogoutUrl = this.config.openid?.logout_url;
+        if (customLogoutUrl) {
+          endSessionUrl = customLogoutUrl + requestQueryParameters;
+        } else if (this.openIdAuthConfig.endSessionEndpoint) {
+          endSessionUrl =
+            this.openIdAuthConfig.endSessionEndpoint +
+            requestQueryParameters +
+            '&id_token_hint=' +
+            token;
+        }
+        return response.redirected({
+          headers: {
+            location: endSessionUrl,
+          }
+        });
+      }
+    );
+  }
+
+  private parseTokenResponse(payload: Buffer) {
+    const payloadString = payload.toString();
+    if (payloadString.trim()[0] === '{') {
+      try {
+        return JSON.parse(payloadString);
+      } catch (error) {
+        throw Error(`Invalid JSON payload: ${error}`);
+      }
+    }
+    return parse(payloadString);
+  }
+
+  private getBaseRedirectUrl(): string {
+    if (this.config.openid?.base_redirect_url) {
+      let baseRedirectUrl = this.config.openid.base_redirect_url;
+      return baseRedirectUrl.endsWith('/') ? baseRedirectUrl.slice(0, -1) : baseRedirectUrl;
+    }
+
+    const host = this.core.http.getServerInfo().host;
+    const port = this.core.http.getServerInfo().port;
+    const protocol = this.core.http.getServerInfo().protocol;
+    if (this.core.http.basePath.serverBasePath) {
+      return `${protocol}://${host}:${port}${this.core.http.basePath.serverBasePath}`;
+    }
+    return `${protocol}://${host}:${port}`;
+  }
+}

--- a/server/backend/opendistro_security_client.ts
+++ b/server/backend/opendistro_security_client.ts
@@ -49,7 +49,7 @@ export class SecurityClient {
     request: KibanaRequest,
     headerName: string,
     headerValue: string,
-    whitelistedHeadersAndValues: any,
+    whitelistedHeadersAndValues: any = {},
     additionalAuthHeaders: any = {}
   ): Promise<User> {
     try {

--- a/server/multitenancy/routes.ts
+++ b/server/multitenancy/routes.ts
@@ -47,7 +47,7 @@ export function setupMultitenantRoutes(
           body: 'Invalid cookie',
         });
       }
-      cookie.tentent = tenant;
+      cookie.tenant = tenant;
       sessionStroageFactory.asScoped(request);
       return response.ok({
         body: tenant,
@@ -69,7 +69,7 @@ export function setupMultitenantRoutes(
         });
       }
       return response.ok({
-        body: cookie.tentent,
+        body: cookie.tenant,
       });
     }
   );

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -75,10 +75,10 @@ export function resolveTenant(
  */
 export function isMultitenantPath(request: KibanaRequest): boolean {
   return (
-    request.url.path?.startsWith('/elasticsearch') ||
-    request.url.path?.startsWith('/api') ||
-    request.url.path?.startsWith('/app') ||
-    request.url.path === '/'
+    request.url.pathname?.startsWith('/elasticsearch') ||
+    request.url.pathname?.startsWith('/api') ||
+    request.url.pathname?.startsWith('/app') ||
+    request.url.pathname === '/'
   );
 }
 

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -47,8 +47,8 @@ export function resolveTenant(
     selectedTenant = request.headers.securitytenant
       ? (request.headers.securitytenant as string)
       : (request.headers.security_tenant as string);
-  } else if (cookie.tentent) {
-    selectedTenant = cookie.tentent;
+  } else if (cookie.tenant) {
+    selectedTenant = cookie.tenant;
   } else {
     selectedTenant = undefined;
   }

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -40,6 +40,7 @@ import {
   ISavedObjectTypeRegistry,
 } from '../../../src/core/server/saved_objects';
 import { setupIndexTemplate, migrateTenantIndices } from './multitenancy/tenant_index';
+import { OpenIdAuthentication } from './auth/types/openid/openid_auth';
 
 export class OpendistroSecurityPlugin
   implements Plugin<OpendistroSecurityPluginSetup, OpendistroSecurityPluginStart> {
@@ -97,6 +98,16 @@ export class OpendistroSecurityPlugin
         router,
         esClient,
         core
+      );
+      core.http.registerAuth(auth.authHandler);
+    } else if (config.auth.type === 'openid') {
+      const auth = new OpenIdAuthentication(
+        config,
+        securitySessionStorageFactory,
+        router,
+        esClient,
+        core,
+        this.logger
       );
       core.http.registerAuth(auth.authHandler);
     }

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -18,7 +18,7 @@ import { SecurityPluginConfigType } from '..';
 
 export interface SecuritySessionCookie {
   // security_authentication
-  username: string;
+  username?: string;
   credentials?: any;
   authType?: string;
   assignAuthHeader?: boolean;
@@ -28,6 +28,9 @@ export interface SecuritySessionCookie {
 
   // security_storage
   tentent?: any;
+
+  // for oicd auth workflow
+  oidcState?: any;
 }
 
 export function getSecurityCookieOptions(

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -27,7 +27,7 @@ export interface SecuritySessionCookie {
   additionalAuthHeaders?: any;
 
   // security_storage
-  tentent?: any;
+  tenant?: any;
 
   // for oicd auth workflow
   oidcState?: any;

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -29,7 +29,7 @@ export interface SecuritySessionCookie {
   // security_storage
   tenant?: any;
 
-  // for oicd auth workflow
+  // for oidc auth workflow
   oidcState?: any;
 }
 


### PR DESCRIPTION

*Description of changes:* Add implementation of OpenID Connect (OIDC) authentication workflow.

* When user is not authenticated, redirect to /auth/openid/login API to initiate the oidc auth *code* workflow
* when oidc Idp redirect back with code, exchange the code with auth tokens
* save tokens in cookie for subsequent requests, then redirect back to kibana app

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
