### PR TITLE
Fix custom icon scaling issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,6 +264,7 @@ export default function (kibana) {
                     url: '/app/security-configuration#/'
                 }
             ],
+            styleSheetPaths: require('path').resolve(__dirname, 'public/app.css'),
             chromeNavControls: [
                 'plugins/opendistro_security/chrome/btn_logout/btn_logout.js'
             ]

--- a/public/app.css
+++ b/public/app.css
@@ -1,0 +1,6 @@
+figure {
+    max-width: 16px !important;
+    margin-right: 12px;
+    flex-grow: 0;
+    flex-shrink: 0;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes the custom icon scaling issue. Adds formatting for the `figure` element which is how custom plugin icons used to be formatted by adding the css class [here](https://github.com/elastic/eui/blob/master/src/components/list_group/_list_group_item.scss#L109) to the `figure` element. This is no longer included in Kibana 7.7.X.

This fixes the scaling issue by adding this styling back in a separate `app.css` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
