### PR TITLE
enhance eslint ci to use current branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: security-kibana-plugin
-        ref: 'dev'
+        ref: ${{ github.ref }}
     - name: Bootstrap Kibana
       run: |
         mv ./security-kibana-plugin ./kibana/plugins/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Address Yuxiang's offline feedback that developers may use branch names which are not "dev" for development. Thus this change is to increase the robustness of the ci check.

*Test:*
I would watch the CI of this change to suceed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
