### PR TITLE
Backport audit logging UI changes & version bump to 0.10.1.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ export default function (kibana) {
                 },
                 {
                     id: 'security-audit',
-                    title: 'Audit',
+                    title: 'Audit logs',
                     description: 'Audit logging',
                     main: 'plugins/opendistro_security/apps/audit/app',
                     linkToLastSubUrl: false,

--- a/lib/configuration/validation/audit.js
+++ b/lib/configuration/validation/audit.js
@@ -18,7 +18,9 @@ export default Joi.object().keys({
       'BAD_HEADERS',
       'FAILED_LOGIN',
       'GRANTED_PRIVILEGES',
+      'INDEX_EVENT',
       'MISSING_PRIVILEGES',
+      'OPENDISTRO_SECURITY_INDEX_ATTEMPT',
       'SSL_EXCEPTION'
     ),
     resolve_bulk_requests: Joi.boolean(),

--- a/opendistro-elasticsearch-security-kibana-plugin.release-notes
+++ b/opendistro-elasticsearch-security-kibana-plugin.release-notes
@@ -1,4 +1,9 @@
-## 2020-01-29, Version 0.10.0.4 (Current)
+## 2020-07-31, Version 0.10.1.1 (Current)
+
+- UI to update Audit logging configuration
+- Fixed bug in redirecting to error page
+
+## 2020-01-29, Version 0.10.0.4
 - New account details UI page with support for users to change own password configured through basicauth internal user
 
 ## 2019-09-05, Version 0.10.0.3

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>com.amazon.opendistroforelasticsearch</groupId>
   <artifactId>opendistro_security_kibana_plugin</artifactId>
   <packaging>pom</packaging>
-  <version>0.10.1.0</version>
+  <version>0.10.1.1</version>
   <name>Open Distro Security for Elasticsearch Kibana Plugin</name>
   <description>Open Distro Security for Elasticsearch Kibana Plugin</description>
   <url>https://github.com/opendistro-for-elasticsearch/security-kibana-plugin</url>
@@ -55,7 +55,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security-kibana-plugin</url>
     <connection>scm:git:git@github.com:mauve-hedgehog/opendistro-elasticsearch-security-kibana-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:mauve-hedgehog/opendistro-elasticsearch-security-kibana-plugin.git</developerConnection>
-    <tag>v0.10.1.0</tag>
+    <tag>v0.10.1.1</tag>
   </scm>
 
   <issueManagement>

--- a/public/apps/audit/components/main/ContentPanel.js
+++ b/public/apps/audit/components/main/ContentPanel.js
@@ -12,7 +12,7 @@ import {
 const ContentPanel = ({ title, children, configureHandler }) => (
   <Fragment>
     <EuiPanel paddingSize="none">
-      <div style={{ padding: 20, paddingBottom: 0 }}>
+      <div style={{ padding: 20, paddingBottom: 12 }}>
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiTitle>
@@ -27,7 +27,7 @@ const ContentPanel = ({ title, children, configureHandler }) => (
         </EuiFlexGroup>
       </div>
       <EuiHorizontalRule margin="xs" />
-      <div style={{ padding: 32, paddingBottom: 0 }}>{children}</div>
+      <div style={{ padding: 24, paddingBottom: 0 }}>{children}</div>
     </EuiPanel>
   </Fragment>
 );

--- a/public/apps/audit/components/main/EditSettingGroup.js
+++ b/public/apps/audit/components/main/EditSettingGroup.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
+  EuiCallOut,
   EuiCodeBlock,
   EuiComboBox,
   EuiDescribedFormGroup,
@@ -84,9 +85,8 @@ function EditSettingGroup({
           <EuiTextColor color="subdued">
             <p>
               {setting.content}
-              <br />
               <EuiLink href={setting.url}>
-                Learn more in the documentation
+                Learn more
                 <EuiIcon type="popout" />
               </EuiLink>
             </p>
@@ -104,6 +104,20 @@ function EditSettingGroup({
         <EuiCodeBlock language="json" paddingSize="none">
           {setting.code}
         </EuiCodeBlock>
+      </Fragment>
+    );
+  };
+
+  const renderCallout = message => {
+    return (
+      <Fragment>
+        <EuiCallOut>
+          <EuiText size="s">
+            <EuiTextColor color="default">
+              <p>{message}</p>
+            </EuiTextColor>
+          </EuiText>
+        </EuiCallOut>
       </Fragment>
     );
   };
@@ -129,11 +143,12 @@ function EditSettingGroup({
                   <Fragment>
                     {setting.description}
                     {setting.code && renderCodeBlock(setting)}
+                    {setting.note && renderCallout(setting.note)}
                   </Fragment>
                 }
                 fullWidth
               >
-                <EuiFormRow label={displayLabel(setting.path)}>
+                <EuiFormRow label={setting.hideLabel ? null : displayLabel(setting.path)}>
                   {renderField(config, setting, handleChange, handleInvalid)}
                 </EuiFormRow>
               </EuiDescribedFormGroup>
@@ -146,7 +161,6 @@ function EditSettingGroup({
   return renderedSettings ? (
     <Fragment>
       {showPanel ? <EuiPanel>{renderedSettings}</EuiPanel> : renderedSettings}
-      <EuiSpacer size="xs" />
     </Fragment>
   ) : null;
 }

--- a/public/apps/audit/components/main/config.js
+++ b/public/apps/audit/components/main/config.js
@@ -1,3 +1,5 @@
+import React, { Fragment } from 'react';
+
 export const AUDIT_API = {
   PUT: '../api/v1/configuration/audit/config',
   GET: '../api/v1/configuration/audit',
@@ -29,28 +31,17 @@ export const RESPONSE_MESSAGES = {
   UPDATE_FAILURE: 'Audit configuration could not be updated. Please check configuration.',
 };
 
-export const CALLOUT_MESSAGES = {
-  AUDIT_SETTINGS: [
-    'Enabling REST and Transport layers (audit:enable_rest, audit:enable_transport) may result in a massive number of logs if AUTHENTICATED and GRANTED_PRIVILEGES are not disabled. We suggest you ignore common requests if doing so.',
-    'Enabling Bulk requests (config:audit:resolve_bulk_requests) will generate one log per request, and may also result in very large log files.',
-  ],
-  COMPLIANCE_SETTINGS: [
-    'Configuring Watched fields and Watched indices (compliance:read_watch_fields, compliance:write_watched_indices) will generate one log per document access, and may result in very large logs files being generated if monitoring commonly accessed indices and fields.',
-  ],
-};
-
 const CONFIG = {
   ENABLED: {
     title: 'Enable audit logging',
     path: 'enabled',
-    description: 'Enable or disable audit logging',
     type: 'bool',
+    hideLabel: true,
   },
   STORAGE: {
-    title: 'Configure Storage',
+    title: 'Storage location',
     path: '',
-    description: 'Where should Elasticsearch store or send audit logs',
-    content: 'Configure the output location and storage types in elasticsearch.yml',
+    content: <Fragment>Configure the output location and storage types in <code>elasticsearch.yml</code> . The default storage location is <code>internal_elasticsearch</code>, which stores the logs in an index on this cluster. </Fragment>,
     url: 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/',
     type: 'text',
   },
@@ -58,48 +49,53 @@ const CONFIG = {
     REST_LAYER: {
       title: 'REST layer',
       path: 'audit.enable_rest',
-      description: 'Enable or disable auditing events that happen on the REST layer',
+      description: 'Enable or disable auditing events that happen on the REST layer.',
       type: 'bool',
     },
     REST_DISABLED_CATEGORIES: {
       title: 'REST disabled categories',
       path: 'audit.disabled_rest_categories',
-      description: 'Specify audit categories which must be ignored on the REST layer',
+      description: 'Specify audit categories which must be ignored on the REST layer.',
       type: 'array',
       options: [
+        'AUTHENTICATED',
         'BAD_HEADERS',
         'FAILED_LOGIN',
-        'MISSING_PRIVILEGES',
         'GRANTED_PRIVILEGES',
-        'SSL_EXCEPTION',
-        'AUTHENTICATED',
+        'MISSING_PRIVILEGES',
+        'SSL_EXCEPTION'
       ],
+      note: <Fragment>We <em>highly</em> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. If enabled, these categories can result in a huge number of logs.</Fragment>,
     },
     TRANSPORT_LAYER: {
       title: 'Transport layer',
       path: 'audit.enable_transport',
-      description: 'Enable or disable auditing events that happen on the Transport layer',
+      description: 'Enable or disable auditing events that happen on the Transport layer.',
       type: 'bool',
     },
     TRANSPORT_DISABLED_CATEGORIES: {
       title: 'Transport disabled categories',
       path: 'audit.disabled_transport_categories',
-      description: 'Specify audit categories which must be ignored on the Transport layer',
+      description: 'Specify audit categories which must be ignored on the Transport layer.',
       type: 'array',
       options: [
+        'AUTHENTICATED',
         'BAD_HEADERS',
         'FAILED_LOGIN',
-        'MISSING_PRIVILEGES',
         'GRANTED_PRIVILEGES',
+        'INDEX_EVENT',
+        'MISSING_PRIVILEGES',
+        'OPENDISTRO_SECURITY_INDEX_ATTEMPT',
         'SSL_EXCEPTION',
-        'AUTHENTICATED',
       ],
+      note: <Fragment>We <em>highly</em> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. If enabled, these categories can result in a huge number of logs.</Fragment>
     },
     BULK_REQUESTS: {
       title: 'Bulk requests',
       path: 'audit.resolve_bulk_requests',
       description: 'Resolve bulk requests during auditing of requests.',
       type: 'bool',
+      note: 'Enabling bulk requests generates one log per operation in the request. If you enable this setting, a single bulk request that indexes 10,000 documents results in 10,000 logs. If you disable this setting, that same request results in one log.',
     },
     REQUEST_BODY: {
       title: 'Request body',
@@ -116,7 +112,7 @@ const CONFIG = {
     SENSITIVE_HEADERS: {
       title: 'Sensitive headers',
       path: 'audit.exclude_sensitive_headers',
-      description: 'Exclude sensitive headers during auditing. Eg: Authorization header',
+      description: 'Exclude sensitive headers during auditing. Eg: Authorization header.',
       type: 'bool',
     },
     IGNORED_USERS: {
@@ -134,27 +130,33 @@ const CONFIG = {
   },
   COMPLIANCE: {
     ENABLED: {
-      title: 'Enable compliance mode',
+      title: 'Compliance logging',
       path: 'compliance.enabled',
-      description: 'Enable or disable compliance logging',
+      description: 'Enable or disable compliance logging.',
+      type: 'bool',
+      hideLabel: true,
+    },
+    MODE: {
+      title: 'Compliance mode',
+      path: 'compliance.enabled',
       type: 'bool',
     },
     INTERNAL_CONFIG: {
       title: 'Internal config logging',
       path: 'compliance.internal_config',
-      description: 'Enable or disable logging of events on internal security index',
+      description: 'Enable or disable logging of events on internal security index.',
       type: 'bool',
     },
     EXTERNAL_CONFIG: {
       title: 'External config logging',
       path: 'compliance.external_config',
-      description: 'Enable or disable logging of external configuration',
+      description: 'Enable or disable logging of external configuration.',
       type: 'bool',
     },
     READ_METADATA_ONLY: {
       title: 'Read metadata',
       path: 'compliance.read_metadata_only',
-      description: 'Do not log any document fields. Log only metadata of the document',
+      description: 'Do not log any document fields. Log only metadata of the document.',
       type: 'bool',
     },
     READ_IGNORED_USERS: {
@@ -167,7 +169,7 @@ const CONFIG = {
       title: 'Watched fields',
       path: 'compliance.read_watched_fields',
       description:
-        'List the indices and fields to watch during read events. Sample data content is as follows',
+        'List the indices and fields to watch during read events. Sample data content is as follows:',
       type: 'map',
       code: `{
   "index-name-pattern": ["field-name-pattern"],
@@ -175,17 +177,18 @@ const CONFIG = {
   "twitter": ["id", "user*"]
 }`,
       error: 'Invalid content. Please check sample data content.',
+      note: 'Adding watched fields generates one log each time a user accesses a document and could result in a large number of logs. We don\'t recommend adding frequently accessed fields.'
     },
     WRITE_METADATA_ONLY: {
       title: 'Write metadata',
       path: 'compliance.write_metadata_only',
-      description: 'Do not log any document content. Log only metadata of the document',
+      description: 'Do not log any document content. Log only metadata of the document.',
       type: 'bool',
     },
     WRITE_LOG_DIFFS: {
       title: 'Log diffs',
       path: 'compliance.write_log_diffs',
-      description: 'Log only diffs for document updates',
+      description: 'Log only diffs for document updates.',
       type: 'bool',
     },
     WRITE_IGNORED_USERS: {
@@ -199,13 +202,14 @@ const CONFIG = {
       path: 'compliance.write_watched_indices',
       description: 'List the indices to watch during write events.',
       type: 'array',
+      note: 'Adding watched indices generates one log each time a user accesses a document and could result in a large number of logs. We don\'t recommend adding frequently accessed indices.',
     },
   },
 };
 
 export const SETTING_GROUPS = {
   AUDIT_SETTINGS: {
-    settings: [CONFIG.ENABLED, CONFIG.STORAGE],
+    settings: [CONFIG.STORAGE, CONFIG.ENABLED],
   },
   LAYER_SETTINGS: {
     title: CONFIG_LABELS.LAYER_SETTINGS,
@@ -229,9 +233,12 @@ export const SETTING_GROUPS = {
     title: CONFIG_LABELS.IGNORE_SETTINGS,
     settings: [CONFIG.AUDIT.IGNORED_USERS, CONFIG.AUDIT.IGNORED_REQUESTS],
   },
-  COMPLIANCE_MODE_SETTINGS: {
+  COMPLIANCE_LOGGING_SETTINGS: {
     title: CONFIG_LABELS.COMPLIANCE_MODE,
     settings: [CONFIG.COMPLIANCE.ENABLED],
+  },
+  COMPLIANCE_MODE_SETTINGS: {
+    settings: [CONFIG.COMPLIANCE.MODE],
   },
   COMPLIANCE_CONFIG_SETTINGS: {
     title: CONFIG_LABELS.COMPLIANCE_CONFIG_SETTINGS,

--- a/public/apps/audit/components/main/main.js
+++ b/public/apps/audit/components/main/main.js
@@ -17,7 +17,6 @@ import {
   CONFIG_LABELS,
   SETTING_GROUPS,
   RESPONSE_MESSAGES,
-  CALLOUT_MESSAGES,
   TOAST_MESSAGES,
 } from './config';
 import ContentPanel from './ContentPanel';
@@ -118,19 +117,6 @@ export class Main extends Component {
       });
   };
 
-  renderCallout = messages => {
-    return (
-      <Fragment>
-        <EuiCallOut title="Warning" color="warning">
-          {messages.map((message, index) => {
-            return <p key={index}>{message}</p>;
-          })}
-        </EuiCallOut>
-        <EuiSpacer />
-      </Fragment>
-    );
-  };
-
   renderError = () => {
     const { showError } = this.state;
     return showError ? (
@@ -180,7 +166,6 @@ export class Main extends Component {
         </EuiTitle>
         <EuiSpacer size="m" />
         <EuiPanel>
-          {this.renderCallout(CALLOUT_MESSAGES.AUDIT_SETTINGS)}
           <EditSettingGroup
             settingGroup={SETTING_GROUPS.LAYER_SETTINGS}
             config={editConfig}
@@ -215,14 +200,13 @@ export class Main extends Component {
         <EuiSpacer size="m" />
         <EuiPanel>
           <EditSettingGroup
-            settingGroup={SETTING_GROUPS.COMPLIANCE_MODE_SETTINGS}
+            settingGroup={SETTING_GROUPS.COMPLIANCE_LOGGING_SETTINGS}
             config={editConfig}
             handleChange={this.handleChange}
             readonly={readonly}
           />
           {editConfig.compliance.enabled && (
             <Fragment>
-              {this.renderCallout(CALLOUT_MESSAGES.COMPLIANCE_SETTINGS)}
               <EditSettingGroup
                 settingGroup={SETTING_GROUPS.COMPLIANCE_CONFIG_SETTINGS}
                 config={editConfig}
@@ -230,7 +214,7 @@ export class Main extends Component {
                 readonly={readonly}
                 showPanel={true}
               />
-              <EuiSpacer size="s" />
+              <EuiSpacer />
               <EditSettingGroup
                 settingGroup={SETTING_GROUPS.COMPLIANCE_READ_SETTINGS}
                 config={editConfig}
@@ -239,7 +223,7 @@ export class Main extends Component {
                 readonly={readonly}
                 showPanel={true}
               />
-              <EuiSpacer size="s" />
+              <EuiSpacer />
               <EditSettingGroup
                 settingGroup={SETTING_GROUPS.COMPLIANCE_WRITE_SETTINGS}
                 config={editConfig}
@@ -266,6 +250,7 @@ export class Main extends Component {
             handleChange={this.handleChangeWithSave}
             readonly={readonly}
           />
+          <EuiSpacer size="s" />
         </ContentPanel>
         {config.enabled && (
           <Fragment>

--- a/public/apps/audit/components/main/utils.js
+++ b/public/apps/audit/components/main/utils.js
@@ -3,7 +3,7 @@ export function displayBoolean(val) {
 }
 
 export function displayArray(val) {
-  return val && val.length != 0 ? val.join(' , ') : '--';
+  return val && val.length != 0 ? val.join(', ') : '--';
 }
 
 export function displayMap(val) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Please check PR #310 for additional details and screenshots. This is a backport PR

<img width="1392" alt="Screen Shot 2020-07-31 at 10 43 33 AM" src="https://user-images.githubusercontent.com/5506137/89062341-1f3eab80-d31b-11ea-83de-c38d38655ef8.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 10 43 39 AM" src="https://user-images.githubusercontent.com/5506137/89062353-236ac900-d31b-11ea-9d18-885d697931e5.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 10 43 42 AM" src="https://user-images.githubusercontent.com/5506137/89062362-26fe5000-d31b-11ea-8661-d526d78da557.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 10 43 49 AM" src="https://user-images.githubusercontent.com/5506137/89062364-2960aa00-d31b-11ea-96ec-2eb21352a984.png">
<img width="1392" alt="Screen Shot 2020-07-31 at 10 43 54 AM" src="https://user-images.githubusercontent.com/5506137/89062372-2bc30400-d31b-11ea-8aef-1920fedb1e4e.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
