### PR TITLE
return 401 instead of 500 when credentials in cookie is invalid.

### DIFF
--- a/lib/backend/errors/wrap_elasticsearch_error.js
+++ b/lib/backend/errors/wrap_elasticsearch_error.js
@@ -32,10 +32,6 @@ export default function wrapElasticsearchError(error) {
       return boomError;
   }
 
-  if (statusCode == 401) {
-    return new  AuthenticationError();
-  }
-
   return Boom.boomify(error, { statusCode: statusCode, message: message });
 
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/283

*Description of changes:* return 401 instead of 500 when credentials in cookie is invalid.

*testing*
by following the steps described in https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/283 , the current implementation returns following response when credentials in cookie is invalid:
```
{"statusCode":500,"error":"Internal Server Error","message":"An internal server error occurred"}
```
after the change, it returns:
```
{"message":"Authentication Exception: Authentication Exception","statusCode":401,"error":"Unauthorized"}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
