### PR TITLE
Implement role-mapping list page

### DIFF
--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -34,27 +34,25 @@ import {
 import { BreadcrumbsPageDependencies } from '../../../types';
 import { buildHashUrl } from '../../utils/url-builder';
 import { ResourceType, Action } from '../../types';
-import { getRoleMappingDeta, MappedUsersListing } from '../../utils/role-mapping-utils';
+import { getRoleMappingData, MappedUsersListing } from '../../utils/role-mapping-utils';
 
 interface RoleViewProps extends BreadcrumbsPageDependencies {
   roleName: string;
 }
 
-function getmappedUserColumns() {
-  return [
-    {
-      field: 'user_type',
-      name: 'User type',
-      sortable: true,
-    },
-    {
-      field: 'user_name',
-      name: 'User',
-      sortable: true,
-      truncateText: true,
-    },
-  ];
-}
+const mappedUserColumns = [
+  {
+    field: 'user_type',
+    name: 'User type',
+    sortable: true,
+  },
+  {
+    field: 'user_name',
+    name: 'User',
+    sortable: true,
+    truncateText: true,
+  },
+];
 
 export function RoleView(props: RoleViewProps) {
   const duplicateRoleLink = buildHashUrl(ResourceType.roles, Action.duplicate, props.roleName);
@@ -62,7 +60,7 @@ export function RoleView(props: RoleViewProps) {
   const [mappedUsers, setMappedUsers] = useState<MappedUsersListing[]>([]);
   const [errorFlag, setErrorFlag] = useState(false);
   const [selection, setSelection] = useState<MappedUsersListing[]>([]);
-  const [message, setMessage] = useState(
+  const message = (
     <EuiEmptyPrompt
       title={<h2>No user has been mapped to this role</h2>}
       titleSize="s"
@@ -95,7 +93,7 @@ export function RoleView(props: RoleViewProps) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const roleMappingData = await getRoleMappingDeta(props.coreStart.http, props.roleName);
+        const roleMappingData = await getRoleMappingData(props.coreStart.http, props.roleName);
         setMappedUsers(roleMappingData);
       } catch (e) {
         console.log(e);
@@ -150,7 +148,7 @@ export function RoleView(props: RoleViewProps) {
             <EuiPageBody>
               <EuiInMemoryTable
                 loading={mappedUsers === [] && !errorFlag}
-                columns={getmappedUserColumns()}
+                columns={mappedUserColumns}
                 items={mappedUsers}
                 itemId={'user_name'}
                 pagination={true}

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import React, { Fragment } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 
 import {
   EuiButton,
@@ -22,32 +22,151 @@ import {
   EuiSpacer,
   EuiTabbedContent,
   EuiTitle,
+  EuiPageContent,
+  EuiText,
+  EuiLink,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPageBody,
+  EuiInMemoryTable,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import { BreadcrumbsPageDependencies } from '../../../types';
 import { buildHashUrl } from '../../utils/url-builder';
 import { ResourceType, Action } from '../../types';
-
-const tabs = [
-  {
-    id: 'permissions',
-    name: 'Permissions',
-    disabled: false,
-    content: <Fragment>Permission working in progress</Fragment>,
-  },
-  {
-    id: 'users',
-    name: 'Users',
-    disabled: false,
-    content: <Fragment>Users working in progress</Fragment>,
-  },
-];
+import { getRoleMappingDeta, MappedUsersListing } from '../../utils/role-mapping-utils';
 
 interface RoleViewProps extends BreadcrumbsPageDependencies {
   roleName: string;
 }
 
+function getmappedUserColumns() {
+  return [
+    {
+      field: 'user_type',
+      name: 'User type',
+      sortable: true,
+    },
+    {
+      field: 'user_name',
+      name: 'User',
+      sortable: true,
+      truncateText: true,
+    },
+  ];
+}
+
 export function RoleView(props: RoleViewProps) {
   const duplicateRoleLink = buildHashUrl(ResourceType.roles, Action.duplicate, props.roleName);
+
+  const [mappedUsers, setMappedUsers] = useState<MappedUsersListing[]>([]);
+  const [errorFlag, setErrorFlag] = useState(false);
+  const [selection, setSelection] = useState<MappedUsersListing[]>([]);
+  const [message, setMessage] = useState(
+    <EuiEmptyPrompt
+      title={<h2>No user has been mapped to this role</h2>}
+      titleSize="s"
+      body={
+        <EuiText size="s" color="subdued" grow={false}>
+          <p>You can map internal users or external identities to this role</p>
+        </EuiText>
+      }
+      actions={
+        <EuiFlexGroup gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              iconType="popout"
+              iconSide="right"
+              onClick={() => {
+                window.location.href = buildHashUrl(ResourceType.users, Action.create);
+              }}
+            >
+              Create internal user
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton fill>Map users</EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+    />
+  );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const roleMappingData = await getRoleMappingDeta(props.coreStart.http, props.roleName);
+        setMappedUsers(roleMappingData);
+      } catch (e) {
+        console.log(e);
+        setErrorFlag(true);
+      }
+    };
+
+    fetchData();
+  }, [props.coreStart.http, props.roleName]);
+
+  const tabs = [
+    {
+      id: 'permissions',
+      name: 'Permissions',
+      disabled: false,
+      content: <Fragment>Permission working in progress</Fragment>,
+    },
+    {
+      id: 'users',
+      name: 'Mapped users',
+      disabled: false,
+      content: (
+        <>
+          <EuiSpacer />
+          <EuiPageContent>
+            <EuiPageContentHeader>
+              <EuiPageContentHeaderSection>
+                <EuiTitle size="s">
+                  <h3>Mapped users ({mappedUsers.length})</h3>
+                </EuiTitle>
+                <EuiText size="xs" color="subdued">
+                  You can map two types of users: 1. Internal users within the Security plugin. An
+                  internal user can have its own backend role and host for an external
+                  authentication and authorization. 2. External identity, which directly maps to
+                  roles through an external authentication system.{' '}
+                  <EuiLink external={true} href="/">
+                    Learn More
+                  </EuiLink>
+                </EuiText>
+              </EuiPageContentHeaderSection>
+              <EuiPageContentHeaderSection>
+                <EuiFlexGroup>
+                  <EuiFlexItem>
+                    <EuiButton isDisabled>Delete mapping</EuiButton>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiButton>Manage mapping</EuiButton>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPageContentHeaderSection>
+            </EuiPageContentHeader>
+            <EuiPageBody>
+              <EuiInMemoryTable
+                loading={mappedUsers === [] && !errorFlag}
+                columns={getmappedUserColumns()}
+                items={mappedUsers}
+                itemId={'user_name'}
+                pagination={true}
+                message={message}
+                selection={{ onSelectionChange: setSelection }}
+                sorting={true}
+                error={
+                  errorFlag ? 'Load data failed, please check console log for more detail.' : ''
+                }
+              />
+            </EuiPageBody>
+          </EuiPageContent>
+        </>
+      ),
+    },
+  ];
 
   return (
     <>

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -42,12 +42,12 @@ interface RoleViewProps extends BreadcrumbsPageDependencies {
 
 const mappedUserColumns = [
   {
-    field: 'user_type',
+    field: 'userType',
     name: 'User type',
     sortable: true,
   },
   {
-    field: 'user_name',
+    field: 'userName',
     name: 'User',
     sortable: true,
     truncateText: true,
@@ -150,7 +150,7 @@ export function RoleView(props: RoleViewProps) {
                 loading={mappedUsers === [] && !errorFlag}
                 columns={mappedUserColumns}
                 items={mappedUsers}
-                itemId={'user_name'}
+                itemId={'userName'}
                 pagination={true}
                 message={message}
                 selection={{ onSelectionChange: setSelection }}

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -66,6 +66,15 @@ export interface RoleDetail extends RoleUpdate {
   reserved: boolean;
 }
 
+export interface RoleMappingDetail {
+  reserved: boolean;
+  hidden: boolean;
+  backend_roles: string[];
+  hosts: string[];
+  users: string[];
+  and_backend_roles: string[];
+}
+
 export interface Tenant {
   reserved: boolean;
   description: string;

--- a/public/apps/configuration/utils/role-mapping-utils.tsx
+++ b/public/apps/configuration/utils/role-mapping-utils.tsx
@@ -19,8 +19,8 @@ import { API_ENDPOINT_ROLESMAPPING } from '../constants';
 import { RoleMappingDetail } from '../types';
 
 export interface MappedUsersListing {
-  user_name: string;
-  user_type: string;
+  userName: string;
+  userType: string;
 }
 
 export enum UserType {
@@ -42,13 +42,13 @@ export async function getRoleMappingData(http: HttpStart, roleName: string) {
 
 export function transformRoleMappingData(rawData: RoleMappingDetail): MappedUsersListing[] {
   const internalUsers = map(rawData.users, (mappedUser: string) => ({
-    user_name: mappedUser,
-    user_type: UserType.internal,
+    userName: mappedUser,
+    userType: UserType.internal,
   }));
 
   const externalIdentity = map(rawData.backend_roles, (mappedExternalIdentity: string) => ({
-    user_name: mappedExternalIdentity,
-    user_type: UserType.external,
+    userName: mappedExternalIdentity,
+    userType: UserType.external,
   }));
 
   return internalUsers.concat(externalIdentity);

--- a/public/apps/configuration/utils/role-mapping-utils.tsx
+++ b/public/apps/configuration/utils/role-mapping-utils.tsx
@@ -1,0 +1,54 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { map } from 'lodash';
+import { HttpStart } from '../../../../../../src/core/public';
+import { API_ENDPOINT_ROLESMAPPING } from '../constants';
+import { RoleMappingDetail } from '../types';
+
+export interface MappedUsersListing {
+  user_name: string;
+  user_type: string;
+}
+
+export enum UserType {
+  internal = 'Internal user',
+  external = 'External identity',
+}
+
+export async function getRoleMappingDeta(http: HttpStart, roleName: string) {
+  try {
+    const rawData = (await http.get(
+      `${API_ENDPOINT_ROLESMAPPING}/${roleName}`
+    )) as RoleMappingDetail;
+    return transformRoleMappingData(rawData);
+  } catch (e) {
+    return [];
+  }
+}
+
+export function transformRoleMappingData(rawData: RoleMappingDetail): MappedUsersListing[] {
+  const internalUsers = map(rawData.users, (v) => ({
+    user_name: v,
+    user_type: UserType.internal,
+  }));
+
+  const externalIdentity = map(rawData.backend_roles, (v) => ({
+    user_name: v,
+    user_type: UserType.external,
+  }));
+
+  return internalUsers.concat(externalIdentity);
+}

--- a/public/apps/configuration/utils/role-mapping-utils.tsx
+++ b/public/apps/configuration/utils/role-mapping-utils.tsx
@@ -28,25 +28,26 @@ export enum UserType {
   external = 'External identity',
 }
 
-export async function getRoleMappingDeta(http: HttpStart, roleName: string) {
+export async function getRoleMappingData(http: HttpStart, roleName: string) {
   try {
     const rawData = (await http.get(
       `${API_ENDPOINT_ROLESMAPPING}/${roleName}`
     )) as RoleMappingDetail;
     return transformRoleMappingData(rawData);
   } catch (e) {
-    return [];
+    if (e.response.status === 404) return [];
+    throw e;
   }
 }
 
 export function transformRoleMappingData(rawData: RoleMappingDetail): MappedUsersListing[] {
-  const internalUsers = map(rawData.users, (v) => ({
-    user_name: v,
+  const internalUsers = map(rawData.users, (mappedUser: string) => ({
+    user_name: mappedUser,
     user_type: UserType.internal,
   }));
 
-  const externalIdentity = map(rawData.backend_roles, (v) => ({
-    user_name: v,
+  const externalIdentity = map(rawData.backend_roles, (mappedExternalIdentity: string) => ({
+    user_name: mappedExternalIdentity,
     user_type: UserType.external,
   }));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implement UI to show the list of mapped users and external identities.

**Screenshots:**

1. When no user mapped to the selected role

_Mockup:_
![image](https://user-images.githubusercontent.com/63824432/88345304-8bf1ee80-ccfa-11ea-83a0-e0c8dee88469.png)

_Implementation:_
![image](https://user-images.githubusercontent.com/63824432/88345432-c9567c00-ccfa-11ea-9162-9b3917f36f1e.png)


2. When some users already has been mapped to the selected role

_Mockup:_
![image](https://user-images.githubusercontent.com/63824432/88345554-0753a000-ccfb-11ea-8c67-98c51bff783d.png)

_Implementation:_
![image](https://user-images.githubusercontent.com/63824432/88345597-22beab00-ccfb-11ea-96e1-b755387e9021.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
