### PR TITLE
Properly redirecting to error page after logout when base_url is spec…

### DIFF
--- a/lib/auth/types/saml/routes.js
+++ b/lib/auth/types/saml/routes.js
@@ -162,7 +162,7 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
         method: ['GET', 'POST'],
         path:  `${APP_ROOT}/_opendistro/_security/saml/logout`,
         handler(request, h) {
-            return h.redirect(`${APP_ROOT}/customerror?type=samlLogoutSuccess`);
+            return h.redirect(`${basePath}/customerror?type=samlLogoutSuccess`);
         },
         options: {
             auth: false
@@ -204,7 +204,7 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
             }
 
             request.auth.securitySessionStorage.clear();
-            const redirectURL = (authInfo && authInfo.sso_logout_url) ? authInfo.sso_logout_url : `${APP_ROOT}/customerror?type=samlLogoutSuccess`;
+            const redirectURL = (authInfo && authInfo.sso_logout_url) ? authInfo.sso_logout_url : `${basePath}/customerror?type=samlLogoutSuccess`;
 
             return {redirectURL};
         },


### PR DESCRIPTION
*Description of changes:*
Redirect user to proper error page when SAML logout is called, in case url prefix is applied in the kibana settings. 

Tested on the personal domain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
