### PR TITLE
Implement role view page layout

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -22,6 +22,7 @@ import { NavPanel } from './panels/nav-panel';
 import { RoleList } from './panels/role-list';
 import { RoleEdit } from './panels/role-edit/role-edit';
 import { AuthView } from './panels/auth-view/auth-view';
+import { RoleView } from './panels/role-view/role-view';
 
 const RoutesMap: { [key: string]: RouteItem } = {
   getStarted: {
@@ -73,6 +74,10 @@ export function AppRouter(props: AppDependencies) {
             <Route
               path={`${RoutesMap.roles.href}/:action/:sourceRoleName`}
               render={(match) => <RoleEdit {...{ ...props, ...match.match.params }} />}
+            />
+            <Route
+              path={`${RoutesMap.roles.href}/:roleName`}
+              render={(match) => <RoleView {...{ ...props, ...match.match.params }} />}
             />
             <Route path={RoutesMap.roles.href}>
               <RoleList {...props} />

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -1,0 +1,87 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { Fragment } from 'react';
+
+import {
+  EuiBreadcrumbs,
+  EuiButton,
+  EuiPageContentHeader,
+  EuiPageContentHeaderSection,
+  EuiSpacer,
+  EuiTabbedContent,
+  EuiTitle,
+} from '@elastic/eui';
+import { AppDependencies } from '../../../types';
+
+const tabs = [
+  {
+    id: 'permissions',
+    name: 'Permissions',
+    disabled: false,
+    content: <Fragment>Permission working in progress</Fragment>,
+  },
+  {
+    id: 'users',
+    name: 'Users',
+    disabled: false,
+    content: <Fragment>Users working in progress</Fragment>,
+  },
+];
+
+interface RoleViewProps extends AppDependencies {
+  roleName: string;
+}
+
+// TODO: move breadcrumbs to router level as it is common in multiple role related pages.
+function createBreadcrumbs(roleName: string) {
+  return [
+    {
+      text: 'Security',
+      href: '#',
+    },
+    {
+      text: 'Roles',
+      href: '#',
+    },
+    {
+      text: roleName,
+    },
+  ];
+}
+
+export function RoleView(props: RoleViewProps) {
+  return (
+    <>
+      <EuiBreadcrumbs breadcrumbs={createBreadcrumbs(props.roleName)} truncate={false} />
+
+      <EuiPageContentHeader>
+        <EuiPageContentHeaderSection>
+          <EuiTitle size="l">
+            <h1>{props.roleName}</h1>
+          </EuiTitle>
+        </EuiPageContentHeaderSection>
+
+        <EuiPageContentHeaderSection>
+          <EuiButton>Duplicate role</EuiButton>
+        </EuiPageContentHeaderSection>
+      </EuiPageContentHeader>
+
+      <EuiTabbedContent tabs={tabs} />
+
+      <EuiSpacer />
+    </>
+  );
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implement the layout of the role detail view page

*Test:*

Note that in my implementation, the "Duplicate role" button is put in EuiPageContentHeaderSection which looks a bit different from mockup. We can sync up with UX about this modification during UX review

mockup
<img width="696" alt="Screen Shot 2020-06-03 at 8 07 42 PM" src="https://user-images.githubusercontent.com/60111637/83710564-f11c4400-a5d5-11ea-990e-dccc5ff2190d.png">


actual
<img width="2544" alt="Screen Shot 2020-06-03 at 8 08 41 PM" src="https://user-images.githubusercontent.com/60111637/83710625-0abd8b80-a5d6-11ea-9ad8-e6964651a27f.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
