### PR TITLE
[AuditLogging] make a dedicated read API for retrieving audit logging…

### DIFF
--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -69,7 +69,7 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
     const fetchConfig = async () => {
       try {
         const rawConfig = await props.coreStart.http.get(API_ENDPOINT_AUDITLOGGING);
-        const fetchedConfig = rawConfig.data.config;
+        const fetchedConfig = rawConfig.config;
         setEditConfig(fetchedConfig);
       } catch (e) {
         console.log(e);

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -70,7 +70,7 @@ export function AuditLogging(props: AuditLoggingProps) {
     const fetchData = async () => {
       try {
         const rawConfiguration = await props.coreStart.http.get(API_ENDPOINT_AUDITLOGGING);
-        setConfiguration(rawConfiguration.data.config);
+        setConfiguration(rawConfiguration.config);
       } catch (e) {
         // TODO: switch to better error handling.
         console.log(e);

--- a/server/backend/opendistro_security_configuration_plugin.ts
+++ b/server/backend/opendistro_security_configuration_plugin.ts
@@ -246,9 +246,19 @@ export default function (Client: any, config: any, components: any) {
   });
 
   /**
+   * Gets audit log configuration.
+   */
+  Client.prototype.opendistro_security.prototype.getAudit = ca({
+    method: 'GET',
+    url: {
+      fmt: '/_opendistro/_security/api/audit',
+    },
+  });
+
+  /**
    * Updates audit log configuration.
    */
-  Client.prototype.opendistro_security.prototype.audit = ca({
+  Client.prototype.opendistro_security.prototype.saveAudit = ca({
     method: 'PUT',
     needBody: true,
     url: {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -509,6 +509,85 @@ export function defineRoutes(router: IRouter) {
   );
 
   /**
+   * Gets audit log configuration。
+   *
+   * Sample payload:
+   * {
+   *   "enabled":true,
+   *   "audit":{
+   *     "enable_rest":false,
+   *     "disabled_rest_categories":[
+   *       "FAILED_LOGIN",
+   *       "AUTHENTICATED"
+   *     ],
+   *     "enable_transport":true,
+   *     "disabled_transport_categories":[
+   *       "GRANTED_PRIVILEGES"
+   *     ],
+   *     "resolve_bulk_requests":true,
+   *     "log_request_body":false,
+   *     "resolve_indices":true,
+   *     "exclude_sensitive_headers":true,
+   *     "ignore_users":[
+   *       "admin",
+   *     ],
+   *     "ignore_requests":[
+   *       "SearchRequest",
+   *       "indices:data/read/*"
+   *     ]
+   *   },
+   *   "compliance":{
+   *     "enabled":true,
+   *     "internal_config":false,
+   *     "external_config":false,
+   *     "read_metadata_only":false,
+   *     "read_watched_fields":{
+   *       "indexName1":[
+   *         "field1",
+   *         "fields-*"
+   *       ]
+   *     },
+   *     "read_ignore_users":[
+   *       "kibanaserver",
+   *       "operator/*"
+   *     ],
+   *     "write_metadata_only":false,
+   *     "write_log_diffs":false,
+   *     "write_watched_indices":[
+   *       "indexName2",
+   *       "indexPatterns-*"
+   *     ],
+   *     "write_ignore_users":[
+   *       "admin"
+   *     ]
+   *   }
+   * }
+   */
+  router.get(
+    {
+      path: `${API_PREFIX}/configuration/audit`,
+      validate: false,
+    },
+    async (context, request, response): Promise<IKibanaResponse<any | ResponseError>> => {
+      const client = context.security_plugin.esClient.asScoped(request);
+
+      let esResp;
+      try {
+        esResp = await client.callAsCurrentUser('opendistro_security.getAudit');
+
+        return response.ok({
+          body: esResp,
+        });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode,
+          body: parseEsErrorResponse(error),
+        });
+      }
+    }
+  );
+
+  /**
    * Update audit log configuration。
    *
    * Sample payload:
@@ -574,7 +653,7 @@ export function defineRoutes(router: IRouter) {
       const client = context.security_plugin.esClient.asScoped(request);
       let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opendistro_security.audit', {
+        esResp = await client.callAsCurrentUser('opendistro_security.saveAudit', {
           body: request.body,
         });
         return response.ok({


### PR DESCRIPTION
… configuration

*Issue #, if available:*

*Description of changes:*

The read API for audit logging happens to work because it meets the format of "listResource". Since audit logging configuration is not a resource, e.g role, this change will create a read API for it. Also we will rename the existing update API to reflect the name difference.

*Test*
Verify the read and edit view works.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
