### PR TITLE
add global breadcrumbs for audit log pages

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -13,10 +13,11 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiPage, EuiPageBody, EuiPageSideBar, EuiBreadcrumbs } from '@elastic/eui';
+import { EuiBreadcrumbs, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eui';
 import React from 'react';
 import { HashRouter as Router, Route, Switch } from 'react-router-dom';
 import { partial } from 'lodash';
+import { CoreStart } from 'kibana/public';
 import { AppDependencies } from '../types';
 import { AuthView } from './panels/auth-view/auth-view';
 import { NavPanel } from './panels/nav-panel';
@@ -24,8 +25,8 @@ import { RoleEdit } from './panels/role-edit/role-edit';
 import { RoleList } from './panels/role-list';
 import { RoleView } from './panels/role-view/role-view';
 import { UserList } from './panels/user-list';
-import { RouteItem, ResourceType, Action } from './types';
-import { buildUrl, buildHashUrl } from './utils/url-builder';
+import { Action, ResourceType, RouteItem } from './types';
+import { buildHashUrl, buildUrl } from './utils/url-builder';
 import { InternalUserEdit } from './panels/internal-user-edit/internal-user-edit';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';
@@ -89,6 +90,7 @@ const allNavPanelUrls = ROUTE_LIST.map((route) => route.href).concat([
 // url regex pattern for all pages with left nav panel, (/|/roles|/internalusers|...)
 const PATTERNS_ROUTES_WITH_NAV_PANEL = '(' + allNavPanelUrls.join('|') + ')';
 
+// TODO: migrate to global Breadcrumbs.
 function Breadcrumbs(resourceType: ResourceType, pageTitle: string) {
   return (
     <EuiBreadcrumbs
@@ -107,6 +109,31 @@ function Breadcrumbs(resourceType: ResourceType, pageTitle: string) {
       ]}
     />
   );
+}
+
+export function setGlobalBreadcrumbs(
+  coreStart: CoreStart,
+  resourceType: ResourceType,
+  pageTitle?: string
+) {
+  const breadcrumbs: [{ text: string; href?: string }] = [
+    {
+      text: 'Security',
+      href: buildHashUrl(),
+    },
+    {
+      text: ROUTE_MAP[resourceType].name,
+      href: buildHashUrl(resourceType),
+    },
+  ];
+
+  if (pageTitle) {
+    breadcrumbs.push({
+      text: pageTitle,
+    });
+  }
+
+  coreStart.chrome.setBreadcrumbs(breadcrumbs);
 }
 
 export function AppRouter(props: AppDependencies) {
@@ -156,17 +183,34 @@ export function AppRouter(props: AppDependencies) {
             <Route path={ROUTE_MAP.users.href}>
               <UserList {...props} />
             </Route>
-            <Route path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT}>
-              <AuditLoggingEditSettings setting={'general'} {...props} />
-            </Route>
+            <Route
+              path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT}
+              render={() => {
+                setGlobalBreadcrumbs(
+                  props.coreStart,
+                  ResourceType.auditLogging,
+                  'General settings'
+                );
+                return <AuditLoggingEditSettings setting={'general'} {...props} />;
+              }}
+            />
             <Route
               path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT}
-            >
-              <AuditLoggingEditSettings setting={'compliance'} {...props} />
-            </Route>
+              render={(match) => {
+                setGlobalBreadcrumbs(
+                  props.coreStart,
+                  ResourceType.auditLogging,
+                  'Compliance settings'
+                );
+                return <AuditLoggingEditSettings setting={'compliance'} {...props} />;
+              }}
+            />
             <Route
               path={ROUTE_MAP.auditLogging.href + '/:fromType?'}
-              render={(match) => <AuditLogging {...{ ...props, ...match.match.params }} />}
+              render={(match) => {
+                setGlobalBreadcrumbs(props.coreStart, ResourceType.auditLogging);
+                return <AuditLogging {...{ ...props, ...match.match.params }} />;
+              }}
             />
             <Route path={ROUTE_MAP.permissions.href}>
               <PermissionList {...props} />


### PR DESCRIPTION
…t logging

*Issue #, if available:*

*Description of changes:*
This change is to add breadcrumbs display for audit logging pages. 

After checking the existing behavior of the code, it will only add breadcrumbs to the top of the right-side page if there is nav panel instead of treating nav panel + the right-side page as a whole.

I tried to follow the current logic for navpanel to add another Route for breadcrumbs. However, there are a few problems:
1) app-route becomes more complicated with branching logic. If only navpanel, it looks fine. But with another component, it starts becoming messy.
2) Within audit logging, there are a few pages whose breadcrumbs title needs to be update. E.g general vs compliance. It seems that the app-route only uses the initial values without dynamically changing during same-hash pages.

Thus I decide to make some refactoring so that each page takes care of their own rendering of side panel and breadcrumbs. The benefit is that we only need to look at the feature's own tsx to understand its rendering effect and keep app-route simple.

*Test:*
Verify that all the pages this PR touch have the same display for nav panel and breadcrumbs as before.

Specifically for audit logging,
Below are the mockups

![screencapture-aws-uxdr-invisionapp-share-ZTVZTJJKURY-2020-07-23-23_20_45](https://user-images.githubusercontent.com/60111637/88365658-9ed8e300-cd3b-11ea-88e3-3b987b8840af.png)

![screencapture-aws-uxdr-invisionapp-share-ZTVZTJJKURY-2020-07-23-23_21_03](https://user-images.githubusercontent.com/60111637/88365667-a6988780-cd3b-11ea-98c2-942f940315d0.png)

![screencapture-aws-uxdr-invisionapp-share-ZTVZTJJKURY-2020-07-23-23_21_35](https://user-images.githubusercontent.com/60111637/88365678-aef0c280-cd3b-11ea-88d3-b71b9dec2e55.png)

Implementation:
![screencapture-localhost-5601-app-opendistro-security-2020-07-23-23_22_26](https://user-images.githubusercontent.com/60111637/88365691-b912c100-cd3b-11ea-99c2-1e159b194eba.png)

![screencapture-localhost-5601-app-opendistro-security-2020-07-23-23_22_45](https://user-images.githubusercontent.com/60111637/88365703-bfa13880-cd3b-11ea-92d7-e3c2e056ef65.png)

![screencapture-localhost-5601-app-opendistro-security-2020-07-23-23_23_04](https://user-images.githubusercontent.com/60111637/88365710-c5971980-cd3b-11ea-9634-76da50652240.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
