### PR TITLE
add backend calls to enable or disable audit logging

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -23,6 +23,7 @@ export const API_ENDPOINT_TENANTS = API_ENDPOINT + '/tenants';
 export const API_ENDPOINT_SECURITYCONFIG = API_ENDPOINT + '/securityconfig';
 export const API_ENDPOINT_INTERNALUSERS = API_ENDPOINT + '/internalusers';
 export const API_ENDPOINT_AUDITLOGGING = API_ENDPOINT + '/audit';
+export const API_ENDPOINT_AUDITLOGGING_UPDATE = API_ENDPOINT_AUDITLOGGING + '/config';
 
 export const CLUSTER_PERMISSIONS = [
   'cluster:admin/ingest/pipeline/delete',

--- a/public/apps/configuration/panels/audit-logging/types.tsx
+++ b/public/apps/configuration/panels/audit-logging/types.tsx
@@ -1,0 +1,55 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export interface GeneralSettings {
+  // layer
+  enable_rest?: boolean;
+  enable_transport?: boolean;
+  disabled_rest_categories?: string[];
+  disabled_transport_categories?: string[];
+
+  // attribute
+  resolve_bulk_requests?: boolean;
+  resolve_indices?: boolean;
+  log_request_body?: boolean;
+  exclude_sensitive_headers?: boolean;
+
+  // ignore
+  ignore_users?: string[];
+  ignore_requests?: string[];
+}
+
+export interface ComplianceSettings {
+  enabled?: boolean;
+
+  // read
+  read_metadata_only?: boolean;
+  read_ignore_users?: string[];
+  read_watched_fields?: {
+    [key: string]: string;
+  };
+
+  // write
+  write_metadata_only?: boolean;
+  write_log_diffs?: boolean;
+  write_ignore_users?: string[];
+  write_watched_indices?: string[];
+}
+
+export interface AuditLoggingSettings {
+  enabled?: boolean;
+  audit?: GeneralSettings;
+  compliance?: ComplianceSettings;
+}

--- a/public/apps/configuration/utils/audit-logging-view-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-view-utils.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlexGrid,
   EuiForm,
   EuiFormRow,
+  EuiHorizontalRule,
   EuiPanel,
   EuiSpacer,
   EuiSwitch,
@@ -25,60 +26,38 @@ import {
 } from '@elastic/eui';
 
 import React from 'react';
+import { HttpStart } from 'kibana/public';
 import { displayArray, displayBoolean, displayObject, renderTextFlexItem } from './display-utils';
-
-interface GeneralSettings {
-  // layer
-  enable_rest: boolean;
-  enable_transport: boolean;
-  disabled_rest_categories: string[];
-  disabled_transport_categories: string[];
-
-  // attribute
-  resolve_bulk_requests: boolean;
-  resolve_indices: boolean;
-  log_request_body: boolean;
-  exclude_sensitive_headers: boolean;
-
-  // ignore
-  ignore_users: string[];
-  ignore_requests: string[];
-}
-
-interface ComplianceSettings {
-  enabled: boolean;
-
-  // read
-  read_metadata_only: boolean;
-  read_ignore_users: string[];
-  read_watched_fields: {
-    [key: string]: string;
-  };
-
-  // write
-  write_metadata_only: boolean;
-  write_log_diffs: boolean;
-  write_ignore_users: string[];
-  write_watched_indices: string[];
-}
+import { API_ENDPOINT_AUDITLOGGING_UPDATE } from '../constants';
+import {
+  AuditLoggingSettings,
+  ComplianceSettings,
+  GeneralSettings,
+} from '../panels/audit-logging/types';
 
 export function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: boolean) {
   return (
-    <EuiForm>
-      <EuiDescribedFormGroup
-        title={<h3>Enable audit logging</h3>}
-        description={<>Enable or disable audit logging</>}
-      >
-        <EuiFormRow>
-          <EuiSwitch
-            name="auditLoggingEnabledSwitch"
-            label={displayBoolean(auditLoggingEnabled)}
-            checked={auditLoggingEnabled}
-            onChange={onSwitchChange}
-          />
-        </EuiFormRow>
-      </EuiDescribedFormGroup>
-    </EuiForm>
+    <EuiPanel>
+      <EuiTitle>
+        <h3>Audit logging</h3>
+      </EuiTitle>
+      <EuiHorizontalRule />
+      <EuiForm>
+        <EuiDescribedFormGroup
+          title={<h3>Enable audit logging</h3>}
+          description={<>Enable or disable audit logging</>}
+        >
+          <EuiFormRow>
+            <EuiSwitch
+              name="auditLoggingEnabledSwitch"
+              label={displayBoolean(auditLoggingEnabled)}
+              checked={auditLoggingEnabled}
+              onChange={onSwitchChange}
+            />
+          </EuiFormRow>
+        </EuiDescribedFormGroup>
+      </EuiForm>
+    </EuiPanel>
   );
 }
 
@@ -214,4 +193,10 @@ export function renderComplianceSettings(complianceSettings: ComplianceSettings)
       </EuiPanel>
     </>
   );
+}
+
+export async function updateAuditLogging(http: HttpStart, updateObject: AuditLoggingSettings) {
+  return await http.post(`${API_ENDPOINT_AUDITLOGGING_UPDATE}`, {
+    body: JSON.stringify(updateObject),
+  });
 }

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -31,14 +31,14 @@ export function renderTextFlexItem(header: string, value: string) {
   );
 }
 
-export function displayBoolean(bool: boolean) {
+export function displayBoolean(bool: boolean | undefined) {
   return bool ? 'Enabled' : 'Disabled';
 }
 
-export function displayArray(array: string[]) {
+export function displayArray(array: string[] | undefined) {
   return array?.join(', ') || '--';
 }
 
-export function displayObject(object: object) {
+export function displayObject(object: object | undefined) {
   return !isEmpty(object) ? JSON.stringify(object) : '--';
 }

--- a/server/backend/opendistro_security_configuration_plugin.ts
+++ b/server/backend/opendistro_security_configuration_plugin.ts
@@ -214,4 +214,12 @@ export default function (Client: any, config: any, components: any) {
       fmt: '/_opendistro/_security/api/authtoken',
     },
   });
+
+  Client.prototype.opendistro_security.prototype.audit = ca({
+    method: 'PUT',
+    needBody: true,
+    url: {
+      fmt: '/_opendistro/_security/api/audit/config',
+    },
+  });
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -298,6 +298,34 @@ export function defineRoutes(router: IRouter, esClient: IClusterClient) {
       }
     }
   );
+
+  router.post(
+    {
+      path: `${API_PREFIX}/configuration/audit/config`,
+      validate: {
+        body: schema.any(),
+      },
+    },
+    async (context, request, response) => {
+      const client = esClient.asScoped(request);
+      let esResp;
+      try {
+        esResp = await client.callAsCurrentUser('opendistro_security.audit', {
+          body: request.body,
+        });
+        return response.ok({
+          body: {
+            message: esResp.message,
+          },
+        });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode,
+          body: parseEsErrorResponse(error),
+        });
+      }
+    }
+  );
 }
 
 function parseEsErrorResponse(error: any) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add the backend interactions when users disable or enable the audit logging. Please note that during disabling, only the status itself is changed instead of wiping out all the configurations. This is the intended behavior.

*Test*
Initially enabled.
![screencapture-localhost-5601-app-opendistro-security-2020-06-18-18_34_28](https://user-images.githubusercontent.com/60111637/85087478-8270e600-b192-11ea-9c81-da7bebd396ac.png)

Then disabled
![screencapture-localhost-5601-app-opendistro-security-2020-06-18-18_34_45](https://user-images.githubusercontent.com/60111637/85087503-91579880-b192-11ea-9ce3-da9bda5b8c6c.png)

Then enabled again
![screencapture-localhost-5601-app-opendistro-security-2020-06-18-18_35_06](https://user-images.githubusercontent.com/60111637/85087510-961c4c80-b192-11ea-9503-66c7dbe84d02.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
