### PR TITLE
implement edit view for general settings

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -28,6 +28,12 @@ import { RouteItem, ResourceType, Action } from './types';
 import { buildUrl, buildHashUrl } from './utils/url-builder';
 import { InternalUserEdit } from './panels/internal-user-edit/internal-user-edit';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
+import { AuditLoggingEditGeneralSetting } from './panels/audit-logging/audit-logging-general-settings';
+import { AuditLoggingEditComplianceSetting } from './panels/audit-logging/audit-logging-compliance-settings';
+import {
+  SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
+  SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
+} from './panels/audit-logging/constants';
 import { PermissionList } from './panels/permission-list';
 
 const ROUTE_MAP: { [key: string]: RouteItem } = {
@@ -71,8 +77,13 @@ const ROUTE_LIST = [
   ROUTE_MAP[ResourceType.auditLogging],
 ];
 
+const allNavPanelUrls = ROUTE_LIST.map((route) => route.href).concat([
+  buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
+  buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
+]);
+
 // url regex pattern for all pages with left nav panel, (/|/roles|/internalusers|...)
-const PATTERNS_ROUTES_WITH_NAV_PANEL = '(' + ROUTE_LIST.map((route) => route.href).join('|') + ')';
+const PATTERNS_ROUTES_WITH_NAV_PANEL = '(' + allNavPanelUrls.join('|') + ')';
 
 function Breadcrumbs(resourceType: ResourceType, pageTitle: string) {
   return (
@@ -140,6 +151,14 @@ export function AppRouter(props: AppDependencies) {
             />
             <Route path={ROUTE_MAP.users.href}>
               <UserList {...props} />
+            </Route>
+            <Route path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT}>
+              <AuditLoggingEditGeneralSetting {...props} />
+            </Route>
+            <Route
+              path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT}
+            >
+              <AuditLoggingEditComplianceSetting {...props} />
             </Route>
             <Route path={ROUTE_MAP.auditLogging.href}>
               <AuditLogging {...props} />

--- a/public/apps/configuration/panels/audit-logging/audit-logging-compliance-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-compliance-settings.tsx
@@ -1,0 +1,21 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { AppDependencies } from '../../../types';
+
+export function AuditLoggingEditComplianceSetting(props: AppDependencies) {
+  return <>WORKING IN PROGRESS</>;
+}

--- a/public/apps/configuration/panels/audit-logging/audit-logging-general-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-general-settings.tsx
@@ -1,0 +1,172 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiGlobalToastList,
+  EuiPageHeader,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { cloneDeep, set } from 'lodash';
+import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
+import { AppDependencies } from '../../../types';
+import { EditSettingGroup } from './edit-setting-group';
+import { SETTING_GROUPS, SettingContent } from './constants';
+import { API_ENDPOINT_AUDITLOGGING } from '../../constants';
+import { updateAuditLogging } from '../../utils/audit-logging-view-utils';
+import { AuditLoggingSettings } from './types';
+import { buildHashUrl } from '../../utils/url-builder';
+import { ResourceType } from '../../types';
+
+export function AuditLoggingEditGeneralSetting(props: AppDependencies) {
+  const [editConfig, setEditConfig] = useState<AuditLoggingSettings>({});
+
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const addToast = useCallback((toastToAdd: Toast) => {
+    setToasts((state) => state.concat(toastToAdd));
+  }, []);
+  const removeToast = (toastToDelete: Toast) => {
+    setToasts(toasts.filter((toast) => toast.id !== toastToDelete.id));
+  };
+
+  const handleChange = (setting: SettingContent, val: boolean | string[]) => {
+    setEditConfig((previousEditedConfig) => {
+      return set(cloneDeep(editConfig), setting.path, val);
+    });
+  };
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const rawConfig = await props.coreStart.http.get(API_ENDPOINT_AUDITLOGGING);
+        const fetchedConfig = rawConfig.data.config;
+        setEditConfig(fetchedConfig);
+      } catch (e) {
+        console.log(e);
+      }
+    };
+
+    fetchConfig();
+  }, [props.coreStart.http]);
+
+  const renderSaveAndCancel = () => {
+    return (
+      <>
+        <EuiFlexGroup justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              onClick={() => {
+                window.location.href = buildHashUrl(ResourceType.auditLogging);
+              }}
+            >
+              Cancel
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              onClick={() => {
+                saveConfig(editConfig);
+              }}
+            >
+              Save
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </>
+    );
+  };
+
+  const saveConfig = async (configToUpdate: object) => {
+    try {
+      await updateAuditLogging(props.coreStart.http, configToUpdate);
+
+      const successToast: Toast = {
+        id: 'update-result',
+        color: 'success',
+        iconType: 'check',
+        title: 'Audit configuration was successfully updated.',
+      };
+
+      addToast(successToast);
+    } catch (e) {
+      const failureToast: Toast = {
+        id: 'update-result',
+        color: 'danger',
+        iconType: 'alert',
+        title: 'Failed to update audit configuration due to ' + e?.message,
+      };
+
+      addToast(failureToast);
+    } finally {
+      window.scrollTo({ top: 0 });
+    }
+  };
+
+  return (
+    <>
+      <EuiPageHeader>
+        <EuiTitle size="l">
+          <h1>General settings</h1>
+        </EuiTitle>
+      </EuiPageHeader>
+
+      <EuiPanel>
+        <EuiCallOut title="Warning" color="warning">
+          <p>
+            Enabling REST and Transport layers (config:enable_rest, config:enable_transport) may
+            result in a massive number of logs if AUTHENTICATED and GRANTED_PRIVILEGES are not
+            disabled. We suggest you ignore common requests if doing so.
+          </p>
+
+          <p>
+            Enabling Bulk requests (config:resolve_bulk_requests) will generate one log per request,
+            and may also result in very large log files.
+          </p>
+        </EuiCallOut>
+
+        <EuiSpacer />
+
+        <EditSettingGroup
+          settingGroup={SETTING_GROUPS.LAYER_SETTINGS}
+          config={editConfig}
+          handleChange={handleChange}
+        />
+        <EuiSpacer size="xl" />
+        <EditSettingGroup
+          settingGroup={SETTING_GROUPS.ATTRIBUTE_SETTINGS}
+          config={editConfig}
+          handleChange={handleChange}
+        />
+        <EuiSpacer size="xl" />
+        <EditSettingGroup
+          settingGroup={SETTING_GROUPS.IGNORE_SETTINGS}
+          config={editConfig}
+          handleChange={handleChange}
+        />
+      </EuiPanel>
+      <EuiSpacer />
+      {renderSaveAndCancel()}
+
+      <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />
+    </>
+  );
+}

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -33,6 +33,10 @@ import {
   updateAuditLogging,
 } from '../../utils/audit-logging-view-utils';
 import { AuditLoggingSettings } from './types';
+import {
+  SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
+  SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
+} from './constants';
 
 export function AuditLogging(props: AppDependencies) {
   const [configuration, setConfiguration] = useState<AuditLoggingSettings>({});
@@ -84,7 +88,13 @@ export function AuditLogging(props: AppDependencies) {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton>Configure</EuiButton>
+            <EuiButton
+              onClick={() => {
+                window.location.href += SUB_URL_FOR_GENERAL_SETTINGS_EDIT;
+              }}
+            >
+              Configure
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiHorizontalRule />
@@ -101,7 +111,13 @@ export function AuditLogging(props: AppDependencies) {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton>Configure</EuiButton>
+            <EuiButton
+              onClick={() => {
+                window.location.href += SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT;
+              }}
+            >
+              Configure
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -1,0 +1,203 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export const CONFIG_LABELS = {
+  AUDIT_LOGGING: 'Audit logging',
+  GENERAL_SETTINGS: 'General settings',
+  LAYER_SETTINGS: 'Layer settings',
+  ATTRIBUTE_SETTINGS: 'Attribute settings',
+  IGNORE_SETTINGS: 'Ignore settings',
+  COMPLIANCE_SETTINGS: 'Compliance settings',
+  COMPLIANCE_CONFIG_SETTINGS: 'Config settings',
+  COMPLIANCE_READ: 'Read',
+  COMPLIANCE_WRITE: 'Write',
+};
+
+export const RESPONSE_MESSAGES = {
+  FETCH_ERROR_TITLE: 'Sorry, there was an error fetching audit configuration.',
+  FETCH_ERROR_MESSAGE:
+    'Please ensure hot reloading of audit configuration is enabled in the security plugin.',
+  UPDATE_SUCCESS: 'Audit configuration was successfully updated.',
+  UPDATE_FAILURE: 'Audit configuration could not be updated. Please check configuration.',
+};
+
+export interface SettingContent {
+  title: string;
+  key: string;
+  path: string;
+  description: string;
+  type: string;
+  options?: string[];
+}
+
+const REST_LAYER: SettingContent = {
+  title: 'REST layer',
+  key: 'config:audit:enable_rest',
+  path: 'audit.enable_rest',
+  description: 'Enable or disable auditing events that happen on the REST layer',
+  type: 'bool',
+};
+
+const REST_DISABLED_CATEGORIES: SettingContent = {
+  title: 'REST disabled categories',
+  key: 'config:audit:disabled_rest_categories',
+  path: 'audit.disabled_rest_categories',
+  description: 'Specify audit categories which must be ignored on the REST layer',
+  type: 'array',
+  options: [
+    'BAD_HEADERS',
+    'FAILED_LOGIN',
+    'MISSING_PRIVILEGES',
+    'GRANTED_PRIVILEGES',
+    'SSL_EXCEPTION',
+    'AUTHENTICATED',
+  ],
+};
+
+const TRANSPORT_LAYER: SettingContent = {
+  title: 'Transport layer',
+  key: 'config:audit:enable_transport',
+  path: 'audit.enable_transport',
+  description: 'Enable or disable auditing events that happen on the Transport layer',
+  type: 'bool',
+};
+
+const TRANSPORT_DISABLED_CATEGORIES: SettingContent = {
+  title: 'Transport disabled categories',
+  key: 'config:audit:disabled_transport_categories',
+  path: 'audit.disabled_transport_categories',
+  description: 'Specify audit categories which must be ignored on the Transport layer',
+  type: 'array',
+  options: [
+    'BAD_HEADERS',
+    'FAILED_LOGIN',
+    'MISSING_PRIVILEGES',
+    'GRANTED_PRIVILEGES',
+    'SSL_EXCEPTION',
+    'AUTHENTICATED',
+  ],
+};
+
+const BULK_REQUESTS: SettingContent = {
+  title: 'Bulk requests',
+  key: 'config:audit:resolve_bulk_requests',
+  path: 'audit.resolve_bulk_requests',
+  description: 'Resolve bulk requests during auditing of requests.',
+  type: 'bool',
+};
+
+const REQUEST_BODY: SettingContent = {
+  title: 'Request body',
+  key: 'config:audit:log_request_body',
+  path: 'audit.log_request_body',
+  description: 'Include request body during auditing of requests.',
+  type: 'bool',
+};
+
+const RESOLVE_INDICES: SettingContent = {
+  title: 'Resolve indices',
+  key: 'config:audit:resolve_indices',
+  path: 'audit.resolve_indices',
+  description: 'Resolve indices during auditing of requests.',
+  type: 'bool',
+};
+
+const SENSITIVE_HEADERS: SettingContent = {
+  title: 'Sensitive headers',
+  key: 'config:audit:exclude_sensitive_headers',
+  path: 'audit.exclude_sensitive_headers',
+  description: 'Exclude sensitive headers during auditing. Eg: Authorization header',
+  type: 'bool',
+};
+
+const IGNORED_USERS: SettingContent = {
+  title: 'Ignored users',
+  key: 'config:audit:ignore_users',
+  path: 'audit.ignore_users',
+  description: 'Users to ignore during auditing.',
+  type: 'array',
+};
+
+const IGNORED_REQUESTS: SettingContent = {
+  title: 'Ignored requests',
+  key: 'config:audit:ignore_requests',
+  path: 'audit.ignore_requests',
+  description: 'Request patterns to ignore during auditing.',
+  type: 'array',
+};
+
+const CONFIG = {
+  ENABLED: {
+    title: 'Enable audit logging',
+    key: 'config:enabled',
+    path: 'enabled',
+    description: 'Enable or disable audit logging',
+    type: 'bool',
+  },
+  AUDIT: {
+    REST_LAYER,
+    REST_DISABLED_CATEGORIES,
+    TRANSPORT_LAYER,
+    TRANSPORT_DISABLED_CATEGORIES,
+    BULK_REQUESTS,
+    REQUEST_BODY,
+    RESOLVE_INDICES,
+    SENSITIVE_HEADERS,
+    IGNORED_USERS,
+    IGNORED_REQUESTS,
+  },
+};
+
+export interface SettingGroup {
+  title: string;
+  settings: SettingContent[];
+}
+
+export const LAYER_SETTINGS: SettingGroup = {
+  title: CONFIG_LABELS.LAYER_SETTINGS,
+  settings: [
+    CONFIG.AUDIT.REST_LAYER,
+    CONFIG.AUDIT.REST_DISABLED_CATEGORIES,
+    CONFIG.AUDIT.TRANSPORT_LAYER,
+    CONFIG.AUDIT.TRANSPORT_DISABLED_CATEGORIES,
+  ],
+};
+
+export const ATTRIBUTE_SETTINGS: SettingGroup = {
+  title: CONFIG_LABELS.ATTRIBUTE_SETTINGS,
+  settings: [
+    CONFIG.AUDIT.BULK_REQUESTS,
+    CONFIG.AUDIT.REQUEST_BODY,
+    CONFIG.AUDIT.RESOLVE_INDICES,
+    CONFIG.AUDIT.SENSITIVE_HEADERS,
+  ],
+};
+
+export const IGNORE_SETTINGS: SettingGroup = {
+  title: CONFIG_LABELS.IGNORE_SETTINGS,
+  settings: [CONFIG.AUDIT.IGNORED_USERS, CONFIG.AUDIT.IGNORED_REQUESTS],
+};
+
+export const SETTING_GROUPS = {
+  AUDIT_SETTINGS: {
+    settings: [CONFIG.ENABLED],
+  },
+  LAYER_SETTINGS,
+  ATTRIBUTE_SETTINGS,
+  IGNORE_SETTINGS,
+};
+
+export const SUB_URL_FOR_GENERAL_SETTINGS_EDIT = '/edit/generalSettings';
+export const SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT = '/edit/complianceSettings';

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { Fragment } from 'react';
+import {
+  EuiComboBox,
+  EuiDescribedFormGroup,
+  EuiFormRow,
+  EuiSpacer,
+  EuiSwitch,
+  EuiTitle,
+} from '@elastic/eui';
+import { get } from 'lodash';
+import { displayBoolean } from '../../utils/display-utils';
+import { comboBoxOptionToString, stringToComboBoxOption } from '../../utils/combo-box-utils';
+import { AuditLoggingSettings } from './types';
+import { SettingContent, SettingGroup } from './constants';
+
+export function EditSettingGroup(props: {
+  settingGroup: SettingGroup;
+  config: AuditLoggingSettings;
+  handleChange: (setting: SettingContent, val: boolean | string[]) => void;
+}) {
+  const renderField = (
+    config: AuditLoggingSettings,
+    setting: SettingContent,
+    handleChange: (setting: SettingContent, val: boolean | string[]) => void
+  ) => {
+    let val = get(config, setting.path);
+
+    if (setting.type === 'bool') {
+      val = val || false;
+
+      return (
+        <EuiSwitch
+          label={displayBoolean(val)}
+          checked={val}
+          onChange={(e) => {
+            handleChange(setting, e.target.checked);
+          }}
+        />
+      );
+    } else if (setting.type === 'array' && typeof setting.options !== 'undefined') {
+      val = val || [];
+
+      return (
+        <EuiComboBox
+          placeholder={setting.title}
+          options={setting.options.map(stringToComboBoxOption)}
+          selectedOptions={val.map(stringToComboBoxOption)}
+          onChange={(selectedOptions) => {
+            handleChange(setting, selectedOptions.map(comboBoxOptionToString));
+          }}
+        />
+      );
+    } else if (setting.type === 'array') {
+      val = val || [];
+
+      return (
+        <EuiComboBox
+          noSuggestions
+          placeholder={setting.title}
+          selectedOptions={val.map(stringToComboBoxOption)}
+          onChange={(selectedOptions) => {
+            handleChange(setting, selectedOptions.map(comboBoxOptionToString));
+          }}
+          onCreateOption={(searchValue) => {
+            handleChange(setting, [...val, searchValue]);
+          }}
+        />
+      );
+    } else {
+      return <></>;
+    }
+  };
+
+  const settingGroup = props.settingGroup;
+
+  return (
+    <>
+      {settingGroup.title && (
+        <>
+          <EuiTitle>
+            <h3>{settingGroup.title}</h3>
+          </EuiTitle>
+          <EuiSpacer />
+        </>
+      )}
+      {settingGroup.settings.map((setting: SettingContent) => {
+        return (
+          <Fragment key={setting.key}>
+            <EuiDescribedFormGroup
+              title={<h3>{setting.title}</h3>}
+              description={<>{setting.description}</>}
+              fullWidth
+            >
+              <EuiFormRow label={setting.key}>
+                {renderField(props.config, setting, props.handleChange)}
+              </EuiFormRow>
+            </EuiDescribedFormGroup>
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change implements the edit page for general settings. It creates a EditSettingGroup which can also be used for compliance setting edit page later.

*Test*
mockup
![screencapture-aws-uxdr-invisionapp-share-ZTVZTJJKURY-2020-07-13-14_36_51](https://user-images.githubusercontent.com/60111637/87356089-5426c200-c516-11ea-9a0e-06c75f4be76f.png)

implementation:
initial load
note that "Sensitive headers" is enabled and "Ignored requests" has value "11111"
![screencapture-localhost-5601-app-opendistro-security-2020-07-13-14_37_59](https://user-images.githubusercontent.com/60111637/87356218-89cbab00-c516-11ea-959e-1530feb8aecb.png)

Next I am going to update "Sensitive headers" to disabled and add another value "22222" to "Ignored requests" and click save
![screencapture-localhost-5601-app-opendistro-security-2020-07-13-14_40_18](https://user-images.githubusercontent.com/60111637/87356376-d1523700-c516-11ea-9484-b6a9a5871560.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
