### PR TITLE
Show - for empty attributes list on user listing page

### DIFF
--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -31,7 +31,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { Dictionary, difference, map } from 'lodash';
+import { Dictionary, difference, map, isEmpty } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { getAuthInfo } from '../../../utils/auth-info-utils';
 import { AppDependencies } from '../../types';
@@ -45,6 +45,9 @@ import { buildHashUrl } from '../utils/url-builder';
 
 function dictView() {
   return (items: Dictionary<string>) => {
+    if (isEmpty(items)) {
+      return '-';
+    }
     return (
       <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
         {map(items, (v, k) => (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Show `-` for empty attributes list on user listing page.

Screenshots:
Mockup:
![image](https://user-images.githubusercontent.com/63078162/84212918-054bbf80-aa74-11ea-8841-71c2cdf8da35.png)

Implementation:
![image](https://user-images.githubusercontent.com/63078162/84212934-15fc3580-aa74-11ea-9421-a1367eb3462e.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
