### PR TITLE
display general and compliance settings for audit logging

### DIFF
--- a/public/apps/configuration/utils/audit-logging-view-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-view-utils.tsx
@@ -1,0 +1,217 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+import {
+  EuiDescribedFormGroup,
+  EuiFlexGrid,
+  EuiForm,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+
+import React from 'react';
+import { displayArray, displayBoolean, displayObject, renderTextFlexItem } from './display-utils';
+
+interface GeneralSettings {
+  // layer
+  enable_rest: boolean;
+  enable_transport: boolean;
+  disabled_rest_categories: string[];
+  disabled_transport_categories: string[];
+
+  // attribute
+  resolve_bulk_requests: boolean;
+  resolve_indices: boolean;
+  log_request_body: boolean;
+  exclude_sensitive_headers: boolean;
+
+  // ignore
+  ignore_users: string[];
+  ignore_requests: string[];
+}
+
+interface ComplianceSettings {
+  enabled: boolean;
+
+  // read
+  read_metadata_only: boolean;
+  read_ignore_users: string[];
+  read_watched_fields: {
+    [key: string]: string;
+  };
+
+  // write
+  write_metadata_only: boolean;
+  write_log_diffs: boolean;
+  write_ignore_users: string[];
+  write_watched_indices: string[];
+}
+
+export function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: boolean) {
+  return (
+    <EuiForm>
+      <EuiDescribedFormGroup
+        title={<h3>Enable audit logging</h3>}
+        description={<>Enable or disable audit logging</>}
+      >
+        <EuiFormRow>
+          <EuiSwitch
+            name="auditLoggingEnabledSwitch"
+            label={displayBoolean(auditLoggingEnabled)}
+            checked={auditLoggingEnabled}
+            onChange={onSwitchChange}
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+    </EuiForm>
+  );
+}
+
+export function renderGeneralSettings(generalSettings: GeneralSettings) {
+  return (
+    <>
+      {renderGeneralSettingsForLayer(generalSettings)}
+
+      <EuiSpacer />
+
+      {renderGeneralSettingsForAttribute(generalSettings)}
+
+      <EuiSpacer />
+
+      {renderGeneralSettingsForIgnore(generalSettings)}
+    </>
+  );
+}
+
+function renderGeneralSettingsForLayer(generalSettings: GeneralSettings) {
+  return (
+    <>
+      <EuiText>
+        <h3>Layer settings</h3>
+      </EuiText>
+
+      <EuiSpacer />
+
+      <EuiFlexGrid columns={3}>
+        {renderTextFlexItem('REST layer', displayBoolean(generalSettings.enable_rest))}
+        {renderTextFlexItem('Transport layer', displayBoolean(generalSettings.enable_transport))}
+        {renderTextFlexItem(
+          'REST disabled categories',
+          displayArray(generalSettings.disabled_rest_categories)
+        )}
+        {renderTextFlexItem(
+          'Transport disabled categories',
+          displayArray(generalSettings.disabled_transport_categories)
+        )}
+      </EuiFlexGrid>
+    </>
+  );
+}
+
+function renderGeneralSettingsForAttribute(generalSettings: GeneralSettings) {
+  return (
+    <>
+      <EuiText>
+        <h3>Attribute settings</h3>
+      </EuiText>
+
+      <EuiSpacer />
+
+      <EuiFlexGrid columns={3}>
+        {renderTextFlexItem('Bulk requests', displayBoolean(generalSettings.resolve_bulk_requests))}
+        {renderTextFlexItem('Resolve indices', displayBoolean(generalSettings.resolve_indices))}
+        {renderTextFlexItem('Request body', displayBoolean(generalSettings.log_request_body))}
+        {renderTextFlexItem(
+          'Sensitive headers',
+          displayBoolean(generalSettings.exclude_sensitive_headers)
+        )}
+      </EuiFlexGrid>
+    </>
+  );
+}
+
+function renderGeneralSettingsForIgnore(generalSettings: GeneralSettings) {
+  return (
+    <>
+      <EuiText>
+        <h3>Ignore settings</h3>
+      </EuiText>
+
+      <EuiSpacer />
+
+      <EuiFlexGrid columns={3}>
+        {renderTextFlexItem('Exclude users', displayArray(generalSettings.ignore_users))}
+        {renderTextFlexItem('Exclude requests', displayArray(generalSettings.ignore_requests))}
+      </EuiFlexGrid>
+    </>
+  );
+}
+
+export function renderComplianceSettings(complianceSettings: ComplianceSettings) {
+  return (
+    <>
+      {renderTextFlexItem('Compliance mode', displayBoolean(complianceSettings.enabled))}
+
+      <EuiSpacer />
+
+      <EuiPanel>
+        <EuiTitle>
+          <h4>Read</h4>
+        </EuiTitle>
+
+        <EuiSpacer />
+
+        <EuiFlexGrid columns={3}>
+          {renderTextFlexItem(
+            'Read metadata only',
+            displayBoolean(complianceSettings.read_metadata_only)
+          )}
+          {renderTextFlexItem('Ignored users', displayArray(complianceSettings.read_ignore_users))}
+          {/* read_watched_fields is object instead of array.*/}
+          {renderTextFlexItem(
+            'Watched fields',
+            displayObject(complianceSettings.read_watched_fields)
+          )}
+        </EuiFlexGrid>
+      </EuiPanel>
+
+      <EuiSpacer />
+
+      <EuiPanel>
+        <EuiTitle>
+          <h4>Write</h4>
+        </EuiTitle>
+
+        <EuiSpacer />
+
+        <EuiFlexGrid columns={3}>
+          {renderTextFlexItem(
+            'Write metadata only',
+            displayBoolean(complianceSettings.write_metadata_only)
+          )}
+          {renderTextFlexItem('Log diffs', displayBoolean(complianceSettings.write_log_diffs))}
+          {renderTextFlexItem('Ignored users', displayArray(complianceSettings.write_ignore_users))}
+          {renderTextFlexItem(
+            'Watched indices',
+            displayArray(complianceSettings.write_watched_indices)
+          )}
+        </EuiFlexGrid>
+      </EuiPanel>
+    </>
+  );
+}

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -1,0 +1,44 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+// TODO: call the util functions from wherever applicable.
+
+import { EuiFlexItem, EuiText } from '@elastic/eui';
+import { isEmpty } from 'lodash';
+
+import React from 'react';
+
+export function renderTextFlexItem(header: string, value: string) {
+  return (
+    <EuiFlexItem>
+      <EuiText size="xs">
+        <strong>{header}</strong>
+        <div>{value}</div>
+      </EuiText>
+    </EuiFlexItem>
+  );
+}
+
+export function displayBoolean(bool: boolean) {
+  return bool ? 'Enabled' : 'Disabled';
+}
+
+export function displayArray(array: string[]) {
+  return array?.join(', ') || '--';
+}
+
+export function displayObject(object: object) {
+  return !isEmpty(object) ? JSON.stringify(object) : '--';
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR will add the read view for general settings and compliance settings.

This is the mockup
![screencapture-aws-uxdr-invisionapp-share-ZTVZTJJKURY-2020-06-15-22_51_25](https://user-images.githubusercontent.com/60111637/84736624-1b1d2100-af5b-11ea-9f78-bae59fea8b30.png)

This is the implementation.
![screencapture-localhost-5601-app-opendistro-security-2020-06-15-22_52_09 (1)](https://user-images.githubusercontent.com/60111637/84736633-253f1f80-af5b-11ea-9081-c64606986906.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
