### PR TITLE
Add config options for changing storage and preferences cookie names

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ export default function (kibana) {
                 cookie: Joi.object().keys({
                     secure: Joi.boolean().default(false),
                     name: Joi.string().default('security_authentication'),
+                    storage_cookie_name: Joi.string().default('security_storage'),
+                    preferences_cookie_name: Joi.string().default('security_preferences'),
                     password: Joi.string().min(32).default('security_cookie_default_password'),
                     ttl: Joi.number().integer().min(0).default(60 * 60 * 1000),
                     domain: Joi.string(),
@@ -348,7 +350,7 @@ export default function (kibana) {
                 storageCookieConf["domain"] = config.get('opendistro_security.cookie.domain');
             }
 
-            server.state('security_storage', storageCookieConf);
+            server.state(config.get('opendistro_security.cookie.storage_cookie_name'), storageCookieConf);
 
 
             if (authType && authType !== '' && ['basicauth', 'jwt', 'openid', 'saml', 'proxycache'].indexOf(authType) > -1) {
@@ -446,7 +448,7 @@ export default function (kibana) {
                     preferenceCookieConf["domain"] = config.get('opendistro_security.cookie.domain');
                 }
 
-                server.state('security_preferences', preferenceCookieConf);
+                server.state(config.get("opendistro_security.cookie.preferences_cookie_name"), preferenceCookieConf);
 
 
                 this.status.yellow("Security multitenancy registered.");

--- a/lib/backend/opendistro_security.js
+++ b/lib/backend/opendistro_security.js
@@ -48,6 +48,8 @@ export default class SecurityBackend {
 
         // the es config for later use
         this._esconfig = esConfig;
+
+        this._preferencesCookieName = server.config().get("opendistro_security.cookie.preferences_cookie_name");
     }
 
     /**
@@ -304,7 +306,7 @@ export default class SecurityBackend {
 
     updateAndGetTenantPreferences(request, user, tenant) {
 
-        var prefs = request.state.security_preferences;
+        var prefs = request.state[this._preferencesCookieName];
         // no prefs cookie present
         if (!prefs) {
             var newPrefs = {};
@@ -327,7 +329,7 @@ export default class SecurityBackend {
             return null;
         }
         // get users preferred tenant
-        var prefs = request.state.security_preferences;
+        var prefs = request.state[this._preferencesCookieName];
 
         if (prefs) {
             var preferredTenant = prefs[username];

--- a/lib/multitenancy/headers.js
+++ b/lib/multitenancy/headers.js
@@ -108,7 +108,7 @@ export default function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT, auth
             request.auth.securitySessionStorage.putStorage('tenant', {
                 selected: selectedTenant
             });
-            h.state('security_preferences', prefcookie);
+            h.state(config.get('opendistro_security.cookie.preferences_cookie_name'), prefcookie);
         }
 
         if (debugEnabled) {

--- a/lib/multitenancy/routes.js
+++ b/lib/multitenancy/routes.js
@@ -35,6 +35,7 @@ import { migrateTenant } from './migrate_tenants';
 
 module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
 
+    const config = server.config();
     const backend = server.plugins.opendistro_security.getSecurityBackend();
     const { setupIndexTemplate } = indexTemplate(this, server);
     const debugEnabled = server.config().get("opendistro_security.multitenancy.debug");
@@ -56,7 +57,7 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
                 request.log(['info', 'security', 'tenant_POST'], selectedTenant);
             }
 
-            return h.response(request.payload.tenant).state('security_preferences', prefs);
+            return h.response(request.payload.tenant).state(config.get('opendistro_security.cookie.preferences_cookie_name'), prefs);
         }
     });
 

--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -5,12 +5,6 @@ import filterAuthHeaders from '../auth/filter_auth_headers';
 const Hoek = require('hoek');
 const Joi = require('joi');
 
-/**
- * Name of the cookie where we store additional session information, such as authInfo
- * @type {string}
- */
-const storageCookieName = 'security_storage';
-
 let internals = {};
 
 internals.config = Joi.object({
@@ -29,6 +23,12 @@ const register = function (server, options) {
     Hoek.assert(!results.error, results.error);
 
     let settings = results.value;
+
+    /**
+     * Name of the cookie where we store additional session information, such as authInfo
+     * @type {string}
+     */
+    const storageCookieName = server.config().get("opendistro_security.cookie.storage_cookie_name");
 
 
     // @todo Don't register e.g. authenticate() when we have Kerberos or Proxy-Auth?


### PR DESCRIPTION
*Issue #, if available:* #214 

*Description of changes:* Add two new settings, 'storage_cookie_name' and 'preferences_cookie_name'.

At first I was considering creating a single setting like 'cookie_name_prefix', but I decided to use the approach Search Guard used instead and created different settings for each cookie. Thoughts?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
