### PR TITLE
call auditlogging API to get data

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -22,6 +22,7 @@ export const API_ENDPOINT_ACTIONGROUPS = API_ENDPOINT + '/actiongroups';
 export const API_ENDPOINT_TENANTS = API_ENDPOINT + '/tenants';
 export const API_ENDPOINT_SECURITYCONFIG = API_ENDPOINT + '/securityconfig';
 export const API_ENDPOINT_INTERNALUSERS = API_ENDPOINT + '/internalusers';
+export const API_ENDPOINT_AUDITLOGGING = API_ENDPOINT + '/audit';
 
 export const CLUSTER_PERMISSIONS = [
   'cluster:admin/ingest/pipeline/delete',

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -25,6 +25,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { AppDependencies } from '../../../types';
+import { API_ENDPOINT_AUDITLOGGING } from '../../constants';
 
 function renderStatusPanel(onSwitchChange: any, auditLoggingEnabled: boolean) {
   return (
@@ -52,11 +53,21 @@ export function AuditLogging(props: AppDependencies) {
   const onSwitchChange = () => {
     setAuditLoggingEnabled((prevAuditLoggingEnabled) => !prevAuditLoggingEnabled);
   };
+
   useEffect(() => {
-    // TODO: switch to actual calls to fetch data once backend APIs are ready.
-    const enabled = true;
-    setAuditLoggingEnabled(enabled);
-  }, []);
+    const fetchData = async () => {
+      try {
+        const configuration = await props.coreStart.http.get(API_ENDPOINT_AUDITLOGGING);
+
+        setAuditLoggingEnabled(configuration.data.config.enabled);
+      } catch (e) {
+        // TODO: switch to better error handling.
+        console.log(e);
+      }
+    };
+
+    fetchData();
+  }, [props.coreStart.http]);
 
   const content = renderStatusPanel(onSwitchChange, auditLoggingEnabled);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add the backend support for audit logging. Previously it just used hardcoded value. Now with this change, it is fetching and parsing backend data. More information from the response will be used to render other components. 

Experienced some issues where the API is showing 404 return. After debugging, the API was added to a wrong place (under commons not configuration).

*Test*
The backend response has audit logging enabled. This is how the UI looks like. We can see that it is showing enabled status.

<img width="2111" alt="Screen Shot 2020-06-15 at 3 36 13 PM" src="https://user-images.githubusercontent.com/60111637/84712675-0e2e0c80-af1e-11ea-88ab-59624776b4b4.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
