### PR TITLE
Permission listing page - add search option, add single permissions and set default sorting by type

### DIFF
--- a/public/apps/configuration/panels/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list.tsx
@@ -34,7 +34,7 @@ import {
 import { difference } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { AppDependencies } from '../../types';
-import { ActionGroupListingItem, fetchActionGroupListing } from '../utils/action-groups-utils';
+import { ActionGroupListingItem, getAllPermissionsListing } from '../utils/action-groups-utils';
 import { renderCustomization } from '../utils/display-utils';
 import { requestDeleteUsers } from '../utils/internal-user-list-utils';
 
@@ -80,7 +80,7 @@ export function PermissionList(props: AppDependencies) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        setActionGroups(await fetchActionGroupListing(props.coreStart.http));
+        setActionGroups(await getAllPermissionsListing(props.coreStart.http));
       } catch (e) {
         console.log(e);
         setErrorFlag(true);

--- a/public/apps/configuration/panels/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list.tsx
@@ -30,6 +30,7 @@ import {
   EuiText,
   EuiTitle,
   EuiIcon,
+  EuiSearchBarProps,
 } from '@elastic/eui';
 import { difference } from 'lodash';
 import React, { useEffect, useState } from 'react';
@@ -69,6 +70,42 @@ const COLUMNS = [
     render: renderCustomization,
   },
 ];
+
+const SEARCH_OPTIONS: EuiSearchBarProps = {
+  box: { placeholder: 'Search for action group name or permission name' },
+  filters: [
+    {
+      type: 'field_value_selection',
+      field: 'type',
+      name: 'All types',
+      options: [{ value: 'Action group' }, { value: 'Single permission' }],
+    },
+    {
+      type: 'field_value_selection',
+      name: 'All permissions',
+      options: [
+        { field: 'hasClusterPermission', name: 'Cluster permissions', value: true },
+        { field: 'hasIndexPermission', name: 'Index permissions', value: true },
+      ],
+    },
+    {
+      type: 'field_value_selection',
+      field: 'reserved',
+      name: 'Customization',
+      multiSelect: false,
+      options: [
+        {
+          value: true,
+          view: renderCustomization(true),
+        },
+        {
+          value: false,
+          view: renderCustomization(false),
+        },
+      ],
+    },
+  ],
+};
 
 export function PermissionList(props: AppDependencies) {
   const [actionGroups, setActionGroups] = useState<ActionGroupListingItem[]>([]);
@@ -229,9 +266,9 @@ export function PermissionList(props: AppDependencies) {
             items={actionGroups}
             itemId={'name'}
             pagination
-            search={{ box: { placeholder: 'Search for action group name or permission name' } }}
+            search={SEARCH_OPTIONS}
             selection={{ onSelectionChange: setSelection }}
-            sorting
+            sorting={{ sort: { field: 'type', direction: 'asc' } }}
             error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
           />
         </EuiPageBody>

--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -15,7 +15,7 @@
 
 import { HttpStart } from 'kibana/public';
 import { map } from 'lodash';
-import { API_ENDPOINT_ACTIONGROUPS } from '../constants';
+import { API_ENDPOINT_ACTIONGROUPS, CLUSTER_PERMISSIONS, INDEX_PERMISSIONS } from '../constants';
 import { DataObject, ActionGroupItem } from '../types';
 
 export interface ActionGroupListingItem {
@@ -47,4 +47,31 @@ function tranformActionGroupsToListingFormat(
 
 export async function fetchActionGroupListing(http: HttpStart): Promise<ActionGroupListingItem[]> {
   return tranformActionGroupsToListingFormat(await fetchActionGroups(http));
+}
+
+function getClusterSinglePermissions(): ActionGroupListingItem[] {
+  return CLUSTER_PERMISSIONS.map((permission) => ({
+    name: permission,
+    type: 'Single permission',
+    reserved: true,
+    allowedActions: [],
+    hasClusterPermission: true,
+    hasIndexPermission: false,
+  }));
+}
+
+function getIndexSinglePermissions(): ActionGroupListingItem[] {
+  return INDEX_PERMISSIONS.map((permission) => ({
+    name: permission,
+    type: 'Single permission',
+    reserved: true,
+    allowedActions: [],
+    hasClusterPermission: false,
+    hasIndexPermission: true,
+  }));
+}
+
+export async function getAllPermissionsListing(http: HttpStart): Promise<ActionGroupListingItem[]> {
+  const actionGroups = await fetchActionGroupListing(http);
+  return actionGroups.concat(getClusterSinglePermissions()).concat(getIndexSinglePermissions());
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. add search option
2. add single permissions 
3. set default sorting by type

Mockup:
![image](https://user-images.githubusercontent.com/63078162/88217921-21668300-cc14-11ea-92fe-efd9bef3e35a.png)

Implementation:
![image](https://user-images.githubusercontent.com/63078162/88217991-3fcc7e80-cc14-11ea-9312-26cfcb1acd8c.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
