### PR TITLE
Fix a bug that not able to delete permission group

### DIFF
--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -85,3 +85,9 @@ export async function updateActionGroup(
     body: JSON.stringify(updateObject),
   });
 }
+
+export async function requestDeleteActionGroups(http: HttpStart, groups: string[]) {
+  for (const group of groups) {
+    await http.delete(`${API_ENDPOINT_ACTIONGROUPS}/${group}`);
+  }
+}

--- a/public/apps/configuration/utils/internal-user-list-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-list-utils.tsx
@@ -26,6 +26,7 @@ export function transformUserData(rawData: DataObject<InternalUser>): InternalUs
   return map(rawData, (value: InternalUser, key?: string) => ({
     username: key || '',
     attributes: value.attributes,
+    backend_roles: value.backend_roles,
   }));
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fix a bug that permission group deletion doesn't work
2. Fix a bug that delete button is enabled when selecting reserved permission
3. Some minor type fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
