### PR TITLE
use default current repository in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: security-kibana-plugin
-        repository: opendistro-for-elasticsearch/security-kibana-plugin
         ref: 'dev'
     - name: Bootstrap Kibana
       run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current behavior is that the workflow will run against OD repository instead of the current repository. After Yuxiang's research, the default value of repository is the current one. Thus we do not need to explicitly set the value. The benefit is that the author will be able to know the workflow result before merging the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
