### PR TITLE
add the audit logging status panel for enabled or disabled

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -27,6 +27,7 @@ import { UserList } from './panels/user-list';
 import { RouteItem, ResourceType, Action } from './types';
 import { buildUrl, buildHashUrl } from './utils/url-builder';
 import { InternalUserEdit } from './panels/internal-user-edit/internal-user-edit';
+import { AuditLogging } from './panels/audit-logging/audit-logging';
 
 const ROUTE_MAP: { [key: string]: RouteItem } = {
   getStarted: {
@@ -53,6 +54,10 @@ const ROUTE_MAP: { [key: string]: RouteItem } = {
     name: 'Authentication and authorization',
     href: buildUrl(ResourceType.auth),
   },
+  [ResourceType.auditLogging]: {
+    name: 'Audit logs',
+    href: buildUrl(ResourceType.auditLogging),
+  },
 };
 
 const ROUTE_LIST = [
@@ -62,6 +67,7 @@ const ROUTE_LIST = [
   ROUTE_MAP[ResourceType.users],
   ROUTE_MAP[ResourceType.permissions],
   ROUTE_MAP[ResourceType.tenants],
+  ROUTE_MAP[ResourceType.auditLogging],
 ];
 
 // url regex pattern for all pages with left nav panel, (/|/roles|/internalusers|...)
@@ -133,6 +139,9 @@ export function AppRouter(props: AppDependencies) {
             />
             <Route path={ROUTE_MAP.users.href}>
               <UserList {...props} />
+            </Route>
+            <Route path={ROUTE_MAP.auditLogging.href}>
+              <AuditLogging {...props} />
             </Route>
           </Switch>
         </EuiPageBody>

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -1,0 +1,72 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+import {
+  EuiDescribedFormGroup,
+  EuiForm,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiSwitch,
+  EuiTitle,
+} from '@elastic/eui';
+import { AppDependencies } from '../../../types';
+
+function renderStatusPanel(onSwitchChange: any, auditLoggingEnabled: boolean) {
+  return (
+    <EuiForm>
+      <EuiDescribedFormGroup
+        title={<h3>Enable audit logging</h3>}
+        description={<>Enable or disable audit logging</>}
+      >
+        <EuiFormRow>
+          <EuiSwitch
+            name="auditLoggingEnabledSwitch"
+            label={auditLoggingEnabled ? 'Enabled' : 'Disabled'}
+            checked={auditLoggingEnabled}
+            onChange={onSwitchChange}
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+    </EuiForm>
+  );
+}
+
+export function AuditLogging(props: AppDependencies) {
+  const [auditLoggingEnabled, setAuditLoggingEnabled] = useState<boolean>(false);
+
+  const onSwitchChange = () => {
+    setAuditLoggingEnabled((prevAuditLoggingEnabled) => !prevAuditLoggingEnabled);
+  };
+  useEffect(() => {
+    // TODO: switch to actual calls to fetch data once backend APIs are ready.
+    const enabled = true;
+    setAuditLoggingEnabled(enabled);
+  }, []);
+
+  const content = renderStatusPanel(onSwitchChange, auditLoggingEnabled);
+
+  return (
+    <EuiPanel>
+      <EuiTitle>
+        <h3>Audit logging</h3>
+      </EuiTitle>
+      <EuiHorizontalRule />
+      {content}
+    </EuiPanel>
+  );
+}

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -19,6 +19,7 @@ export enum ResourceType {
   permissions = 'permissions',
   tenants = 'tenants',
   auth = 'auth',
+  auditLogging = 'auditLogging',
 }
 
 export enum Action {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implement the status panel.

**_The section "Configure Storage" is still under discussion whether or not support it_**. So, in this iteration, I won't implement it. Also the additional content for enabled view will be implemented later.

**_Also since the backend APIs are not ready, I have todo in the code to switch to actual API calls._**

This is the mockup for enabled.
<img width="717" alt="Screen Shot 2020-06-10 at 6 58 26 PM" src="https://user-images.githubusercontent.com/60111637/84336816-f08f2a80-ab4c-11ea-8d60-e043768aa8ed.png">


This is the implementation for enabled.
<img width="2558" alt="Screen Shot 2020-06-10 at 6 58 38 PM" src="https://user-images.githubusercontent.com/60111637/84336806-e705c280-ab4c-11ea-99c7-951e18c1e36f.png">


This is the mockup for disabled.
<img width="724" alt="Screen Shot 2020-06-10 at 6 58 17 PM" src="https://user-images.githubusercontent.com/60111637/84336836-f97ffc00-ab4c-11ea-9516-bc1ffdd0cf17.png">


This is the implementation for disabled.
<img width="2552" alt="Screen Shot 2020-06-10 at 6 58 44 PM" src="https://user-images.githubusercontent.com/60111637/84336787-dd7c5a80-ab4c-11ea-8dfd-d633834e74aa.png">


*Test*
started local server and screenshots shared above.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
