### PR TITLE
Remove password pattern requirement and bug fixes on user editing page

### DIFF
--- a/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
@@ -69,7 +69,7 @@ function generateAttributesPanels(
             <FormRow headerText={arrayIndex === 0 ? 'Variable name' : ''}>
               <EuiFieldText
                 value={userAttribute.key}
-                onChange={onValueChangeHandler('key')}
+                onChange={(e) => onValueChangeHandler('key')(e.target.value)}
                 placeholder="Type in variable name"
               />
             </FormRow>
@@ -78,7 +78,7 @@ function generateAttributesPanels(
             <FormRow headerText={arrayIndex === 0 ? 'Value' : ''}>
               <EuiFieldText
                 value={userAttribute.value}
-                onChange={onValueChangeHandler('value')}
+                onChange={(e) => onValueChangeHandler('value')(e.target.value)}
                 placeholder="Type in value"
               />
             </FormRow>

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -27,9 +27,9 @@ export function PasswordEditPanel(props: {
 
   useEffect(() => {
     props.updatePassword(password);
-    const isValid = repeatPassword !== password;
-    setIsRepeatPasswordInvalid(isValid);
-    props.updateIsInvalid(isValid);
+    const isInvalid = repeatPassword !== password;
+    setIsRepeatPasswordInvalid(isInvalid);
+    props.updateIsInvalid(isInvalid);
   }, [password, props, repeatPassword]);
 
   const passwordChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -13,57 +13,48 @@
  *   permissions and limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { EuiFieldText, EuiIcon } from '@elastic/eui';
 import { FormRow } from './form-row';
-
-// At least one uppercase, one lowercase, one digit and one special character
-// and at least 8 characters long
-const PASSWORD_PATTERN = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?([^\w\s]|[_])).{8,}$/;
-
-// TODO: Add unit test
-function isValidPassword(password: string) {
-  return PASSWORD_PATTERN.test(password);
-}
 
 export function PasswordEditPanel(props: {
   updatePassword: (p: string) => void;
   updateIsInvalid: (v: boolean) => void;
 }) {
   const [password, setPassword] = useState<string>('');
-  const [isPasswordInvalid, setIsPasswordInvalid] = useState<boolean>(false);
+  const [repeatPassword, setRepeatPassword] = useState<string>('');
   const [isRepeatPasswordInvalid, setIsRepeatPasswordInvalid] = useState<boolean>(false);
 
+  useEffect(() => {
+    props.updatePassword(password);
+    const isValid = repeatPassword !== password;
+    setIsRepeatPasswordInvalid(isValid);
+    props.updateIsInvalid(isValid);
+  }, [password, repeatPassword])
+
   const passwordChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    setPassword(newValue);
-    setIsPasswordInvalid(!isValidPassword(newValue) && newValue !== '');
-    props.updatePassword(newValue);
-    props.updateIsInvalid(isPasswordInvalid || isRepeatPasswordInvalid);
+    setPassword(e.target.value);
   };
 
   const repeatPasswordChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    setIsRepeatPasswordInvalid(newValue !== password);
-    props.updateIsInvalid(isPasswordInvalid || isRepeatPasswordInvalid);
+    setRepeatPassword(e.target.value);
   };
 
   return (
     <>
       <FormRow
         headerText="Password"
-        helpText="Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
+        helpText="A good password will be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
       >
         <EuiFieldText
           prepend={<EuiIcon type="lock" />}
           type="password"
-          isInvalid={isPasswordInvalid}
           onChange={passwordChangeHandler}
         />
       </FormRow>
 
       <FormRow
-        headerText="Re-enter assword"
+        headerText="Re-enter password"
         helpText="The password must be identical to what you entered above"
       >
         <EuiFieldText

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -30,7 +30,7 @@ export function PasswordEditPanel(props: {
     const isValid = repeatPassword !== password;
     setIsRepeatPasswordInvalid(isValid);
     props.updateIsInvalid(isValid);
-  }, [password, repeatPassword])
+  }, [password, props, repeatPassword]);
 
   const passwordChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fix typo.
2. Fix a bug that set whole event object (instead of event.target.value) to state on a text change event.
3. Remove the password pattern requirement.
4. Fix a bug that still set invalid when repeating password is already identical to password.
5. Fix a bug that in this case: filling repeating password box first then password box, in this case it shows invalid since the validation is on text change event of repeating password box.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
