### PR TITLE
[AuditLogging] add storage instructions and callouts for editing sett…

### DIFF
--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -16,7 +16,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   EuiButton,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiGlobalToastList,
@@ -154,18 +153,6 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
           />
           {editConfig.compliance && editConfig.compliance.enabled && (
             <>
-              <EuiCallOut title="Warning" color="warning">
-                <p>
-                  Configuring Watched fields and Watched indices (compliance:read_watch_fields,
-                  compliance:write_watched_indices) will <br />
-                  generate one log per documented access, and may result in very large log files
-                  being generated if monitoring commonly <br />
-                  accessed indices and fields.
-                </p>
-              </EuiCallOut>
-
-              <EuiSpacer />
-
               <EditSettingGroup
                 settingGroup={SETTING_GROUPS.COMPLIANCE_CONFIG_SETTINGS}
                 config={editConfig}
@@ -210,21 +197,6 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
         </EuiPageHeader>
 
         <EuiPanel>
-          <EuiCallOut title="Warning" color="warning">
-            <p>
-              Enabling REST and Transport layers (config:enable_rest, config:enable_transport) may
-              result in a massive number of logs if AUTHENTICATED and GRANTED_PRIVILEGES are not
-              disabled. We suggest you ignore common requests if doing so.
-            </p>
-
-            <p>
-              Enabling Bulk requests (config:resolve_bulk_requests) will generate one log per
-              request, and may also result in very large log files.
-            </p>
-          </EuiCallOut>
-
-          <EuiSpacer />
-
           <EditSettingGroup
             settingGroup={SETTING_GROUPS.LAYER_SETTINGS}
             config={editConfig}

--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -13,6 +13,9 @@
  *   permissions and limitations under the License.
  */
 
+import { EuiText } from '@elastic/eui';
+import React from 'react';
+
 export const CONFIG_LABELS = {
   AUDIT_LOGGING: 'Audit logging',
   GENERAL_SETTINGS: 'General settings',
@@ -46,6 +49,7 @@ export interface SettingContent {
   options?: string[];
   code?: string;
   error?: string;
+  callOut?: React.ReactNode;
 }
 
 const REST_LAYER: SettingContent = {
@@ -68,6 +72,12 @@ const REST_DISABLED_CATEGORIES: SettingContent = {
     'SSL_EXCEPTION',
     'AUTHENTICATED',
   ],
+  callOut: (
+    <EuiText>
+      We <i>highly</i> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. <br />
+      If enabled, these categories can result in a hugh number of logs.
+    </EuiText>
+  ),
 };
 
 const TRANSPORT_LAYER: SettingContent = {
@@ -90,6 +100,12 @@ const TRANSPORT_DISABLED_CATEGORIES: SettingContent = {
     'SSL_EXCEPTION',
     'AUTHENTICATED',
   ],
+  callOut: (
+    <EuiText>
+      We <i>highly</i> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. <br />
+      If enabled, these categories can result in a hugh number of logs.
+    </EuiText>
+  ),
 };
 
 const BULK_REQUESTS: SettingContent = {
@@ -97,6 +113,13 @@ const BULK_REQUESTS: SettingContent = {
   path: 'audit.resolve_bulk_requests',
   description: 'Resolve bulk requests during auditing of requests.',
   type: 'bool',
+  callOut: (
+    <EuiText>
+      Enabling bulk requests generates one log per operation in the request. <br />
+      If you enable this setting, a single bulk request that indexes 10,000 documents results in
+      10,000 logs. If you disable this setting, that same request results in one log.
+    </EuiText>
+  ),
 };
 
 const REQUEST_BODY: SettingContent = {
@@ -181,6 +204,12 @@ const READ_WATCHED_FIELDS: SettingContent = {
   "twitter": ["id", "user*"]
 }`,
   error: 'Invalid content. Please check sample data content.',
+  callOut: (
+    <EuiText>
+      Adding watched fields generates one log each time a user accesses a document and could result
+      in a large number of logs. We don&apos;t recommend adding frequently accessed fields.
+    </EuiText>
+  ),
 };
 
 const WRITE_METADATA_ONLY: SettingContent = {
@@ -209,6 +238,12 @@ const WRITE_WATCHED_FIELDS: SettingContent = {
   path: 'compliance.write_watched_indices',
   description: 'List the indices to watch during write events.',
   type: 'array',
+  callOut: (
+    <EuiText>
+      Adding watched indices generates one log each time a user accesses a document and could result
+      in a large number of logs. We don&apos;t recommend adding frequently accessed indices.
+    </EuiText>
+  ),
 };
 
 const CONFIG = {

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -22,6 +22,7 @@ import {
   EuiSpacer,
   EuiSwitch,
   EuiTitle,
+  EuiCallOut,
 } from '@elastic/eui';
 import { get } from 'lodash';
 import { displayBoolean, displayObject } from '../../utils/display-utils';
@@ -38,6 +39,10 @@ const renderCodeBlock = (setting: SettingContent) => {
       </EuiCodeBlock>
     </>
   );
+};
+
+const renderCallOut = (setting: SettingContent) => {
+  return <EuiCallOut size={'s'}>{setting.callOut}</EuiCallOut>;
 };
 
 const displayLabel = (val: string) => {
@@ -140,10 +145,11 @@ export function EditSettingGroup(props: {
             <EuiDescribedFormGroup
               title={<h3>{setting.title}</h3>}
               description={
-                <>
+                <div style={{ maxWidth: '450px' }}>
                   {setting.description}
                   {setting.code && renderCodeBlock(setting)}
-                </>
+                  {setting.callOut && renderCallOut(setting)}
+                </div>
               }
               fullWidth
             >

--- a/public/apps/configuration/utils/audit-logging-view-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-view-utils.tsx
@@ -23,6 +23,7 @@ import {
   EuiSwitch,
   EuiText,
   EuiTitle,
+  EuiLink,
 } from '@elastic/eui';
 
 import React from 'react';
@@ -36,6 +37,10 @@ import {
 } from '../panels/audit-logging/types';
 
 export function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: boolean) {
+  const describedFormGroupStyle = {
+    maxWidth: '1500px',
+  };
+
   return (
     <EuiPanel>
       <EuiTitle>
@@ -46,6 +51,7 @@ export function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnable
         <EuiDescribedFormGroup
           title={<h3>Enable audit logging</h3>}
           description={<>Enable or disable audit logging</>}
+          style={describedFormGroupStyle}
         >
           <EuiFormRow>
             <EuiSwitch
@@ -54,6 +60,20 @@ export function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnable
               checked={auditLoggingEnabled}
               onChange={onSwitchChange}
             />
+          </EuiFormRow>
+        </EuiDescribedFormGroup>
+        <EuiDescribedFormGroup
+          title={<h3>Configure Storage</h3>}
+          description={<>Where should Elasticsearch store or send audit logs</>}
+          style={describedFormGroupStyle}
+        >
+          <EuiFormRow style={{ maxWidth: '800px' }}>
+            <EuiText color="subdued" grow={false}>
+              Configure the output location and storage types in elasticsearch.yml <br />
+              <EuiLink external={true} href="/">
+                Learn more in the documentation
+              </EuiLink>
+            </EuiText>
           </EuiFormRow>
         </EuiDescribedFormGroup>
       </EuiForm>


### PR DESCRIPTION
…ings

*Issue #, if available:*


*Description of changes:*
This change implements a few mockup updates from UX designer.

1. add the instruction for storage settings.
2. add a few callouts to help users edit the settings.

*Test*:
Mockup for storage settings:
<img width="1441" alt="Screen Shot 2020-07-30 at 12 01 32 AM" src="https://user-images.githubusercontent.com/60111637/88891369-efe34e00-d1f7-11ea-8cea-fa839ffe807e.png">


Implementation for storage settings:
![screencapture-localhost-5601-app-opendistro-security-2020-07-30-00_12_45](https://user-images.githubusercontent.com/60111637/88892368-7d736d80-d1f9-11ea-92b2-1d542d7f7174.png)

Mockup for callouts in general settings:
![screencapture-aws-uxdr-invisionapp-share-ZTVZTJJKURY-2020-07-30-00_13_53](https://user-images.githubusercontent.com/60111637/88892641-f2df3e00-d1f9-11ea-9e18-b6cade1b8cb7.png)



Implementation for callouts in general settings:
![screencapture-localhost-5601-app-opendistro-security-2020-07-30-00_14_15](https://user-images.githubusercontent.com/60111637/88892595-df33d780-d1f9-11ea-87e2-bcfed434b1d7.png)



Mockup for callouts in compliance settings:


![screencapture-aws-uxdr-invisionapp-share-ZTVZTJJKURY-2020-07-30-00_17_15 (1)](https://user-images.githubusercontent.com/60111637/88892744-2a4dea80-d1fa-11ea-93a1-fdc4710d667e.png)


Implementation for callouts in compliance settings:
![screencapture-localhost-5601-app-opendistro-security-2020-07-30-00_17_40](https://user-images.githubusercontent.com/60111637/88892722-21f5af80-d1fa-11ea-8dca-d36fd37f23ae.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
