### PR TITLE
implement AuthC/Z configurations view pages

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -19,6 +19,7 @@ export const API_ENDPOINT = API_PREFIX + '/configuration';
 export const API_ENDPOINT_ROLES = API_PREFIX + '/configuration/roles';
 export const API_ENDPOINT_ROLESMAPPING = API_PREFIX + '/configuration/rolesmapping';
 export const API_ENDPOINT_ACTIONGROUPS = API_PREFIX + '/configuration/actiongroups';
+export const API_ENDPOINT_SECURITYCONFIG = API_PREFIX + '/configuration/securityconfig';
 
 export const CLUSTER_PERMISSIONS = [
   'cluster:admin/ingest/pipeline/delete',

--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -14,16 +14,113 @@
  */
 
 import React from 'react';
+import { EuiInMemoryTable } from '@elastic/eui';
+import { _ } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 
-export function AuthenticationSequencePanel(props: {}) {
+import { ExpressionModal } from './expression-modal';
+
+const renderExpression = (title: string) => {
+  return (expression: string) => {
+    if (_.isEmpty(expression)) {
+      return '-';
+    }
+
+    return <ExpressionModal title={title} expression={expression} />;
+  };
+};
+
+const columns = [
+  {
+    field: 'order',
+    name: 'Execution order',
+    sortable: true,
+  },
+  {
+    field: 'domain_name',
+    name: 'Domain name',
+  },
+  {
+    field: 'http_enabled',
+    name: 'HTTP',
+  },
+  {
+    field: 'transport_enabled',
+    name: 'TRANSPORT',
+  },
+  {
+    field: 'http_type',
+    name: 'HTTP type',
+  },
+  {
+    field: 'http_challenge',
+    name: 'HTTP challenge',
+  },
+  {
+    field: 'http_configuration',
+    name: 'HTTP configuration',
+    render: renderExpression('HTTP configuration'),
+  },
+  {
+    field: 'backend_type',
+    name: 'Backend type',
+  },
+  {
+    field: 'backend_configuration',
+    name: 'Backend configuration',
+    render: renderExpression('Backend configuration'),
+  },
+];
+
+const ENABLED_STRING = 'Enabled';
+const DISABLED_STRING = 'Disabled';
+const TRUE_STRING = 'True';
+const FALSE_STRING = 'False';
+
+export function AuthenticationSequencePanel(props: { authc: [] }) {
+  const domains = _.keys(props.authc);
+
+  const items = _.map(domains, function(domain: string) {
+    const data = _.get(props.authc, domain);
+    const httpAuthenticator = data.http_authenticator;
+    const backend = data.authentication_backend;
+    return {
+      order: data.order,
+      domain_name: domain,
+      http_enabled: data.http_enabled ? ENABLED_STRING : DISABLED_STRING,
+      transport_enabled: data.transport_enabled ? ENABLED_STRING : DISABLED_STRING,
+      http_type: httpAuthenticator.type,
+      http_challenge: httpAuthenticator.challenge ? TRUE_STRING : FALSE_STRING,
+      http_configuration: httpAuthenticator.config,
+      backend_type: backend.type,
+      backend_configuration: backend.config,
+    };
+  });
+
+  const search = {
+    box: {
+      placeholder: 'Search authentication domain',
+    },
+  };
+
+  const headerText = 'Authentication sequences (' + domains.length + ')';
+
   return (
     <PanelWithHeader
-      headerText="Authentication sequences"
-      headerSubText="WORKING IN PROGRESS"
+      headerText={headerText}
+      headerSubText="An authentication module specifies where to get the user credentials from, and against which
+      backend they should be authenticated. When there are multiple authentication domains, the plugin will authenticate
+      the user sequentially against each backend until one succeeds"
       helpLink="/"
     >
-      WORKING IN PROGRESS
+      <EuiInMemoryTable
+        columns={columns}
+        items={items}
+        itemId={'domain_name'}
+        pagination={true}
+        sorting={true}
+        search={search}
+      />
     </PanelWithHeader>
   );
 }

--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -15,14 +15,14 @@
 
 import React from 'react';
 import { EuiInMemoryTable } from '@elastic/eui';
-import { _ } from 'lodash';
+import { isEmpty, keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 
 import { ExpressionModal } from './expression-modal';
 
 const renderExpression = (title: string) => {
   return (expression: string) => {
-    if (_.isEmpty(expression)) {
+    if (isEmpty(expression)) {
       return '-';
     }
 
@@ -78,10 +78,10 @@ const TRUE_STRING = 'True';
 const FALSE_STRING = 'False';
 
 export function AuthenticationSequencePanel(props: { authc: [] }) {
-  const domains = _.keys(props.authc);
+  const domains = keys(props.authc);
 
-  const items = _.map(domains, function(domain: string) {
-    const data = _.get(props.authc, domain);
+  const items = map(domains, function(domain: string) {
+    const data = get(props.authc, domain);
     const httpAuthenticator = data.http_authenticator;
     const backend = data.authentication_backend;
     return {

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -14,12 +14,89 @@
  */
 
 import React from 'react';
+import { EuiInMemoryTable } from '@elastic/eui';
+import { _ } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 
-export function AuthorizationPanel(props: {}) {
+import { ExpressionModal } from './expression-modal';
+
+const renderExpression = (title: string) => {
+  return (expression: string) => {
+    if (_.isEmpty(expression)) {
+      return '-';
+    }
+
+    return <ExpressionModal title={title} expression={expression} />;
+  };
+};
+
+const columns = [
+  {
+    field: 'domain_name',
+    name: 'Domain name',
+  },
+  {
+    field: 'http_enabled',
+    name: 'HTTP',
+  },
+  {
+    field: 'transport_enabled',
+    name: 'TRANSPORT',
+  },
+  {
+    field: 'backend_type',
+    name: 'Backend type',
+  },
+  {
+    field: 'backend_configuration',
+    name: 'Backend configuration',
+    render: renderExpression('Backend configuration'),
+  },
+];
+
+const ENABLED_STRING = 'Enabled';
+const DISABLED_STRING = 'Disabled';
+const TRUE_STRING = 'True';
+const FALSE_STRING = 'False';
+
+export function AuthorizationPanel(props: { authz: [] }) {
+  const domains = _.keys(props.authz);
+
+  const items = _.map(domains, function(domain: string) {
+    const data = _.get(props.authz, domain);
+    const backend = data.authorization_backend;
+    return {
+      domain_name: domain,
+      http_enabled: data.http_enabled ? ENABLED_STRING : DISABLED_STRING,
+      transport_enabled: data.transport_enabled ? ENABLED_STRING : DISABLED_STRING,
+      backend_type: backend.type,
+      backend_configuration: backend.config,
+    };
+  });
+
+  const search = {
+    box: {
+      placeholder: 'Search authorization domain',
+    },
+  };
+
+  const headerText = 'Authorization (' + domains.length + ')';
+
   return (
-    <PanelWithHeader headerText="Authorization" headerSubText="WORKING IN PROGRESS" helpLink="/">
-      WORKING IN PROGRESS
+    <PanelWithHeader
+      headerText={headerText}
+      headerSubText="After the user has been authenticated, authorization allows optional user collection from backend systems.
+      There is no execution order among multiple authorization domains."
+      helpLink="/"
+    >
+      <EuiInMemoryTable
+        columns={columns}
+        items={items}
+        itemId={'domain_name'}
+        pagination={true}
+        sorting={true}
+        search={search}
+      />
     </PanelWithHeader>
   );
 }

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -15,14 +15,14 @@
 
 import React from 'react';
 import { EuiInMemoryTable } from '@elastic/eui';
-import { _ } from 'lodash';
+import { isEmpty, keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 
 import { ExpressionModal } from './expression-modal';
 
 const renderExpression = (title: string) => {
   return (expression: string) => {
-    if (_.isEmpty(expression)) {
+    if (isEmpty(expression)) {
       return '-';
     }
 
@@ -56,14 +56,12 @@ const columns = [
 
 const ENABLED_STRING = 'Enabled';
 const DISABLED_STRING = 'Disabled';
-const TRUE_STRING = 'True';
-const FALSE_STRING = 'False';
 
 export function AuthorizationPanel(props: { authz: [] }) {
-  const domains = _.keys(props.authz);
+  const domains = keys(props.authz);
 
-  const items = _.map(domains, function(domain: string) {
-    const data = _.get(props.authz, domain);
+  const items = map(domains, function(domain: string) {
+    const data = get(props.authz, domain);
     const backend = data.authorization_backend;
     return {
       domain_name: domain,

--- a/public/apps/configuration/panels/auth-view/expression-modal.tsx
+++ b/public/apps/configuration/panels/auth-view/expression-modal.tsx
@@ -1,0 +1,67 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiCodeBlock,
+  EuiForm,
+  EuiModal,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
+} from '@elastic/eui';
+
+export function ExpressionModal(props: { title: string; expression: string }) {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  const closeModal = () => setIsModalVisible(false);
+
+  const showModal = () => setIsModalVisible(true);
+
+  const formSample = (
+    <EuiForm>
+      <EuiCodeBlock fontSize="m" paddingSize="m" color="dark" overflowHeight={300} isCopyable>
+        {JSON.stringify(props.expression, null, 2)}
+      </EuiCodeBlock>
+    </EuiForm>
+  );
+
+  let modal;
+
+  if (isModalVisible) {
+    modal = (
+      <EuiOverlayMask>
+        <EuiModal onClose={closeModal}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>{props.title}</EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>{formSample}</EuiModalBody>
+        </EuiModal>
+      </EuiOverlayMask>
+    );
+  }
+
+  return (
+    <div>
+      <EuiButtonEmpty size="xs" onClick={showModal}>
+        View expression
+      </EuiButtonEmpty>
+      {modal}
+    </div>
+  );
+}

--- a/public/apps/configuration/panels/auth-view/expression-modal.tsx
+++ b/public/apps/configuration/panels/auth-view/expression-modal.tsx
@@ -17,7 +17,6 @@ import React, { useState } from 'react';
 import {
   EuiButtonEmpty,
   EuiCodeBlock,
-  EuiForm,
   EuiModal,
   EuiModalBody,
   EuiModalHeader,
@@ -32,14 +31,6 @@ export function ExpressionModal(props: { title: string; expression: string }) {
 
   const showModal = () => setIsModalVisible(true);
 
-  const formSample = (
-    <EuiForm>
-      <EuiCodeBlock fontSize="m" paddingSize="m" color="dark" overflowHeight={300} isCopyable>
-        {JSON.stringify(props.expression, null, 2)}
-      </EuiCodeBlock>
-    </EuiForm>
-  );
-
   let modal;
 
   if (isModalVisible) {
@@ -50,7 +41,11 @@ export function ExpressionModal(props: { title: string; expression: string }) {
             <EuiModalHeaderTitle>{props.title}</EuiModalHeaderTitle>
           </EuiModalHeader>
 
-          <EuiModalBody>{formSample}</EuiModalBody>
+          <EuiModalBody>
+            <EuiCodeBlock fontSize="m" paddingSize="m" color="dark" overflowHeight={300} isCopyable>
+              {JSON.stringify(props.expression, null, 2)}
+            </EuiCodeBlock>
+          </EuiModalBody>
         </EuiModal>
       </EuiOverlayMask>
     );

--- a/public/apps/configuration/utils/panel-with-header.tsx
+++ b/public/apps/configuration/utils/panel-with-header.tsx
@@ -26,7 +26,7 @@ interface PanelWithHeaderDeps {
 export function PanelWithHeader(props: PanelWithHeaderDeps) {
   return (
     <EuiPanel>
-      <EuiTitle size="xs">
+      <EuiTitle size="s">
         <h3>{props.headerText}</h3>
       </EuiTitle>
       <EuiText size="xs" color="subdued">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implement AuthC and AuthZ content display.

Since there is no UI to configure the data, I use the APIs to set some test data. See this for references.
https://opendistro.github.io/for-elasticsearch-docs/docs/security-access-control/api/#update-configuration

https://opendistro.github.io/for-elasticsearch-docs/docs/security-configuration/configuration/

*Test:*
Run Kibana with the plugin locally. Also I have run lint.

1. Instruction page if there is no authentication configured
Implementation:
<img width="2555" alt="Screen Shot 2020-05-28 at 1 59 54 PM" src="https://user-images.githubusercontent.com/60111637/83197813-f28bcf00-a0f2-11ea-9013-dd4c203b3333.png">
Mockup:
<img width="1313" alt="Screen Shot 2020-05-28 at 2 57 12 PM" src="https://user-images.githubusercontent.com/60111637/83198208-9bd2c500-a0f3-11ea-8cba-041d627bdb53.png">


2. list view for both authentication and authorization
Implementation:
<img width="2558" alt="Screen Shot 2020-05-28 at 2 00 21 PM" src="https://user-images.githubusercontent.com/60111637/83197830-fa4b7380-a0f2-11ea-8f2c-f44aedc07dbb.png">

Mockup:
<img width="697" alt="Screen Shot 2020-05-28 at 2 57 31 PM" src="https://user-images.githubusercontent.com/60111637/83198224-a1c8a600-a0f3-11ea-92e1-f7a5f515f041.png">


3. Modal popup to view HTTP configuration details
Implementation:
<img width="2554" alt="Screen Shot 2020-05-28 at 2 00 36 PM" src="https://user-images.githubusercontent.com/60111637/83197859-07686280-a0f3-11ea-8400-bf81d8012b6b.png">

Mockup:
<img width="1414" alt="Screen Shot 2020-05-28 at 2 57 40 PM" src="https://user-images.githubusercontent.com/60111637/83198243-a725f080-a0f3-11ea-9400-77ceffe79251.png">


4. Modal popup to view Backend configuration details
Implementation:
<img width="2553" alt="Screen Shot 2020-05-28 at 2 00 44 PM" src="https://user-images.githubusercontent.com/60111637/83197873-0d5e4380-a0f3-11ea-8bab-2b0a38195e4e.png">


Mockup:

same as 3



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
