### PR TITLE
[AuditLogging] redirect to read view with toast after save success

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -30,6 +30,8 @@ import { InternalUserEdit } from './panels/internal-user-edit/internal-user-edit
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';
 import {
+  FROM_COMPLIANCE_SAVE_SUCCESS,
+  FROM_GENERAL_SAVE_SUCCESS,
   SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
   SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
 } from './panels/audit-logging/constants';
@@ -80,6 +82,8 @@ const ROUTE_LIST = [
 const allNavPanelUrls = ROUTE_LIST.map((route) => route.href).concat([
   buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
   buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
+  buildUrl(ResourceType.auditLogging) + FROM_GENERAL_SAVE_SUCCESS,
+  buildUrl(ResourceType.auditLogging) + FROM_COMPLIANCE_SAVE_SUCCESS,
 ]);
 
 // url regex pattern for all pages with left nav panel, (/|/roles|/internalusers|...)
@@ -160,9 +164,10 @@ export function AppRouter(props: AppDependencies) {
             >
               <AuditLoggingEditSettings setting={'compliance'} {...props} />
             </Route>
-            <Route path={ROUTE_MAP.auditLogging.href}>
-              <AuditLogging {...props} />
-            </Route>
+            <Route
+              path={ROUTE_MAP.auditLogging.href + '/:fromType?'}
+              render={(match) => <AuditLogging {...{ ...props, ...match.match.params }} />}
+            />
             <Route path={ROUTE_MAP.permissions.href}>
               <PermissionList {...props} />
             </Route>

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -28,7 +28,12 @@ import {
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import { cloneDeep, set, without } from 'lodash';
 import { AppDependencies } from '../../../types';
-import { SETTING_GROUPS, SettingMapItem } from './constants';
+import {
+  FROM_COMPLIANCE_SAVE_SUCCESS,
+  FROM_GENERAL_SAVE_SUCCESS,
+  SETTING_GROUPS,
+  SettingMapItem,
+} from './constants';
 import { EditSettingGroup } from './edit-setting-group';
 import { AuditLoggingSettings } from './types';
 import { buildHashUrl } from '../../utils/url-builder';
@@ -115,14 +120,9 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
     try {
       await updateAuditLogging(props.coreStart.http, configToUpdate);
 
-      const successToast: Toast = {
-        id: 'update-result',
-        color: 'success',
-        iconType: 'check',
-        title: 'Audit configuration was successfully updated.',
-      };
-
-      addToast(successToast);
+      window.location.href =
+        buildHashUrl(ResourceType.auditLogging) +
+        (props.setting === 'general' ? FROM_GENERAL_SAVE_SUCCESS : FROM_COMPLIANCE_SAVE_SUCCESS);
     } catch (e) {
       const failureToast: Toast = {
         id: 'update-result',

--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -318,3 +318,6 @@ export const SETTING_GROUPS = {
 
 export const SUB_URL_FOR_GENERAL_SETTINGS_EDIT = '/edit/generalSettings';
 export const SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT = '/edit/complianceSettings';
+
+export const FROM_GENERAL_SAVE_SUCCESS = '/generalSuccess';
+export const FROM_COMPLIANCE_SAVE_SUCCESS = '/complianceSuccess';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Before this change, the success toast will show on the same edit page. Based on UX feedback, after a successful save, it will redirect to the read view and display the toast with a corresponding success message.

*Test*:
Mockup:
<img width="1617" alt="Screen Shot 2020-07-22 at 3 49 31 PM" src="https://user-images.githubusercontent.com/60111637/88237020-31418f80-cc33-11ea-9bf3-12d1f3866021.png">

Implementation:
starting page (edit view of compliance setting)
![screencapture-localhost-5601-app-opendistro-security-2020-07-22-15_49_59](https://user-images.githubusercontent.com/60111637/88237072-4d453100-cc33-11ea-9bb1-612b232127d7.png)

After saving successfully,
![screencapture-localhost-5601-app-opendistro-security-2020-07-22-15_50_17](https://user-images.githubusercontent.com/60111637/88237103-59c98980-cc33-11ea-88c0-7ed75f5f2663.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
