### PR TITLE
Bump version to v1.8.1.1, update audit configuration UI

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ export default function (kibana) {
                 },
                 {
                     id: 'security-audit',
-                    title: 'Audit',
+                    title: 'Audit logs',
                     description: 'Audit logging',
                     main: 'plugins/opendistro_security/apps/audit/app',
                     linkToLastSubUrl: false,

--- a/lib/configuration/validation/audit.js
+++ b/lib/configuration/validation/audit.js
@@ -18,7 +18,9 @@ export default Joi.object().keys({
       'BAD_HEADERS',
       'FAILED_LOGIN',
       'GRANTED_PRIVILEGES',
+      'INDEX_EVENT',
       'MISSING_PRIVILEGES',
+      'OPENDISTRO_SECURITY_INDEX_ATTEMPT',
       'SSL_EXCEPTION'
     ),
     resolve_bulk_requests: Joi.boolean(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendistro_security",
-  "version": "1.8.1.0",
+  "version": "1.8.1.1",
   "description": "Security features for kibana",
   "main": "index.js",
   "homepage": "https://github.com/opendistro-for-elasticsearch/security-kibana-plugin",

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>com.amazon.opendistroforelasticsearch</groupId>
   <artifactId>opendistro_security_kibana_plugin</artifactId>
   <packaging>pom</packaging>
-  <version>1.8.1.0</version>
+  <version>1.8.1.1</version>
   <name>Open Distro Security for Elasticsearch Kibana Plugin</name>
   <description>Open Distro Security for Elasticsearch Kibana Plugin</description>
   <url>https://github.com/opendistro-for-elasticsearch/security-kibana-plugin</url>
@@ -55,7 +55,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security-kibana-plugin</url>
     <connection>scm:git:git@github.com:mauve-hedgehog/opendistro-elasticsearch-security-kibana-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:mauve-hedgehog/opendistro-elasticsearch-security-kibana-plugin.git</developerConnection>
-    <tag>v1.8.1.0</tag>
+    <tag>v1.8.1.1</tag>
   </scm>
 
   <issueManagement>

--- a/public/apps/audit/components/main/ContentPanel.js
+++ b/public/apps/audit/components/main/ContentPanel.js
@@ -12,7 +12,7 @@ import {
 const ContentPanel = ({ title, children, configureHandler }) => (
   <>
     <EuiPanel paddingSize="none">
-      <div style={{ padding: 20, paddingBottom: 0 }}>
+      <div style={{ padding: 20, paddingBottom: 12 }}>
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiTitle>
@@ -27,7 +27,7 @@ const ContentPanel = ({ title, children, configureHandler }) => (
         </EuiFlexGroup>
       </div>
       <EuiHorizontalRule margin="xs" />
-      <div style={{ padding: 32, paddingBottom: 0 }}>{children}</div>
+      <div style={{ padding: 24, paddingBottom: 0 }}>{children}</div>
     </EuiPanel>
   </>
 );

--- a/public/apps/audit/components/main/EditSettingGroup.js
+++ b/public/apps/audit/components/main/EditSettingGroup.js
@@ -1,6 +1,7 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
+  EuiCallOut,
   EuiCodeBlock,
   EuiComboBox,
   EuiDescribedFormGroup,
@@ -84,9 +85,8 @@ function EditSettingGroup({
           <EuiTextColor color="subdued">
             <p>
               {setting.content}
-              <br />
               <EuiLink href={setting.url}>
-                Learn more in the documentation
+                Learn more
                 <EuiIcon type="popout" />
               </EuiLink>
             </p>
@@ -104,6 +104,20 @@ function EditSettingGroup({
         <EuiCodeBlock language="json" paddingSize="none" isCopyable>
           {setting.code}
         </EuiCodeBlock>
+      </>
+    );
+  };
+
+  const renderCallout = message => {
+    return (
+      <>
+        <EuiCallOut>
+          <EuiText size="s">
+            <EuiTextColor color="default">
+              <p>{message}</p>
+            </EuiTextColor>
+          </EuiText>
+        </EuiCallOut>
       </>
     );
   };
@@ -129,11 +143,12 @@ function EditSettingGroup({
                   <>
                     {setting.description}
                     {setting.code && renderCodeBlock(setting)}
+                    {setting.note && renderCallout(setting.note)}
                   </>
                 }
                 fullWidth
               >
-                <EuiFormRow label={displayLabel(setting.path)}>
+                <EuiFormRow label={setting.hideLabel ? null : displayLabel(setting.path)}>
                   {renderField(config, setting, handleChange, handleInvalid)}
                 </EuiFormRow>
               </EuiDescribedFormGroup>
@@ -144,10 +159,7 @@ function EditSettingGroup({
     ) : null;
 
   return renderedSettings ? (
-    <>
-      {showPanel ? <EuiPanel>{renderedSettings}</EuiPanel> : renderedSettings}
-      <EuiSpacer size="xs" />
-    </>
+    <>{showPanel ? <EuiPanel>{renderedSettings}</EuiPanel> : renderedSettings}</>
   ) : null;
 }
 

--- a/public/apps/audit/components/main/config.js
+++ b/public/apps/audit/components/main/config.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export const AUDIT_API = {
   PUT: '../api/v1/configuration/audit/config',
   GET: '../api/v1/configuration/audit',
@@ -29,28 +31,17 @@ export const RESPONSE_MESSAGES = {
   UPDATE_FAILURE: 'Audit configuration could not be updated. Please check configuration.',
 };
 
-export const CALLOUT_MESSAGES = {
-  AUDIT_SETTINGS: [
-    'Enabling REST and Transport layers (audit:enable_rest, audit:enable_transport) may result in a massive number of logs if AUTHENTICATED and GRANTED_PRIVILEGES are not disabled. We suggest you ignore common requests if doing so.',
-    'Enabling Bulk requests (config:audit:resolve_bulk_requests) will generate one log per request, and may also result in very large log files.',
-  ],
-  COMPLIANCE_SETTINGS: [
-    'Configuring Watched fields and Watched indices (compliance:read_watch_fields, compliance:write_watched_indices) will generate one log per document access, and may result in very large logs files being generated if monitoring commonly accessed indices and fields.',
-  ],
-};
-
 const CONFIG = {
   ENABLED: {
     title: 'Enable audit logging',
     path: 'enabled',
-    description: 'Enable or disable audit logging',
     type: 'bool',
+    hideLabel: true,
   },
   STORAGE: {
-    title: 'Configure Storage',
+    title: 'Storage location',
     path: '',
-    description: 'Where should Elasticsearch store or send audit logs',
-    content: 'Configure the output location and storage types in elasticsearch.yml',
+    content: <>Configure the output location and storage types in <code>elasticsearch.yml</code> . The default storage location is <code>internal_elasticsearch</code>, which stores the logs in an index on this cluster.  </>,
     url: 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/',
     type: 'text',
   },
@@ -58,48 +49,53 @@ const CONFIG = {
     REST_LAYER: {
       title: 'REST layer',
       path: 'audit.enable_rest',
-      description: 'Enable or disable auditing events that happen on the REST layer',
+      description: 'Enable or disable auditing events that happen on the REST layer.',
       type: 'bool',
     },
     REST_DISABLED_CATEGORIES: {
       title: 'REST disabled categories',
       path: 'audit.disabled_rest_categories',
-      description: 'Specify audit categories which must be ignored on the REST layer',
+      description: 'Specify audit categories which must be ignored on the REST layer.',
       type: 'array',
       options: [
+        'AUTHENTICATED',
         'BAD_HEADERS',
         'FAILED_LOGIN',
-        'MISSING_PRIVILEGES',
         'GRANTED_PRIVILEGES',
-        'SSL_EXCEPTION',
-        'AUTHENTICATED',
+        'MISSING_PRIVILEGES',
+        'SSL_EXCEPTION'
       ],
+      note: <>We <em>highly</em> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. If enabled, these categories can result in a huge number of logs.</>,
     },
     TRANSPORT_LAYER: {
       title: 'Transport layer',
       path: 'audit.enable_transport',
-      description: 'Enable or disable auditing events that happen on the Transport layer',
+      description: 'Enable or disable auditing events that happen on the Transport layer.',
       type: 'bool',
     },
     TRANSPORT_DISABLED_CATEGORIES: {
       title: 'Transport disabled categories',
       path: 'audit.disabled_transport_categories',
-      description: 'Specify audit categories which must be ignored on the Transport layer',
+      description: 'Specify audit categories which must be ignored on the Transport layer.',
       type: 'array',
       options: [
+        'AUTHENTICATED',
         'BAD_HEADERS',
         'FAILED_LOGIN',
-        'MISSING_PRIVILEGES',
         'GRANTED_PRIVILEGES',
+        'INDEX_EVENT',
+        'MISSING_PRIVILEGES',
+        'OPENDISTRO_SECURITY_INDEX_ATTEMPT',
         'SSL_EXCEPTION',
-        'AUTHENTICATED',
       ],
+      note: <>We <em>highly</em> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. If enabled, these categories can result in a huge number of logs.</>
     },
     BULK_REQUESTS: {
       title: 'Bulk requests',
       path: 'audit.resolve_bulk_requests',
       description: 'Resolve bulk requests during auditing of requests.',
       type: 'bool',
+      note: 'Enabling bulk requests generates one log per operation in the request. If you enable this setting, a single bulk request that indexes 10,000 documents results in 10,000 logs. If you disable this setting, that same request results in one log.',
     },
     REQUEST_BODY: {
       title: 'Request body',
@@ -116,7 +112,7 @@ const CONFIG = {
     SENSITIVE_HEADERS: {
       title: 'Sensitive headers',
       path: 'audit.exclude_sensitive_headers',
-      description: 'Exclude sensitive headers during auditing. Eg: Authorization header',
+      description: 'Exclude sensitive headers during auditing. Eg: Authorization header.',
       type: 'bool',
     },
     IGNORED_USERS: {
@@ -134,27 +130,33 @@ const CONFIG = {
   },
   COMPLIANCE: {
     ENABLED: {
-      title: 'Enable compliance mode',
+      title: 'Compliance logging',
       path: 'compliance.enabled',
-      description: 'Enable or disable compliance logging',
+      description: 'Enable or disable compliance logging.',
+      type: 'bool',
+      hideLabel: true,
+    },
+    MODE: {
+      title: 'Compliance mode',
+      path: 'compliance.enabled',
       type: 'bool',
     },
     INTERNAL_CONFIG: {
       title: 'Internal config logging',
       path: 'compliance.internal_config',
-      description: 'Enable or disable logging of events on internal security index',
+      description: 'Enable or disable logging of events on internal security index.',
       type: 'bool',
     },
     EXTERNAL_CONFIG: {
       title: 'External config logging',
       path: 'compliance.external_config',
-      description: 'Enable or disable logging of external configuration',
+      description: 'Enable or disable logging of external configuration.',
       type: 'bool',
     },
     READ_METADATA_ONLY: {
       title: 'Read metadata',
       path: 'compliance.read_metadata_only',
-      description: 'Do not log any document fields. Log only metadata of the document',
+      description: 'Do not log any document fields. Log only metadata of the document.',
       type: 'bool',
     },
     READ_IGNORED_USERS: {
@@ -167,7 +169,7 @@ const CONFIG = {
       title: 'Watched fields',
       path: 'compliance.read_watched_fields',
       description:
-        'List the indices and fields to watch during read events. Sample data content is as follows',
+        'List the indices and fields to watch during read events. Sample data content is as follows:',
       type: 'map',
       code: `{
   "index-name-pattern": ["field-name-pattern"],
@@ -175,17 +177,18 @@ const CONFIG = {
   "twitter": ["id", "user*"]
 }`,
       error: 'Invalid content. Please check sample data content.',
+      note: 'Adding watched fields generates one log each time a user accesses a document and could result in a large number of logs. We don\'t recommend adding frequently accessed fields.'
     },
     WRITE_METADATA_ONLY: {
       title: 'Write metadata',
       path: 'compliance.write_metadata_only',
-      description: 'Do not log any document content. Log only metadata of the document',
+      description: 'Do not log any document content. Log only metadata of the document.',
       type: 'bool',
     },
     WRITE_LOG_DIFFS: {
       title: 'Log diffs',
       path: 'compliance.write_log_diffs',
-      description: 'Log only diffs for document updates',
+      description: 'Log only diffs for document updates.',
       type: 'bool',
     },
     WRITE_IGNORED_USERS: {
@@ -199,13 +202,14 @@ const CONFIG = {
       path: 'compliance.write_watched_indices',
       description: 'List the indices to watch during write events.',
       type: 'array',
+      note: 'Adding watched indices generates one log each time a user accesses a document and could result in a large number of logs. We don\'t recommend adding frequently accessed indices.',
     },
   },
 };
 
 export const SETTING_GROUPS = {
   AUDIT_SETTINGS: {
-    settings: [CONFIG.ENABLED, CONFIG.STORAGE],
+    settings: [CONFIG.STORAGE, CONFIG.ENABLED],
   },
   LAYER_SETTINGS: {
     title: CONFIG_LABELS.LAYER_SETTINGS,
@@ -229,9 +233,12 @@ export const SETTING_GROUPS = {
     title: CONFIG_LABELS.IGNORE_SETTINGS,
     settings: [CONFIG.AUDIT.IGNORED_USERS, CONFIG.AUDIT.IGNORED_REQUESTS],
   },
-  COMPLIANCE_MODE_SETTINGS: {
+  COMPLIANCE_LOGGING_SETTINGS: {
     title: CONFIG_LABELS.COMPLIANCE_MODE,
     settings: [CONFIG.COMPLIANCE.ENABLED],
+  },
+  COMPLIANCE_MODE_SETTINGS: {
+    settings: [CONFIG.COMPLIANCE.MODE],
   },
   COMPLIANCE_CONFIG_SETTINGS: {
     title: CONFIG_LABELS.COMPLIANCE_CONFIG_SETTINGS,

--- a/public/apps/audit/components/main/main.js
+++ b/public/apps/audit/components/main/main.js
@@ -17,7 +17,6 @@ import {
   CONFIG_LABELS,
   SETTING_GROUPS,
   RESPONSE_MESSAGES,
-  CALLOUT_MESSAGES,
   TOAST_MESSAGES,
 } from './config';
 import ContentPanel from './ContentPanel';
@@ -107,19 +106,6 @@ export function Main(props) {
       });
   };
 
-  const renderCallout = messages => {
-    return (
-      <>
-        <EuiCallOut title="Warning" color="warning">
-          {messages.map((message, index) => {
-            return <p key={index}>{message}</p>;
-          })}
-        </EuiCallOut>
-        <EuiSpacer />
-      </>
-    );
-  };
-
   const renderError = () => {
     return showError ? (
       <EuiCallOut title={RESPONSE_MESSAGES.FETCH_ERROR_TITLE} color="danger" iconType="alert">
@@ -166,7 +152,6 @@ export function Main(props) {
         </EuiTitle>
         <EuiSpacer size="m" />
         <EuiPanel>
-          {renderCallout(CALLOUT_MESSAGES.AUDIT_SETTINGS)}
           <EditSettingGroup
             settingGroup={SETTING_GROUPS.LAYER_SETTINGS}
             config={editConfig}
@@ -200,14 +185,13 @@ export function Main(props) {
         <EuiSpacer size="m" />
         <EuiPanel>
           <EditSettingGroup
-            settingGroup={SETTING_GROUPS.COMPLIANCE_MODE_SETTINGS}
+            settingGroup={SETTING_GROUPS.COMPLIANCE_LOGGING_SETTINGS}
             config={editConfig}
             handleChange={handleChange}
             readonly={readonly}
           ></EditSettingGroup>
           {editConfig.compliance.enabled && (
             <>
-              {renderCallout(CALLOUT_MESSAGES.COMPLIANCE_SETTINGS)}
               <EditSettingGroup
                 settingGroup={SETTING_GROUPS.COMPLIANCE_CONFIG_SETTINGS}
                 config={editConfig}
@@ -215,7 +199,7 @@ export function Main(props) {
                 readonly={readonly}
                 showPanel={true}
               ></EditSettingGroup>
-              <EuiSpacer size="s" />
+              <EuiSpacer />
               <EditSettingGroup
                 settingGroup={SETTING_GROUPS.COMPLIANCE_READ_SETTINGS}
                 config={editConfig}
@@ -224,7 +208,7 @@ export function Main(props) {
                 readonly={readonly}
                 showPanel={true}
               ></EditSettingGroup>
-              <EuiSpacer size="s" />
+              <EuiSpacer />
               <EditSettingGroup
                 settingGroup={SETTING_GROUPS.COMPLIANCE_WRITE_SETTINGS}
                 config={editConfig}
@@ -250,6 +234,7 @@ export function Main(props) {
             handleChange={handleChangeWithSave}
             readonly={readonly}
           ></EditSettingGroup>
+          <EuiSpacer size="s" />
         </ContentPanel>
         {config.enabled && (
           <>

--- a/public/apps/audit/components/main/utils.js
+++ b/public/apps/audit/components/main/utils.js
@@ -3,7 +3,7 @@ export function displayBoolean(val) {
 }
 
 export function displayArray(val) {
-  return val && val.length != 0 ? val.join(' , ') : '--';
+  return val && val.length != 0 ? val.join(', ') : '--';
 }
 
 export function displayMap(val) {

--- a/release-notes/opendistro-for-elasticsearch.security-kibana.release-notes-1.8.1.1.md
+++ b/release-notes/opendistro-for-elasticsearch.security-kibana.release-notes-1.8.1.1.md
@@ -1,0 +1,7 @@
+## Open Distro for Elasticsearch 1.8.1.1 Release Notes
+
+Compatible with Kibana 7.7.1 and Open Distro for Elasticsearch 1.8.1.
+
+## Features
+- UI to update Audit logging configuration
+- Fixed bug in redirecting to error page 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Bump version to v1.8.1.1
- Update disabled categories for Transport layer
- Detail audit logging UI
  - Update title to "Audit logs"
  - Remove call out messages and provide notes 
  - Add line periods
  - Remove labels for storage, enable audit log and enable compliance fields
  - Fix padding and spacing 

Screenshots:

<img width="1392" alt="Screen Shot 2020-07-31 at 1 32 13 AM" src="https://user-images.githubusercontent.com/5506137/89016566-c72d8800-d2cd-11ea-9f52-4acf38e872b4.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 1 32 36 AM" src="https://user-images.githubusercontent.com/5506137/89016574-cbf23c00-d2cd-11ea-8479-ad3cc797addd.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 1 32 40 AM" src="https://user-images.githubusercontent.com/5506137/89016578-cd236900-d2cd-11ea-9b95-999bc269e123.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 1 32 43 AM" src="https://user-images.githubusercontent.com/5506137/89016581-ce549600-d2cd-11ea-8011-c76a097f61df.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 1 32 49 AM" src="https://user-images.githubusercontent.com/5506137/89016586-cf85c300-d2cd-11ea-949a-c8d66374c305.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 1 32 51 AM" src="https://user-images.githubusercontent.com/5506137/89016590-d0b6f000-d2cd-11ea-8c54-fb658a7cfc1c.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
