### PR TITLE
Pass logger to route handler via context, update error message when failed to call ES API

### DIFF
--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -23,6 +23,7 @@ import {
   IRouter,
   IClusterClient,
   KibanaRequest,
+  Logger,
 } from '../../../../../../src/core/server';
 import { SecurityPluginConfigType } from '../../..';
 import { SecuritySessionCookie } from '../../../session/security_cookie';
@@ -62,7 +63,8 @@ export class BasicAuthentication {
     private readonly sessionStorageFactory: SessionStorageFactory<SecuritySessionCookie>,
     private readonly router: IRouter,
     private readonly esClient: IClusterClient,
-    private readonly coreSetup: CoreSetup
+    private readonly coreSetup: CoreSetup,
+    private readonly logger: Logger
   ) {
     const multitenantEnabled = config.multitenancy?.enabled || false;
 
@@ -164,8 +166,7 @@ export class BasicAuthentication {
         requestHeaders: headers,
       });
     } catch (error) {
-      // TODO: switch to logger
-      console.log(`error: ${error}`);
+      this.logger.error(`Failed authentication: ${error}`)
       return toolkit.notHandled();
       // TODO: redirect using response?
     }

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -166,7 +166,7 @@ export class BasicAuthentication {
         requestHeaders: headers,
       });
     } catch (error) {
-      this.logger.error(`Failed authentication: ${error}`)
+      this.logger.error(`Failed authentication: ${error}`);
       return toolkit.notHandled();
       // TODO: redirect using response?
     }

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -36,7 +36,6 @@ export class BasicAuthRoutes {
   ) {}
 
   public setupRoutes() {
-
     // login using username and password
     this.router.post(
       {
@@ -54,8 +53,11 @@ export class BasicAuthRoutes {
       async (context, request, response) => {
         const forbiddenUsernames = this.config.auth.forbidden_usernames;
         if (forbiddenUsernames.indexOf(request.body.username) > -1) {
-          context.security_plugin?.logger.error(`Denied login for forbidden username ${request.body.username}`);
-          return response.badRequest({ // Cannot login using forbidden user name.
+          context.security_plugin.logger.error(
+            `Denied login for forbidden username ${request.body.username}`
+          );
+          return response.badRequest({
+            // Cannot login using forbidden user name.
             body: 'Invalid username or password',
           });
         }
@@ -77,7 +79,7 @@ export class BasicAuthRoutes {
 
         this.sessionStorageFactory.asScoped(request).clear();
         const encodedCredentials = Buffer.from(
-          `${request.body.username}:${request.body.password}`,
+          `${request.body.username}:${request.body.password}`
         ).toString('base64');
         const sessionStorage: SecuritySessionCookie = {
           username: user.username,

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -55,10 +55,12 @@ export class BasicAuthRoutes {
       async (context, request, response) => {
         const forbiddenUsernames = this.config.auth.forbidden_usernames;
         if (forbiddenUsernames.indexOf(request.body.username) > -1) {
-          throw new Error('Invalid username or password'); // Cannot login using forbidden user name.
+          context.security_plugin?.logger.error(`Denied login for forbidden username ${request.body.username}`);
+          return response.badRequest({ // Cannot login using forbidden user name.
+            body: 'Invalid username or password',
+          });
         }
 
-        // const authHeaderValue = Buffer.from(`${request.body.username}:${request.body.password}`).toString('base64');
         let user: User;
         try {
           user = await this.securityClient.authenticate(request, {

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -36,12 +36,11 @@ export class BasicAuthRoutes {
   ) {}
 
   public setupRoutes() {
-    const PREFIX = '';
 
     // login using username and password
     this.router.post(
       {
-        path: `${PREFIX}/auth/login`, // TODO: move the API endpoints to common to share with browser app
+        path: `/auth/login`, // TODO: move the API endpoints to common to share with browser app
         validate: {
           body: schema.object({
             username: schema.string(),
@@ -68,6 +67,7 @@ export class BasicAuthRoutes {
             password: request.body.password,
           });
         } catch (error) {
+          context.security_plugin.logger.error(`Failed authentication: ${error}`);
           return response.unauthorized({
             headers: {
               'www-authenticate': error.message,
@@ -75,8 +75,9 @@ export class BasicAuthRoutes {
           });
         }
 
+        this.sessionStorageFactory.asScoped(request).clear();
         const encodedCredentials = Buffer.from(
-          `${request.body.username}:${request.body.password}`
+          `${request.body.username}:${request.body.password}`,
         ).toString('base64');
         const sessionStorage: SecuritySessionCookie = {
           username: user.username,
@@ -122,7 +123,7 @@ export class BasicAuthRoutes {
     // logout
     this.router.post(
       {
-        path: `${PREFIX}/auth/logout`,
+        path: `/auth/logout`,
         validate: false,
         options: {
           authRequired: false,
@@ -137,7 +138,7 @@ export class BasicAuthRoutes {
     // anonymous auth
     this.router.get(
       {
-        path: `${PREFIX}/auth/anonymous`,
+        path: `/auth/anonymous`,
         validate: false,
         options: {
           authRequired: false,
@@ -150,7 +151,7 @@ export class BasicAuthRoutes {
         } else {
           return response.redirected({
             headers: {
-              location: `${PREFIX}/login`,
+              location: `/login`,
             },
           });
         }
@@ -160,7 +161,7 @@ export class BasicAuthRoutes {
     // renders custom error page
     this.router.get(
       {
-        path: `${PREFIX}/customerror`,
+        path: `/customerror`,
         validate: false,
         options: {
           authRequired: false,

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -51,7 +51,7 @@ export class BasicAuthRoutes {
         },
       },
       async (context, request, response) => {
-        const forbiddenUsernames = this.config.auth.forbidden_usernames;
+        const forbiddenUsernames: string[] = this.config.auth.forbidden_usernames;
         if (forbiddenUsernames.indexOf(request.body.username) > -1) {
           context.security_plugin.logger.error(
             `Denied login for forbidden username ${request.body.username}`

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -146,7 +146,7 @@ export class OpenIdAuthRoutes {
             },
           });
         } catch (error) {
-          console.log(error); // TODO: change to logger
+          context.security_plugin.logger.error(`OpenId authentication failed: ${error}`);
           return response.unauthorized();
         }
       }

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -67,7 +67,7 @@ export class SamlAuthRoutes {
             },
           });
         } catch (error) {
-          console.log(error);
+          context.security_plugin.logger.error(`Failed to get saml header: ${error}`);
           return response.internalError(); // TODO: redirect to error page?
         }
       }
@@ -99,7 +99,7 @@ export class SamlAuthRoutes {
             });
           }
         } catch (error) {
-          console.log(error);
+          context.security_plugin.logger.error(`Failed to parse cookie: ${error}`);
           return response.badRequest();
         }
 
@@ -129,7 +129,7 @@ export class SamlAuthRoutes {
             },
           });
         } catch (error) {
-          console.log(error);
+          context.security_plugin.logger.error(`SAML SP initiated authentication workflow failed: ${error}`);
         }
 
         return response.internalError();
@@ -174,7 +174,7 @@ export class SamlAuthRoutes {
             },
           });
         } catch (error) {
-          console.log(error);
+          context.security_plugin.logger.error(`SAML IDP initiated authentication workflow failed: ${error}`);
         }
         return response.internalError();
       }
@@ -197,7 +197,7 @@ export class SamlAuthRoutes {
             },
           });
         } catch (error) {
-          console.log(error);
+          context.security_plugin.logger.error(`SAML logout failed: ${error}`);
           return response.badRequest();
         }
       }

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -129,7 +129,9 @@ export class SamlAuthRoutes {
             },
           });
         } catch (error) {
-          context.security_plugin.logger.error(`SAML SP initiated authentication workflow failed: ${error}`);
+          context.security_plugin.logger.error(
+            `SAML SP initiated authentication workflow failed: ${error}`
+          );
         }
 
         return response.internalError();
@@ -174,7 +176,9 @@ export class SamlAuthRoutes {
             },
           });
         } catch (error) {
-          context.security_plugin.logger.error(`SAML IDP initiated authentication workflow failed: ${error}`);
+          context.security_plugin.logger.error(
+            `SAML IDP initiated authentication workflow failed: ${error}`
+          );
         }
         return response.internalError();
       }

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -22,6 +22,7 @@ import {
   IClusterClient,
   KibanaRequest,
   AuthToolkit,
+  Logger,
 } from '../../../../../../src/core/server';
 import { SecuritySessionCookie } from '../../../session/security_cookie';
 import { CoreSetup } from '../../../../../../src/core/server';
@@ -38,7 +39,8 @@ export class SamlAuthentication {
     private readonly sessionStorageFactory: SessionStorageFactory<SecuritySessionCookie>,
     private readonly router: IRouter,
     private readonly esClient: IClusterClient,
-    private readonly coreSetup: CoreSetup
+    private readonly coreSetup: CoreSetup,
+    private readonly logger: Logger
   ) {
     this.securityClient = new SecurityClient(esClient);
     this.setupRoutes();
@@ -49,7 +51,7 @@ export class SamlAuthentication {
     try {
       cookie = await this.sessionStorageFactory.asScoped(request).get();
     } catch (error) {
-      console.log(error);
+      this.logger.error(`Failed to parse cookie due to: ${error}`);
       toolkit.notHandled();
     }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -114,7 +114,7 @@ export function defineRoutes(router: IRouter, esClient: IClusterClient) {
         }),
       },
     },
-    async (context, request, response) => {
+    async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
       const client = esClient.asScoped(request);
       let esResp;
       try {
@@ -147,7 +147,7 @@ export function defineRoutes(router: IRouter, esClient: IClusterClient) {
         }),
       },
     },
-    async (context, request, response) => {
+    async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
       const client = esClient.asScoped(request);
       let esResp;
       try {
@@ -176,7 +176,7 @@ export function defineRoutes(router: IRouter, esClient: IClusterClient) {
         }),
       },
     },
-    async (context, request, response) => {
+    async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
       const client = esClient.asScoped(request);
       let esResp;
       try {
@@ -209,7 +209,7 @@ export function defineRoutes(router: IRouter, esClient: IClusterClient) {
         body: schema.any(),
       },
     },
-    async (context, request, response) => {
+    async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
       try {
         validateRequestBody(request.params.resourceName, request.body);
       } catch (error) {
@@ -281,7 +281,7 @@ export function defineRoutes(router: IRouter, esClient: IClusterClient) {
       path: `${API_PREFIX}/auth/authinfo`,
       validate: false,
     },
-    async (context, request, response) => {
+    async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
       const client = esClient.asScoped(request);
       let esResp;
       try {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,7 +14,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { IRouter, IClusterClient, ResponseError, IKibanaResponse } from '../../../../src/core/server';
+import {
+  IRouter,
+  IClusterClient,
+  ResponseError,
+  IKibanaResponse,
+} from '../../../../src/core/server';
 import { API_PREFIX } from '../../common';
 
 // TODO: consider to extract entity CRUD operations and put it into a client class
@@ -266,7 +271,7 @@ export function defineRoutes(router: IRouter, esClient: IClusterClient) {
         return response.customError({
           statusCode: error.statusCode,
           body: parseEsErrorResponse(error),
-        })
+        });
       }
     }
   );
@@ -300,7 +305,7 @@ function parseEsErrorResponse(error: any) {
     try {
       const esErrorResponse = JSON.parse(error.response);
       return esErrorResponse.reason || error.response;
-    } catch (error) {
+    } catch (parsingError) {
       return error.response;
     }
   }

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -67,10 +67,7 @@ export function getSecurityCookieOptions(
         return { isValid: false, path: '/' };
       }
 
-      if (
-        sessionStorage.expiryTime === undefined ||
-        sessionStorage.expiryTime < Date.now()
-      ) {
+      if (sessionStorage.expiryTime === undefined || sessionStorage.expiryTime < Date.now()) {
         return { isValid: false, path: '/' };
       }
       return { isValid: true, path: '/' };

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -69,12 +69,12 @@ export function getSecurityCookieOptions(
 
       if (
         sessionStorage.expiryTime === undefined ||
-        new Date(sessionStorage.expiryTime) < new Date()
+        sessionStorage.expiryTime < Date.now()
       ) {
         return { isValid: false, path: '/' };
       }
       return { isValid: true, path: '/' };
     },
-    isSecure: false, // config.cookie.secure,
+    isSecure: false, // TODO: config.cookie.secure,
   };
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Pass logger to route handler via context, refer to https://github.com/elastic/kibana/blob/master/src/core/MIGRATION.md#declare-a-custom-scoped-service
* update error message when failed to call ES API

e.g. when failed to create user, current response looks like:
```
{"statusCode":400,"error":"Bad Request","message":"Bad Request"}
```
updated response includes more informative message from ES:
```
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
