### PR TITLE
Audit logging UI changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,14 @@ export default function (kibana) {
                     icon: 'plugins/opendistro_security/assets/opendistro_security.svg',
                     linkToLastSubUrl: false,
                     url: '/app/security-configuration#/'
+                },
+                {
+                    id: 'security-audit',
+                    title: 'Audit',
+                    description: 'Audit logging',
+                    main: 'plugins/opendistro_security/apps/audit/app',
+                    linkToLastSubUrl: false,
+                    url: '/app/security-audit#/'
                 }
             ],
             styleSheetPaths: require('path').resolve(__dirname, 'public/app.css'),

--- a/lib/configuration/backend/opendistro_security_configuration_backend.js
+++ b/lib/configuration/backend/opendistro_security_configuration_backend.js
@@ -40,6 +40,7 @@ import roles_schema from '../validation/roles';
 import rolesmapping_schema from '../validation/rolesmapping';
 import tenants_schema from '../validation/tenants';
 import account_schema from '../validation/account';
+import audit_schema from '../validation/audit';
 /**
  * The Security  backend.
  */
@@ -68,6 +69,8 @@ export default class SecurityConfigurationBackend {
                     return tenants_schema;
                 case 'account':
                     return account_schema;
+                case 'audit':
+                    return audit_schema;
                 default:
                     throw new Error('Unknown resource');
             }

--- a/lib/configuration/validation/audit.js
+++ b/lib/configuration/validation/audit.js
@@ -1,0 +1,43 @@
+import Joi from 'joi';
+
+export default Joi.object().keys({
+  enabled: Joi.boolean(),
+  audit: Joi.object().keys({
+    enable_rest: Joi.boolean(),
+    disabled_rest_categories: Joi.array().items(
+      'AUTHENTICATED',
+      'BAD_HEADERS',
+      'FAILED_LOGIN',
+      'GRANTED_PRIVILEGES',
+      'MISSING_PRIVILEGES',
+      'SSL_EXCEPTION'
+    ),
+    enable_transport: Joi.boolean(),
+    disabled_transport_categories: Joi.array().items(
+      'AUTHENTICATED',
+      'BAD_HEADERS',
+      'FAILED_LOGIN',
+      'GRANTED_PRIVILEGES',
+      'MISSING_PRIVILEGES',
+      'SSL_EXCEPTION'
+    ),
+    resolve_bulk_requests: Joi.boolean(),
+    log_request_body: Joi.boolean(),
+    resolve_indices: Joi.boolean(),
+    exclude_sensitive_headers: Joi.boolean(),
+    ignore_users: Joi.array().items(Joi.string()),
+    ignore_requests: Joi.array().items(Joi.string()),
+  }),
+  compliance: Joi.object({
+    enabled: Joi.boolean(),
+    external_config: Joi.boolean(),
+    internal_config: Joi.boolean(),
+    read_metadata_only: Joi.boolean(),
+    read_ignore_users: Joi.array().items(Joi.string()),
+    read_watched_fields: Joi.object(),
+    write_log_diffs: Joi.boolean(),
+    write_metadata_only: Joi.boolean(),
+    write_ignore_users: Joi.array().items(Joi.string()),
+    write_watched_indices: Joi.array().items(Joi.string()),
+  }),
+});

--- a/public/apps/audit/app.js
+++ b/public/apps/audit/app.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { uiModules } from 'ui/modules';
+import chrome from 'ui/chrome';
+import { render, unmountComponentAtNode } from 'react-dom';
+
+import { Main } from './components/main';
+
+const app = uiModules.get('apps/audit');
+
+app.config($locationProvider => {
+  $locationProvider.html5Mode({
+    enabled: false,
+    requireBase: false,
+    rewriteLinks: false,
+  });
+});
+app.config(stateManagementConfigProvider => stateManagementConfigProvider.disable());
+
+function RootController($scope, $element, $http) {
+  const domNode = $element[0];
+
+  // render react to DOM
+  render(<Main title="audit" httpClient={$http} />, domNode);
+
+  // unmount react on controller destroy
+  $scope.$on('$destroy', () => {
+    unmountComponentAtNode(domNode);
+  });
+}
+
+chrome.setRootController('audit', RootController);

--- a/public/apps/audit/components/main/ContentPanel.js
+++ b/public/apps/audit/components/main/ContentPanel.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiTitle,
+} from '@elastic/eui';
+
+const ContentPanel = ({ title, children, configureHandler }) => (
+  <>
+    <EuiPanel paddingSize="none">
+      <div style={{ padding: 20, paddingBottom: 0 }}>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiTitle>
+              <h3>{title}</h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          {typeof configureHandler == 'function' && (
+            <EuiFlexItem grow={false}>
+              <EuiButton onClick={configureHandler}>Configure</EuiButton>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </div>
+      <EuiHorizontalRule margin="xs" />
+      <div style={{ padding: 32, paddingBottom: 0 }}>{children}</div>
+    </EuiPanel>
+  </>
+);
+
+ContentPanel.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node,
+  configureHandler: PropTypes.func,
+};
+
+export default ContentPanel;

--- a/public/apps/audit/components/main/DisplaySettingGroup.js
+++ b/public/apps/audit/components/main/DisplaySettingGroup.js
@@ -1,0 +1,64 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import {
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTextColor,
+  EuiTitle,
+} from '@elastic/eui';
+import { displaySettingType, filterReadonly } from './utils';
+import { get } from 'lodash';
+
+function DisplaySettingGroup({ settingGroup, config, readonly, showPanel }) {
+  const settingGroupFiltered = filterReadonly(readonly, settingGroup);
+  const renderedSettings =
+    settingGroupFiltered.settings.length != 0 ? (
+      <>
+        {settingGroupFiltered.title && (
+          <>
+            <EuiTitle size="s">
+              <h2>{settingGroupFiltered.title}</h2>
+            </EuiTitle>
+            <EuiSpacer size="m" />
+          </>
+        )}
+        <EuiFlexGrid columns={3}>
+          {settingGroupFiltered.settings.map(setting => {
+            return (
+              <Fragment key={setting.path}>
+                <EuiFlexItem>
+                  <EuiText size="s">
+                    <h4>{setting.title}</h4>
+                    <p>
+                      <EuiTextColor color="subdued">
+                        <small>{displaySettingType(setting, get(config, setting.path))}</small>
+                      </EuiTextColor>
+                    </p>
+                  </EuiText>
+                </EuiFlexItem>
+              </Fragment>
+            );
+          })}
+        </EuiFlexGrid>
+      </>
+    ) : null;
+
+  return renderedSettings ? (
+    <>
+      {showPanel ? <EuiPanel>{renderedSettings}</EuiPanel> : renderedSettings}
+      <EuiSpacer />
+    </>
+  ) : null;
+}
+
+DisplaySettingGroup.propTypes = {
+  settingGroup: PropTypes.object,
+  config: PropTypes.object,
+  readonly: PropTypes.array,
+  showPanel: PropTypes.bool,
+};
+
+export default DisplaySettingGroup;

--- a/public/apps/audit/components/main/EditSettingGroup.js
+++ b/public/apps/audit/components/main/EditSettingGroup.js
@@ -1,0 +1,163 @@
+import React, { Fragment, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  EuiCodeBlock,
+  EuiComboBox,
+  EuiDescribedFormGroup,
+  EuiFormRow,
+  EuiIcon,
+  EuiLink,
+  EuiPanel,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
+  EuiTextColor,
+  EuiTitle,
+} from '@elastic/eui';
+import { get } from 'lodash';
+import {
+  displayBoolean,
+  displayLabel,
+  generateComboBoxLabels,
+  removeComboBoxLabels,
+  filterReadonly,
+} from './utils';
+import EditorBox from './EditorBox';
+
+function EditSettingGroup({
+  settingGroup,
+  config,
+  handleChange,
+  handleInvalid,
+  readonly,
+  showPanel,
+}) {
+  const renderField = (config, setting, handleChange, handleInvalid) => {
+    const val = get(config, setting.path);
+    if (setting.type === 'bool') {
+      return (
+        <EuiSwitch
+          label={displayBoolean(val)}
+          checked={val}
+          onChange={e => {
+            handleChange(setting, e.target.checked);
+          }}
+        />
+      );
+    } else if (setting.type === 'array' && typeof setting.options !== 'undefined') {
+      return (
+        <EuiComboBox
+          placeholder={setting.title}
+          options={generateComboBoxLabels(setting.options)}
+          selectedOptions={generateComboBoxLabels(val)}
+          onChange={selectedOptions => {
+            handleChange(setting, removeComboBoxLabels(selectedOptions));
+          }}
+        />
+      );
+    } else if (setting.type === 'array') {
+      return (
+        <EuiComboBox
+          noSuggestions
+          placeholder={setting.title}
+          selectedOptions={generateComboBoxLabels(val)}
+          onChange={selectedOptions => {
+            handleChange(setting, removeComboBoxLabels(selectedOptions));
+          }}
+          onCreateOption={searchValue => {
+            handleChange(setting, [...val, searchValue]);
+          }}
+        />
+      );
+    } else if (setting.type === 'map') {
+      return (
+        <EditorBox
+          config={config}
+          handleChange={handleChange}
+          handleInvalid={handleInvalid}
+          setting={setting}
+        />
+      );
+    } else if (setting.type === 'text') {
+      return (
+        <EuiText color="subdued" size="s">
+          <EuiTextColor color="subdued">
+            <p>
+              {setting.content}
+              <br />
+              <EuiLink href={setting.url}>
+                Learn more in the documentation
+                <EuiIcon type="popout" />
+              </EuiLink>
+            </p>
+          </EuiTextColor>
+        </EuiText>
+      );
+    } else {
+      return <></>;
+    }
+  };
+
+  const renderCodeBlock = setting => {
+    return (
+      <>
+        <EuiCodeBlock language="json" paddingSize="none" isCopyable>
+          {setting.code}
+        </EuiCodeBlock>
+      </>
+    );
+  };
+
+  const settingGroupFiltered = filterReadonly(readonly, settingGroup);
+  const renderedSettings =
+    settingGroupFiltered.settings.length != 0 ? (
+      <>
+        {settingGroupFiltered.title && (
+          <>
+            <EuiTitle>
+              <h3>{settingGroupFiltered.title}</h3>
+            </EuiTitle>
+            <EuiSpacer />
+          </>
+        )}
+        {settingGroupFiltered.settings.map(setting => {
+          return (
+            <Fragment key={setting.path}>
+              <EuiDescribedFormGroup
+                title={<h3>{setting.title}</h3>}
+                description={
+                  <>
+                    {setting.description}
+                    {setting.code && renderCodeBlock(setting)}
+                  </>
+                }
+                fullWidth
+              >
+                <EuiFormRow label={displayLabel(setting.path)}>
+                  {renderField(config, setting, handleChange, handleInvalid)}
+                </EuiFormRow>
+              </EuiDescribedFormGroup>
+            </Fragment>
+          );
+        })}
+      </>
+    ) : null;
+
+  return renderedSettings ? (
+    <>
+      {showPanel ? <EuiPanel>{renderedSettings}</EuiPanel> : renderedSettings}
+      <EuiSpacer size="xs" />
+    </>
+  ) : null;
+}
+
+EditSettingGroup.propTypes = {
+  settingGroup: PropTypes.object,
+  config: PropTypes.object,
+  handleChange: PropTypes.func,
+  handleInvalid: PropTypes.func,
+  readonly: PropTypes.array,
+  showPanel: PropTypes.bool,
+};
+
+export default EditSettingGroup;

--- a/public/apps/audit/components/main/EditorBox.js
+++ b/public/apps/audit/components/main/EditorBox.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { EuiCodeEditor, EuiText, EuiTextColor } from '@elastic/eui';
+import { get } from 'lodash';
+
+import 'brace/theme/textmate';
+import 'brace/mode/json';
+
+function EditorBox({ setting, config, handleChange, handleInvalid }) {
+  const [value, updateValue] = useState(JSON.stringify(get(config, setting.path), null, 2));
+  const [invalid, setInvalid] = useState(false);
+
+  const onChange = text => {
+    updateValue(text);
+    try {
+      let parsed = JSON.parse(text);
+      handleChange(setting, parsed);
+      handleInvalid(setting.path, false);
+      setInvalid(false);
+    } catch (e) {
+      setInvalid(true);
+      handleInvalid(setting.path, true);
+    }
+  };
+
+  return (
+    <>
+      <EuiCodeEditor
+        mode="json"
+        theme="textmate"
+        width="100%"
+        height="auto"
+        showGutter={false}
+        minLines={5}
+        maxLines={25}
+        setOptions={{
+          showLineNumbers: false,
+          tabSize: 2,
+        }}
+        value={value}
+        onChange={onChange}
+      />
+      {invalid && (
+        <EuiText size="s">
+          <EuiTextColor color="danger">
+            <small>{setting.error}</small>
+          </EuiTextColor>
+        </EuiText>
+      )}
+    </>
+  );
+}
+
+EditorBox.propTypes = {
+  setting: PropTypes.object,
+  config: PropTypes.object,
+  handleChange: PropTypes.func,
+  handleInvalid: PropTypes.func,
+};
+
+export default EditorBox;

--- a/public/apps/audit/components/main/config.js
+++ b/public/apps/audit/components/main/config.js
@@ -1,0 +1,257 @@
+export const AUDIT_API = {
+  PUT: '../api/v1/configuration/audit/config',
+  GET: '../api/v1/configuration/audit',
+};
+
+export const CONFIG_LABELS = {
+  AUDIT_LOGGING: 'Audit logging',
+  GENERAL_SETTINGS: 'General settings',
+  LAYER_SETTINGS: 'Layer settings',
+  ATTRIBUTE_SETTINGS: 'Attribute settings',
+  IGNORE_SETTINGS: 'Ignore settings',
+  COMPLIANCE_SETTINGS: 'Compliance settings',
+  COMPLIANCE_MODE: 'Compliance mode',
+  COMPLIANCE_CONFIG_SETTINGS: 'Config',
+  COMPLIANCE_READ: 'Read',
+  COMPLIANCE_WRITE: 'Write',
+};
+
+export const TOAST_MESSAGES = {
+  GENERAL_SETTINGS: 'General settings saved',
+  COMPLIANCE_SETTINGS: 'Compliance settings saved',
+};
+
+export const RESPONSE_MESSAGES = {
+  FETCH_ERROR_TITLE: 'Sorry, there was an error fetching audit configuration.',
+  FETCH_ERROR_MESSAGE:
+    'Please ensure hot reloading of audit configuration is enabled in the security plugin.',
+  UPDATE_SUCCESS: 'Audit configuration was successfully updated.',
+  UPDATE_FAILURE: 'Audit configuration could not be updated. Please check configuration.',
+};
+
+export const CALLOUT_MESSAGES = {
+  AUDIT_SETTINGS: [
+    'Enabling REST and Transport layers (audit:enable_rest, audit:enable_transport) may result in a massive number of logs if AUTHENTICATED and GRANTED_PRIVILEGES are not disabled. We suggest you ignore common requests if doing so.',
+    'Enabling Bulk requests (config:audit:resolve_bulk_requests) will generate one log per request, and may also result in very large log files.',
+  ],
+  COMPLIANCE_SETTINGS: [
+    'Configuring Watched fields and Watched indices (compliance:read_watch_fields, compliance:write_watched_indices) will generate one log per document access, and may result in very large logs files being generated if monitoring commonly accessed indices and fields.',
+  ],
+};
+
+const CONFIG = {
+  ENABLED: {
+    title: 'Enable audit logging',
+    path: 'enabled',
+    description: 'Enable or disable audit logging',
+    type: 'bool',
+  },
+  STORAGE: {
+    title: 'Configure Storage',
+    path: '',
+    description: 'Where should Elasticsearch store or send audit logs',
+    content: 'Configure the output location and storage types in elasticsearch.yml',
+    url: 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/',
+    type: 'text',
+  },
+  AUDIT: {
+    REST_LAYER: {
+      title: 'REST layer',
+      path: 'audit.enable_rest',
+      description: 'Enable or disable auditing events that happen on the REST layer',
+      type: 'bool',
+    },
+    REST_DISABLED_CATEGORIES: {
+      title: 'REST disabled categories',
+      path: 'audit.disabled_rest_categories',
+      description: 'Specify audit categories which must be ignored on the REST layer',
+      type: 'array',
+      options: [
+        'BAD_HEADERS',
+        'FAILED_LOGIN',
+        'MISSING_PRIVILEGES',
+        'GRANTED_PRIVILEGES',
+        'SSL_EXCEPTION',
+        'AUTHENTICATED',
+      ],
+    },
+    TRANSPORT_LAYER: {
+      title: 'Transport layer',
+      path: 'audit.enable_transport',
+      description: 'Enable or disable auditing events that happen on the Transport layer',
+      type: 'bool',
+    },
+    TRANSPORT_DISABLED_CATEGORIES: {
+      title: 'Transport disabled categories',
+      path: 'audit.disabled_transport_categories',
+      description: 'Specify audit categories which must be ignored on the Transport layer',
+      type: 'array',
+      options: [
+        'BAD_HEADERS',
+        'FAILED_LOGIN',
+        'MISSING_PRIVILEGES',
+        'GRANTED_PRIVILEGES',
+        'SSL_EXCEPTION',
+        'AUTHENTICATED',
+      ],
+    },
+    BULK_REQUESTS: {
+      title: 'Bulk requests',
+      path: 'audit.resolve_bulk_requests',
+      description: 'Resolve bulk requests during auditing of requests.',
+      type: 'bool',
+    },
+    REQUEST_BODY: {
+      title: 'Request body',
+      path: 'audit.log_request_body',
+      description: 'Include request body during auditing of requests.',
+      type: 'bool',
+    },
+    RESOLVE_INDICES: {
+      title: 'Resolve indices',
+      path: 'audit.resolve_indices',
+      description: 'Resolve indices during auditing of requests.',
+      type: 'bool',
+    },
+    SENSITIVE_HEADERS: {
+      title: 'Sensitive headers',
+      path: 'audit.exclude_sensitive_headers',
+      description: 'Exclude sensitive headers during auditing. Eg: Authorization header',
+      type: 'bool',
+    },
+    IGNORED_USERS: {
+      title: 'Ignored users',
+      path: 'audit.ignore_users',
+      description: 'Users to ignore during auditing.',
+      type: 'array',
+    },
+    IGNORED_REQUESTS: {
+      title: 'Ignored requests',
+      path: 'audit.ignore_requests',
+      description: 'Request patterns to ignore during auditing.',
+      type: 'array',
+    },
+  },
+  COMPLIANCE: {
+    ENABLED: {
+      title: 'Enable compliance mode',
+      path: 'compliance.enabled',
+      description: 'Enable or disable compliance logging',
+      type: 'bool',
+    },
+    INTERNAL_CONFIG: {
+      title: 'Internal config logging',
+      path: 'compliance.internal_config',
+      description: 'Enable or disable logging of events on internal security index',
+      type: 'bool',
+    },
+    EXTERNAL_CONFIG: {
+      title: 'External config logging',
+      path: 'compliance.external_config',
+      description: 'Enable or disable logging of external configuration',
+      type: 'bool',
+    },
+    READ_METADATA_ONLY: {
+      title: 'Read metadata',
+      path: 'compliance.read_metadata_only',
+      description: 'Do not log any document fields. Log only metadata of the document',
+      type: 'bool',
+    },
+    READ_IGNORED_USERS: {
+      title: 'Ignored users',
+      path: 'compliance.read_ignore_users',
+      description: 'Users to ignore during auditing.',
+      type: 'array',
+    },
+    READ_WATCHED_FIELDS: {
+      title: 'Watched fields',
+      path: 'compliance.read_watched_fields',
+      description:
+        'List the indices and fields to watch during read events. Sample data content is as follows',
+      type: 'map',
+      code: `{
+  "index-name-pattern": ["field-name-pattern"],
+  "logs*": ["message"],
+  "twitter": ["id", "user*"]
+}`,
+      error: 'Invalid content. Please check sample data content.',
+    },
+    WRITE_METADATA_ONLY: {
+      title: 'Write metadata',
+      path: 'compliance.write_metadata_only',
+      description: 'Do not log any document content. Log only metadata of the document',
+      type: 'bool',
+    },
+    WRITE_LOG_DIFFS: {
+      title: 'Log diffs',
+      path: 'compliance.write_log_diffs',
+      description: 'Log only diffs for document updates',
+      type: 'bool',
+    },
+    WRITE_IGNORED_USERS: {
+      title: 'Ignored users',
+      path: 'compliance.write_ignore_users',
+      description: 'Users to ignore during auditing.',
+      type: 'array',
+    },
+    WRITE_WATCHED_FIELDS: {
+      title: 'Watch indices',
+      path: 'compliance.write_watched_indices',
+      description: 'List the indices to watch during write events.',
+      type: 'array',
+    },
+  },
+};
+
+export const SETTING_GROUPS = {
+  AUDIT_SETTINGS: {
+    settings: [CONFIG.ENABLED, CONFIG.STORAGE],
+  },
+  LAYER_SETTINGS: {
+    title: CONFIG_LABELS.LAYER_SETTINGS,
+    settings: [
+      CONFIG.AUDIT.REST_LAYER,
+      CONFIG.AUDIT.REST_DISABLED_CATEGORIES,
+      CONFIG.AUDIT.TRANSPORT_LAYER,
+      CONFIG.AUDIT.TRANSPORT_DISABLED_CATEGORIES,
+    ],
+  },
+  ATTRIBUTE_SETTINGS: {
+    title: CONFIG_LABELS.ATTRIBUTE_SETTINGS,
+    settings: [
+      CONFIG.AUDIT.BULK_REQUESTS,
+      CONFIG.AUDIT.REQUEST_BODY,
+      CONFIG.AUDIT.RESOLVE_INDICES,
+      CONFIG.AUDIT.SENSITIVE_HEADERS,
+    ],
+  },
+  IGNORE_SETTINGS: {
+    title: CONFIG_LABELS.IGNORE_SETTINGS,
+    settings: [CONFIG.AUDIT.IGNORED_USERS, CONFIG.AUDIT.IGNORED_REQUESTS],
+  },
+  COMPLIANCE_MODE_SETTINGS: {
+    title: CONFIG_LABELS.COMPLIANCE_MODE,
+    settings: [CONFIG.COMPLIANCE.ENABLED],
+  },
+  COMPLIANCE_CONFIG_SETTINGS: {
+    title: CONFIG_LABELS.COMPLIANCE_CONFIG_SETTINGS,
+    settings: [CONFIG.COMPLIANCE.INTERNAL_CONFIG, CONFIG.COMPLIANCE.EXTERNAL_CONFIG],
+  },
+  COMPLIANCE_READ_SETTINGS: {
+    title: CONFIG_LABELS.COMPLIANCE_READ,
+    settings: [
+      CONFIG.COMPLIANCE.READ_METADATA_ONLY,
+      CONFIG.COMPLIANCE.READ_IGNORED_USERS,
+      CONFIG.COMPLIANCE.READ_WATCHED_FIELDS,
+    ],
+  },
+  COMPLIANCE_WRITE_SETTINGS: {
+    title: CONFIG_LABELS.COMPLIANCE_WRITE,
+    settings: [
+      CONFIG.COMPLIANCE.WRITE_METADATA_ONLY,
+      CONFIG.COMPLIANCE.WRITE_LOG_DIFFS,
+      CONFIG.COMPLIANCE.WRITE_IGNORED_USERS,
+      CONFIG.COMPLIANCE.WRITE_WATCHED_FIELDS,
+    ],
+  },
+};

--- a/public/apps/audit/components/main/index.js
+++ b/public/apps/audit/components/main/index.js
@@ -1,0 +1,1 @@
+export { Main } from './main';

--- a/public/apps/audit/components/main/main.js
+++ b/public/apps/audit/components/main/main.js
@@ -1,0 +1,342 @@
+import React, { useState, useEffect } from 'react';
+import {
+  EuiCallOut,
+  EuiPage,
+  EuiPageBody,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButton,
+} from '@elastic/eui';
+import { toastNotifications } from 'ui/notify';
+import { cloneDeep, pull, set } from 'lodash';
+import {
+  AUDIT_API,
+  CONFIG_LABELS,
+  SETTING_GROUPS,
+  RESPONSE_MESSAGES,
+  CALLOUT_MESSAGES,
+  TOAST_MESSAGES,
+} from './config';
+import ContentPanel from './ContentPanel';
+import DisplaySettingGroup from './DisplaySettingGroup';
+import EditSettingGroup from './EditSettingGroup';
+import { generateReadonlyPaths } from './utils';
+
+export function Main(props) {
+  const [config, setConfig] = useState(null);
+  const [editConfig, setEditConfig] = useState(null);
+  const [readonly, setReadonly] = useState([]);
+  const [showAllSettings, setShowAllSettings] = useState(true);
+  const [showConfigureAudit, setShowConfigureAudit] = useState(false);
+  const [showConfigureCompliance, setShowConfigureCompliance] = useState(false);
+  const [showError, setShowError] = useState(false);
+  const [invalidSettings, setInvalidSettings] = useState([]);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [props.httpClient]);
+
+  const handleChange = (setting, val) => {
+    const editedConfig = set(cloneDeep(editConfig), setting.path, val);
+    setEditConfig(editedConfig);
+  };
+
+  const handleChangeWithSave = (setting, val) => {
+    const editedConfig = set(cloneDeep(editConfig), setting.path, val);
+    saveConfig(editedConfig, false);
+  };
+
+  const handleInvalid = (key, error) => {
+    const invalid = pull([...invalidSettings], key);
+    if (error) {
+      invalid.push(key);
+    }
+    setInvalidSettings(invalid);
+  };
+
+  const toggleDisplay = (
+    show_all_settings = true,
+    show_configure_audit = false,
+    show_configure_compliance = false
+  ) => {
+    setShowAllSettings(show_all_settings);
+    setShowConfigureAudit(show_configure_audit);
+    setShowConfigureCompliance(show_configure_compliance);
+    window.scrollTo({ top: 0 });
+  };
+
+  const cancel = () => {
+    toggleDisplay();
+    setEditConfig(config);
+    setInvalidSettings([]);
+  };
+
+  const saveConfig = (payload, showToast = true, successMessage = '') => {
+    const { httpClient } = props;
+    httpClient
+      .post(AUDIT_API.PUT, payload)
+      .then(() => {
+        if (showToast) {
+          toastNotifications.addSuccess({ title: 'Success', text: successMessage });
+        }
+        toggleDisplay();
+        fetchConfig();
+      })
+      .catch(() => {
+        toastNotifications.addDanger(RESPONSE_MESSAGES.UPDATE_FAILURE);
+      });
+  };
+
+  const fetchConfig = () => {
+    const { httpClient } = props;
+    httpClient
+      .get(AUDIT_API.GET)
+      .then(resp => {
+        const responseConfig = resp.data.data.config;
+        const readonly = generateReadonlyPaths(resp.data.data._readonly);
+        setConfig(responseConfig);
+        setEditConfig(responseConfig);
+        setReadonly(readonly);
+        setShowError(false);
+      })
+      .catch(() => {
+        setShowError(true);
+      });
+  };
+
+  const renderCallout = messages => {
+    return (
+      <>
+        <EuiCallOut title="Warning" color="warning">
+          {messages.map((message, index) => {
+            return <p key={index}>{message}</p>;
+          })}
+        </EuiCallOut>
+        <EuiSpacer />
+      </>
+    );
+  };
+
+  const renderError = () => {
+    return showError ? (
+      <EuiCallOut title={RESPONSE_MESSAGES.FETCH_ERROR_TITLE} color="danger" iconType="alert">
+        <p>{RESPONSE_MESSAGES.FETCH_ERROR_MESSAGE}</p>
+      </EuiCallOut>
+    ) : null;
+  };
+
+  const renderSave = message => {
+    return (
+      <>
+        <EuiSpacer />
+        <EuiFlexGroup justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              onClick={() => {
+                cancel();
+              }}
+            >
+              Cancel
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              isDisabled={invalidSettings.length != 0}
+              onClick={() => {
+                saveConfig(editConfig, true, message);
+              }}
+            >
+              Save
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </>
+    );
+  };
+
+  const renderEditableAuditSettings = () => {
+    return (
+      <>
+        <EuiTitle size="l">
+          <h1>{CONFIG_LABELS.GENERAL_SETTINGS}</h1>
+        </EuiTitle>
+        <EuiSpacer size="m" />
+        <EuiPanel>
+          {renderCallout(CALLOUT_MESSAGES.AUDIT_SETTINGS)}
+          <EditSettingGroup
+            settingGroup={SETTING_GROUPS.LAYER_SETTINGS}
+            config={editConfig}
+            handleChange={handleChange}
+            readonly={readonly}
+          ></EditSettingGroup>
+          <EditSettingGroup
+            settingGroup={SETTING_GROUPS.ATTRIBUTE_SETTINGS}
+            config={editConfig}
+            handleChange={handleChange}
+            readonly={readonly}
+          ></EditSettingGroup>
+          <EditSettingGroup
+            settingGroup={SETTING_GROUPS.IGNORE_SETTINGS}
+            config={editConfig}
+            handleChange={handleChange}
+            readonly={readonly}
+          ></EditSettingGroup>
+        </EuiPanel>
+        {renderSave(TOAST_MESSAGES.GENERAL_SETTINGS)}
+      </>
+    );
+  };
+
+  const renderEditableComplianceSettings = () => {
+    return (
+      <>
+        <EuiTitle size="l">
+          <h1>{CONFIG_LABELS.COMPLIANCE_SETTINGS}</h1>
+        </EuiTitle>
+        <EuiSpacer size="m" />
+        <EuiPanel>
+          <EditSettingGroup
+            settingGroup={SETTING_GROUPS.COMPLIANCE_MODE_SETTINGS}
+            config={editConfig}
+            handleChange={handleChange}
+            readonly={readonly}
+          ></EditSettingGroup>
+          {editConfig.compliance.enabled && (
+            <>
+              {renderCallout(CALLOUT_MESSAGES.COMPLIANCE_SETTINGS)}
+              <EditSettingGroup
+                settingGroup={SETTING_GROUPS.COMPLIANCE_CONFIG_SETTINGS}
+                config={editConfig}
+                handleChange={handleChange}
+                readonly={readonly}
+                showPanel={true}
+              ></EditSettingGroup>
+              <EuiSpacer size="s" />
+              <EditSettingGroup
+                settingGroup={SETTING_GROUPS.COMPLIANCE_READ_SETTINGS}
+                config={editConfig}
+                handleChange={handleChange}
+                handleInvalid={handleInvalid}
+                readonly={readonly}
+                showPanel={true}
+              ></EditSettingGroup>
+              <EuiSpacer size="s" />
+              <EditSettingGroup
+                settingGroup={SETTING_GROUPS.COMPLIANCE_WRITE_SETTINGS}
+                config={editConfig}
+                handleChange={handleChange}
+                readonly={readonly}
+                showPanel={true}
+              ></EditSettingGroup>
+            </>
+          )}
+        </EuiPanel>
+        {renderSave(TOAST_MESSAGES.COMPLIANCE_SETTINGS)}
+      </>
+    );
+  };
+
+  const renderAllSettings = () => {
+    return (
+      <>
+        <ContentPanel title={CONFIG_LABELS.AUDIT_LOGGING}>
+          <EditSettingGroup
+            settingGroup={SETTING_GROUPS.AUDIT_SETTINGS}
+            config={editConfig}
+            handleChange={handleChangeWithSave}
+            readonly={readonly}
+          ></EditSettingGroup>
+        </ContentPanel>
+        {config.enabled && (
+          <>
+            {!readonly.includes('audit') && (
+              <>
+                <EuiSpacer />
+                <ContentPanel
+                  title={CONFIG_LABELS.GENERAL_SETTINGS}
+                  configureHandler={() => {
+                    toggleDisplay(false, true, false);
+                  }}
+                >
+                  <DisplaySettingGroup
+                    settingGroup={SETTING_GROUPS.LAYER_SETTINGS}
+                    config={config}
+                    readonly={readonly}
+                  />
+                  <DisplaySettingGroup
+                    settingGroup={SETTING_GROUPS.ATTRIBUTE_SETTINGS}
+                    config={config}
+                    readonly={readonly}
+                  />
+                  <DisplaySettingGroup
+                    settingGroup={SETTING_GROUPS.IGNORE_SETTINGS}
+                    config={config}
+                    readonly={readonly}
+                  />
+                </ContentPanel>
+              </>
+            )}
+            {!readonly.includes('compliance') && (
+              <>
+                <EuiSpacer />
+                <ContentPanel
+                  title={CONFIG_LABELS.COMPLIANCE_SETTINGS}
+                  configureHandler={() => {
+                    toggleDisplay(false, false, true);
+                  }}
+                >
+                  <DisplaySettingGroup
+                    config={config}
+                    settingGroup={SETTING_GROUPS.COMPLIANCE_MODE_SETTINGS}
+                    readonly={readonly}
+                  />
+                  <DisplaySettingGroup
+                    config={config}
+                    settingGroup={SETTING_GROUPS.COMPLIANCE_CONFIG_SETTINGS}
+                    readonly={readonly}
+                    showPanel={true}
+                  />
+                  <DisplaySettingGroup
+                    settingGroup={SETTING_GROUPS.COMPLIANCE_READ_SETTINGS}
+                    config={config}
+                    readonly={readonly}
+                    showPanel={true}
+                  />
+                  <DisplaySettingGroup
+                    settingGroup={SETTING_GROUPS.COMPLIANCE_WRITE_SETTINGS}
+                    config={config}
+                    readonly={readonly}
+                    showPanel={true}
+                  />
+                </ContentPanel>
+              </>
+            )}
+          </>
+        )}
+      </>
+    );
+  };
+
+  const renderBody = () => {
+    return config && editConfig ? (
+      <>
+        {showAllSettings && renderAllSettings()}
+        {showConfigureAudit && renderEditableAuditSettings()}
+        {showConfigureCompliance && renderEditableComplianceSettings()}
+      </>
+    ) : null;
+  };
+
+  return (
+    <EuiPage restrictWidth={true} style={{ width: '100%' }}>
+      <EuiPageBody>
+        {renderError()}
+        {renderBody()}
+      </EuiPageBody>
+    </EuiPage>
+  );
+}

--- a/public/apps/audit/components/main/utils.js
+++ b/public/apps/audit/components/main/utils.js
@@ -1,0 +1,47 @@
+export function displayBoolean(val) {
+  return val ? 'Enabled' : 'Disabled';
+}
+
+export function displayArray(val) {
+  return val && val.length != 0 ? val.join(' , ') : '--';
+}
+
+export function displayMap(val) {
+  return val && Object.keys(val).length != 0 ? JSON.stringify(val, null, 2) : '--';
+}
+
+export function displayLabel(val) {
+  return val.replace(/\./g, ':');
+}
+
+export function displaySettingType(setting, val) {
+  if (setting.type === 'bool') return displayBoolean(val);
+  else if (setting.type === 'array') {
+    return displayArray(val);
+  } else if (setting.type === 'map') {
+    return displayMap(val);
+  } else {
+    return 'Unknown type';
+  }
+}
+
+export function generateComboBoxLabels(arr) {
+  return arr.map(x => {
+    return { label: x };
+  });
+}
+
+export function removeComboBoxLabels(arr) {
+  return arr.map(x => x.label);
+}
+
+export function generateReadonlyPaths(readonly) {
+  return readonly.map(x => x.substr(1).replace(/\//g, '.'));
+}
+
+export function filterReadonly(readonly, settingGroup) {
+  var settings = settingGroup.settings.filter(setting => {
+    return !readonly.includes(setting.path);
+  });
+  return { ...settingGroup, settings };
+}

--- a/public/apps/configuration/base_controller.js
+++ b/public/apps/configuration/base_controller.js
@@ -75,6 +75,7 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
     $scope.authenticationSvgURL = APP_ROOT + "/plugins/opendistro_security/assets/authentication.svg";
     $scope.purgeCacheSvgURL = APP_ROOT + "/plugins/opendistro_security/assets/purge_cache.svg";
     $scope.tenantsSvgURL = APP_ROOT + "/plugins/opendistro_security/assets/tenants.svg";
+    $scope.auditLogSvgURL = APP_ROOT + "/plugins/opendistro_security/assets/audit_logs.svg";
 
     $scope.title = "Security Configuration";
 

--- a/public/apps/configuration/configuration.html
+++ b/public/apps/configuration/configuration.html
@@ -135,6 +135,17 @@
                                         Purge Cache
                                     </div>
                                 </a>
+
+                                <a id="opendistro_security.link.securityaudit" ng-if="endpointAndMethodEnabled('AUDIT', 'GET')" class="FeaturePanel ng-scope"
+                                   ng-click="goToAuditLogging()"
+                                   tooltip="View and update audit logging configuration">
+                                    <div class="FeaturePanelButton__image">
+                                        <img ng-src="{{auditLogSvgURL}}" width="56" />
+                                    </div>
+                                    <div class="FeaturePanelButton__label">
+                                        Audit logging
+                                    </div>
+                                </a>
                             </div>
                         </div>
                     </div>

--- a/public/apps/configuration/configuration_controller.js
+++ b/public/apps/configuration/configuration_controller.js
@@ -2,6 +2,7 @@ import { uiModules } from 'ui/modules';
 import { get } from 'lodash';
 import client from './backend_api/client';
 import './directives/directives';
+import { chromeWrapper } from "../../services/chrome_wrapper";
 
 const app = uiModules.get('apps/opendistro_security/configuration', ['ui.ace']);
 
@@ -15,4 +16,7 @@ app.controller('securityConfigurationController', function ($scope, $element, $r
         backendAPI.clearCache();
     }
 
+    $scope.goToAuditLogging = function() {
+        $window.location.href = chromeWrapper.getNavLinkById("security-audit").baseUrl;
+    }
 });

--- a/public/assets/audit_logs.svg
+++ b/public/assets/audit_logs.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+    viewBox="0 0 60 60"  style="enable-background:new 0 0 60 60;" xml:space="preserve">
+<style type="text/css">
+	.fill-blue{fill:#0079A5;}
+    .stroke-3px{fill:none;stroke:#0079A5;stroke-width:3;stroke-miterlimit:10;}
+    .stroke-4px{fill:none;stroke:#0079A5;stroke-width:4;stroke-miterlimit:10;}
+</style>
+    <g id="audit_logs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path class="stroke-4px" d="M53,44 L53,16.948441 C53,16.132441 52.685,15.3451285 52.1192857,14.7522535 L40.5458541,2.9945 C39.9383541,2.3601875 39.6460204,2 38.7653061,2 L11.2142857,2 C9.44,2 8,3.428 8,5.1875 L8,49.8125 C8,51.572 9.44,53 11.2142857,53 L44,53" id="Path" stroke="#0079A5" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path class="fill-blue" d="M53,18 L38.6,18 C37.7168,18 37,17.2384 37,16.3 L37,1" id="Fill-3" fill="#0079A5"></path>
+        <path class="stroke-3px" d="M55.5,56 L45.7712528,46.122063 C47.1424895,44.8441804 48,43.0222314 48,41 C48,37.1340068 44.8659932,34 41,34 C37.1340068,34 34,37.1340068 34,41 C34,44.3337113 36.3304174,47.1231244 39.4510514,47.8280386" id="Path" stroke="#0079A5" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path>
+        <line class="stroke-4px" x1="16" y1="11" x2="31" y2="11" id="Line" stroke="#0079A5" stroke-width="4" stroke-linecap="round"></line>
+        <line class="stroke-4px" x1="16" y1="18" x2="31" y2="18" id="Line" stroke="#0079A5" stroke-width="4" stroke-linecap="round"></line>
+        <line class="stroke-4px" x1="16" y1="24.5" x2="45" y2="24.5" id="Line" stroke="#0079A5" stroke-width="4" stroke-linecap="round"></line>
+        <line class="stroke-4px" x1="16" y1="31" x2="33" y2="31" id="Line" stroke="#0079A5" stroke-width="4" stroke-linecap="round"></line>
+        <line class="stroke-4px" x1="16" y1="37.5" x2="27" y2="37.5" id="Line" stroke="#0079A5" stroke-width="4" stroke-linecap="round"></line>
+        <line class="stroke-4px" x1="16" y1="44" x2="27" y2="44" id="Line" stroke="#0079A5" stroke-width="4" stroke-linecap="round"></line>
+    </g>
+</svg>

--- a/public/chrome/configuration/enable_configuration.js
+++ b/public/chrome/configuration/enable_configuration.js
@@ -140,6 +140,7 @@ export function enableConfiguration($http, $window, systemstate) {
     setupResponseErrorHandler($window);
 
     chromeWrapper.hideNavLink('security-configuration', true);
+    chromeWrapper.hideNavLink('security-audit', true);
 
     const ROOT = chrome.getBasePath();
     const APP_ROOT = `${ROOT}`;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Versions to be supported (all opendistro-1.x & opendistro-0.x)
- Implementation strategy:
  - Creating a separate stand alone app page referenced from AngularJS
  - Using ReactJS to build the UI page and elements to get the best out of EUI and AngularJS support is deprecated by Elastic
  - Reusing the Kibana server API (using Hapi) endpoints for querying the security plugin 
  - Based on permissions of signed in user, the audit configuration will be shown to customer. 
- Implementing audit logging UI for security kibana plugin

<img width="1392" alt="Screen Shot 2020-07-20 at 10 56 24 AM" src="https://user-images.githubusercontent.com/5506137/87970261-53db7900-ca78-11ea-8278-e3577156b0ad.png">
<img width="1392" alt="Screen Shot 2020-07-20 at 10 56 18 AM" src="https://user-images.githubusercontent.com/5506137/87970255-5047f200-ca78-11ea-8d42-8581a468c18f.png">
<img width="1392" alt="Screen Shot 2020-07-20 at 10 56 31 AM" src="https://user-images.githubusercontent.com/5506137/87970273-576f0000-ca78-11ea-924e-62e076abde82.png">
<img width="1392" alt="Screen Shot 2020-07-20 at 10 56 34 AM" src="https://user-images.githubusercontent.com/5506137/87970278-5938c380-ca78-11ea-9360-c9a375bac936.png">
<img width="1392" alt="Screen Shot 2020-07-20 at 10 56 39 AM" src="https://user-images.githubusercontent.com/5506137/87970284-5a69f080-ca78-11ea-8779-75cef2e9c09a.png">
<img width="1392" alt="Screen Shot 2020-07-20 at 10 56 42 AM" src="https://user-images.githubusercontent.com/5506137/87970293-5e960e00-ca78-11ea-98e9-6fa03253355c.png">
<img width="1392" alt="Screen Shot 2020-07-20 at 10 56 44 AM" src="https://user-images.githubusercontent.com/5506137/87970297-5fc73b00-ca78-11ea-95e3-dcea28f84081.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
