### PR TITLE
Show an empty row if no data present for user/attributes, role/indexPermission, role/tenant. And remove empty entry before submit.

### DIFF
--- a/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
@@ -21,7 +21,7 @@ import {
   EuiSpacer,
   EuiFormRow,
 } from '@elastic/eui';
-import { map } from 'lodash';
+import { map, isEmpty } from 'lodash';
 import React, { Dispatch, Fragment, SetStateAction } from 'react';
 import { UserAttributes } from '../../types';
 import {
@@ -105,6 +105,10 @@ export function AttributePanel(props: {
   setState: Dispatch<SetStateAction<UserAttributeStateClass[]>>;
 }) {
   const { state, setState } = props;
+  // Show one empty row if there is no data.
+  if (isEmpty(state)) {
+    setState([getEmptyAttribute()]);
+  }
   return (
     <PanelWithHeader
       headerText="Attributes"

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -120,10 +120,13 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         return;
       }
 
+      // Remove attribute with empty key
+      const validAttributes = attributes.filter((v: UserAttributeStateClass) => v.key !== '');
+
       const updateObject: InternalUserUpdate = {
         password,
         backend_roles: backendRoles,
-        attributes: unbuildAttributeState(attributes),
+        attributes: unbuildAttributeState(validAttributes),
       };
       await updateUser(props.coreStart.http, userName, updateObject);
 

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -120,7 +120,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         return;
       }
 
-      // Remove attribute with empty key
+      // Remove attributes with empty key
       const validAttributes = attributes.filter((v: UserAttributeStateClass) => v.key !== '');
 
       const updateObject: InternalUserUpdate = {

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -24,6 +24,7 @@ import {
   EuiTextArea,
 } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction } from 'react';
+import { isEmpty } from 'lodash';
 import { RoleIndexPermission } from '../../types';
 import {
   appendElementToArray,
@@ -38,7 +39,6 @@ import {
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { ComboBoxOptions, FieldLevelSecurityMethod, RoleIndexPermissionStateClass } from './types';
-import { isEmpty } from 'lodash';
 
 export function getEmptyIndexPermission(): RoleIndexPermissionStateClass {
   return {

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -38,6 +38,7 @@ import {
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { ComboBoxOptions, FieldLevelSecurityMethod, RoleIndexPermissionStateClass } from './types';
+import { isEmpty } from 'lodash';
 
 export function getEmptyIndexPermission(): RoleIndexPermissionStateClass {
   return {
@@ -316,6 +317,10 @@ export function IndexPermissionPanel(props: {
   setState: Dispatch<SetStateAction<RoleIndexPermissionStateClass[]>>;
 }) {
   const { state, optionUniverse, setState } = props;
+  // Show one empty row if there is no data.
+  if (isEmpty(state)) {
+    setState([getEmptyIndexPermission()]);
+  }
   return (
     <PanelWithHeader
       headerText="Index permissions"

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -28,6 +28,7 @@ import {
 } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React, { useEffect, useState, useCallback } from 'react';
+import { isEmpty } from 'lodash';
 import { BreadcrumbsPageDependencies } from '../../../types';
 import { CLUSTER_PERMISSIONS, INDEX_PERMISSIONS } from '../../constants';
 import { fetchActionGroups } from '../../utils/action-groups-utils';
@@ -152,10 +153,16 @@ export function RoleEdit(props: RoleEditDeps) {
 
   const updateRoleHandler = async () => {
     try {
+      const validIndexPermission = roleIndexPermission.filter(
+        (v: RoleIndexPermissionStateClass) => !isEmpty(v.indexPatterns)
+      );
+      const validTenantPermission = roleTenantPermission.filter(
+        (v: RoleTenantPermissionStateClass) => !isEmpty(v.tenantPatterns)
+      );
       await updateRole(props.coreStart.http, roleName, {
         cluster_permissions: roleClusterPermission.map(comboBoxOptionToString),
-        index_permissions: unbuildIndexPermissionState(roleIndexPermission),
-        tenant_permissions: unbuildTenantPermissionState(roleTenantPermission),
+        index_permissions: unbuildIndexPermissionState(validIndexPermission),
+        tenant_permissions: unbuildTenantPermissionState(validTenantPermission),
       });
       window.location.href = buildHashUrl(ResourceType.roles, Action.view, roleName);
     } catch (e) {

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -153,12 +153,14 @@ export function RoleEdit(props: RoleEditDeps) {
 
   const updateRoleHandler = async () => {
     try {
+      // Remove index/tenant permissions with empty patterns.
       const validIndexPermission = roleIndexPermission.filter(
         (v: RoleIndexPermissionStateClass) => !isEmpty(v.indexPatterns)
       );
       const validTenantPermission = roleTenantPermission.filter(
         (v: RoleTenantPermissionStateClass) => !isEmpty(v.tenantPatterns)
       );
+
       await updateRole(props.coreStart.http, roleName, {
         cluster_permissions: roleClusterPermission.map(comboBoxOptionToString),
         index_permissions: unbuildIndexPermissionState(validIndexPermission),

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -15,6 +15,7 @@
 
 import { EuiButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSuperSelect } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction } from 'react';
+import { isEmpty } from 'lodash';
 import { RoleTenantPermission } from '../../types';
 import {
   appendElementToArray,
@@ -29,7 +30,6 @@ import {
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { ComboBoxOptions, RoleTenantPermissionStateClass, TenantPermissionType } from './types';
-import { isEmpty } from 'lodash';
 
 const TENANT_READ_PERMISSION = 'kibana_all_read';
 const TENANT_WRITE_PERMISSION = 'kibana_all_write';

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -29,6 +29,7 @@ import {
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { ComboBoxOptions, RoleTenantPermissionStateClass, TenantPermissionType } from './types';
+import { isEmpty } from 'lodash';
 
 const TENANT_READ_PERMISSION = 'kibana_all_read';
 const TENANT_WRITE_PERMISSION = 'kibana_all_write';
@@ -137,6 +138,10 @@ export function TenantPanel(props: {
   setState: Dispatch<SetStateAction<RoleTenantPermissionStateClass[]>>;
 }) {
   const { state, optionUniverse, setState } = props;
+  // Show one empty row if there is no data.
+  if (isEmpty(state)) {
+    setState([getEmptyTenantPermission()]);
+  }
   return (
     <PanelWithHeader
       headerText="Tenants"

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -302,7 +302,7 @@ export function RoleList(props: AppDependencies) {
                 <EuiButton
                   fill
                   onClick={() => {
-                    window.location.href = buildHashUrl(ResourceType.users, Action.create);
+                    window.location.href = buildHashUrl(ResourceType.roles, Action.create);
                   }}
                 >
                   Create role


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Show an empty row if no data present for user/attributes, role/indexPermission, role/tenant. And remove empty entry before submit.
* Fix a bug that link to user creation instead of role creation on role listing page.

*Screenshots:*
*Before*
![image](https://user-images.githubusercontent.com/63078162/85184083-46e22480-b243-11ea-9f77-4506efd8a312.png)
![image](https://user-images.githubusercontent.com/63078162/85184076-3df15300-b243-11ea-8e9c-57aad9861a1b.png)

*After*
![image](https://user-images.githubusercontent.com/63078162/85184030-113d3b80-b243-11ea-86f8-3d261ec384fd.png)
![image](https://user-images.githubusercontent.com/63078162/85184048-24500b80-b243-11ea-904f-da68d54daa33.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
