### PR TITLE
Respect server.basePath when re-writing nav bar links.

### DIFF
--- a/public/services/chrome_wrapper.js
+++ b/public/services/chrome_wrapper.js
@@ -61,7 +61,7 @@ function resetLastSubUrl(id) {
   }
 
    if (getNewPlatform) {
-    updateNavLinkProperty(id, 'url', navLink.subUrlBase);
+    updateNavLinkProperty(id, 'url', chrome.getBasePath() + navLink.subUrlBase);
   } else {
     navLink.lastSubUrl = navLink.url;
   }


### PR DESCRIPTION
*Issue #, if available:* #245

*Description of changes:*

When a user switches tenants via the Kibana GUI Plugin, it resets the URL for several of the links (to include discover, dashboards, and visualizations) in the left-hand navigation bar.

Unfortunately, if server.basePath is set in the Kibana config (commonly done when the server is being a reverse proxy), the resulting URL is malformed. For example, it will reset http://staging/my_kibana_server/app/kibana#/discover to http://staging/app/kibana#/discover.

Since nginx doesn't know where to route /app/, this results in a HTTP404.

This PR simply prepends the basePath so that the result is navigable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
