### PR TITLE
Show permission tree on permission listing

### DIFF
--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -48,7 +48,7 @@ import React, {
 import { AppDependencies } from '../../../types';
 import { Action, DataObject, ActionGroupItem } from '../../types';
 import {
-  ActionGroupListingItem,
+  PermissionListingItem,
   requestDeleteActionGroups,
   updateActionGroup,
   fetchActionGroups,
@@ -69,7 +69,7 @@ function renderBooleanToCheckMark(value: boolean): React.ReactNode {
 }
 
 function toggleRowDetails(
-  item: ActionGroupListingItem,
+  item: PermissionListingItem,
   actionGroupDict: DataObject<ActionGroupItem>,
   setItemIdToExpandedRowMap: Dispatch<SetStateAction<ExpandedRowMapInterface>>
 ) {
@@ -78,7 +78,9 @@ function toggleRowDetails(
     if (itemIdToExpandedRowMapValues[item.name]) {
       delete itemIdToExpandedRowMapValues[item.name];
     } else {
-      itemIdToExpandedRowMapValues[item.name] = (<PermissionTree permissions={item.allowedActions} actionGroups={actionGroupDict} />)
+      itemIdToExpandedRowMapValues[item.name] = (
+        <PermissionTree permissions={item.allowedActions} actionGroups={actionGroupDict} />
+      );
     }
     return itemIdToExpandedRowMapValues;
   });
@@ -88,7 +90,7 @@ function getColumns(
   itemIdToExpandedRowMap: ExpandedRowMapInterface,
   actionGroupDict: DataObject<ActionGroupItem>,
   setItemIdToExpandedRowMap: Dispatch<SetStateAction<ExpandedRowMapInterface>>
-): Array<EuiBasicTableColumn<ActionGroupListingItem>> {
+): Array<EuiBasicTableColumn<PermissionListingItem>> {
   return [
     {
       field: 'name',
@@ -119,7 +121,7 @@ function getColumns(
       align: RIGHT_ALIGNMENT,
       width: '40px',
       isExpander: true,
-      render: (item: ActionGroupListingItem) =>
+      render: (item: PermissionListingItem) =>
         item.type === 'Action group' && (
           <EuiButtonIcon
             onClick={() => toggleRowDetails(item, actionGroupDict, setItemIdToExpandedRowMap)}
@@ -168,10 +170,10 @@ const SEARCH_OPTIONS: EuiSearchBarProps = {
 };
 
 export function PermissionList(props: AppDependencies) {
-  const [actionGroups, setActionGroups] = useState<ActionGroupListingItem[]>([]);
+  const [permissionList, setPermissionList] = useState<PermissionListingItem[]>([]);
   const [actionGroupDict, setActionGroupDict] = useState<DataObject<ActionGroupItem>>({});
   const [errorFlag, setErrorFlag] = useState<boolean>(false);
-  const [selection, setSelection] = useState<ActionGroupListingItem[]>([]);
+  const [selection, setSelection] = useState<PermissionListingItem[]>([]);
   const [isActionsPopoverOpen, setActionsPopoverOpen] = useState<boolean>(false);
   const [isCreateActionGroupPopoverOpen, setCreateActionGroupPopoverOpen] = useState<boolean>(
     false
@@ -187,7 +189,7 @@ export function PermissionList(props: AppDependencies) {
     try {
       const actionGroups = await fetchActionGroups(props.coreStart.http);
       setActionGroupDict(actionGroups);
-      setActionGroups(await getAllPermissionsListingLocal(actionGroups));
+      setPermissionList(await getAllPermissionsListingLocal(actionGroups));
     } catch (e) {
       console.log(e);
       setErrorFlag(true);
@@ -202,7 +204,7 @@ export function PermissionList(props: AppDependencies) {
     const groupsToDelete: string[] = selection.map((r) => r.name);
     try {
       await requestDeleteActionGroups(props.coreStart.http, groupsToDelete);
-      setActionGroups(difference(actionGroups, selection));
+      setPermissionList(difference(permissionList, selection));
       setSelection([]);
     } catch (e) {
       console.log(e);
@@ -247,7 +249,7 @@ export function PermissionList(props: AppDependencies) {
         groupName={initialGroupName}
         action={action}
         allowedActions={initialAllowedAction}
-        optionUniverse={actionGroups.map((group) => stringToComboBoxOption(group.name))}
+        optionUniverse={permissionList.map((group) => stringToComboBoxOption(group.name))}
         handleClose={() => setEditModal(null)}
         handleSave={async (groupName, allowedAction) => {
           try {
@@ -332,7 +334,7 @@ export function PermissionList(props: AppDependencies) {
         <EuiPageContentHeader>
           <EuiPageContentHeaderSection>
             <EuiTitle size="s">
-              <h3>Permissions ({actionGroups.length})</h3>
+              <h3>Permissions ({permissionList.length})</h3>
             </EuiTitle>
             <EuiText size="xs" color="subdued">
               Permissions defines type of access to the cluster or the specified indices. An action
@@ -377,9 +379,9 @@ export function PermissionList(props: AppDependencies) {
         </EuiPageContentHeader>
         <EuiPageBody>
           <EuiInMemoryTable
-            loading={actionGroups === [] && !errorFlag}
+            loading={permissionList === [] && !errorFlag}
             columns={getColumns(itemIdToExpandedRowMap, actionGroupDict, setItemIdToExpandedRowMap)}
-            items={actionGroups}
+            items={permissionList}
             itemId={'name'}
             pagination
             search={SEARCH_OPTIONS}

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -52,7 +52,7 @@ import {
   requestDeleteActionGroups,
   updateActionGroup,
   fetchActionGroups,
-  getAllPermissionsListingLocal,
+  mergeAllPermissions,
 } from '../../utils/action-groups-utils';
 import { stringToComboBoxOption } from '../../utils/combo-box-utils';
 import { renderCustomization } from '../../utils/display-utils';
@@ -189,7 +189,7 @@ export function PermissionList(props: AppDependencies) {
     try {
       const actionGroups = await fetchActionGroups(props.coreStart.http);
       setActionGroupDict(actionGroups);
-      setPermissionList(await getAllPermissionsListingLocal(actionGroups));
+      setPermissionList(await mergeAllPermissions(actionGroups));
     } catch (e) {
       console.log(e);
       setErrorFlag(true);

--- a/public/apps/configuration/panels/permission-tree.tsx
+++ b/public/apps/configuration/panels/permission-tree.tsx
@@ -1,0 +1,53 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { EuiTreeView, EuiIcon } from '@elastic/eui';
+import { Node } from '@elastic/eui/src/components/tree_view/tree_view';
+import React from 'react';
+import { ActionGroupItem, DataObject } from '../types';
+
+const MAX_DEPTH = 5;
+
+function buildTreeItem(
+  name: string,
+  depth: number,
+  actionGroups: DataObject<ActionGroupItem>
+): Node {
+  let children: string[] | null = null;
+  if (depth < MAX_DEPTH) children = actionGroups[name]?.allowed_actions;
+
+  return {
+    label: name,
+    id: name,
+    icon: <EuiIcon type="dot" />,
+    children: children?.map((child) => buildTreeItem(child, depth + 1, actionGroups)),
+  };
+}
+
+export function PermissionTree(props: {
+  permissions: string[];
+  actionGroups: DataObject<ActionGroupItem>;
+}) {
+  return (
+    <EuiTreeView
+      display="compressed"
+      aria-label="Permission tree"
+      showExpansionArrows
+      items={props.permissions.map((permission) =>
+        buildTreeItem(permission, 0, props.actionGroups)
+      )}
+    />
+  );
+}

--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -72,8 +72,15 @@ function getIndexSinglePermissions(): ActionGroupListingItem[] {
 }
 
 export async function getAllPermissionsListing(http: HttpStart): Promise<ActionGroupListingItem[]> {
-  const actionGroups = await fetchActionGroupListing(http);
-  return actionGroups.concat(getClusterSinglePermissions()).concat(getIndexSinglePermissions());
+  return getAllPermissionsListingLocal(await fetchActionGroups(http));
+}
+
+export async function getAllPermissionsListingLocal(
+  actionGroups: DataObject<ActionGroupItem>
+): Promise<ActionGroupListingItem[]> {
+  return tranformActionGroupsToListingFormat(actionGroups)
+    .concat(getClusterSinglePermissions())
+    .concat(getIndexSinglePermissions());
 }
 
 export async function updateActionGroup(

--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -18,7 +18,7 @@ import { map } from 'lodash';
 import { API_ENDPOINT_ACTIONGROUPS, CLUSTER_PERMISSIONS, INDEX_PERMISSIONS } from '../constants';
 import { DataObject, ActionGroupItem, ActionGroupUpdate } from '../types';
 
-export interface ActionGroupListingItem {
+export interface PermissionListingItem {
   name: string;
   type: 'Action group' | 'Single permission';
   reserved: boolean;
@@ -34,7 +34,7 @@ export async function fetchActionGroups(http: HttpStart): Promise<DataObject<Act
 
 function tranformActionGroupsToListingFormat(
   rawData: DataObject<ActionGroupItem>
-): ActionGroupListingItem[] {
+): PermissionListingItem[] {
   return map(rawData, (value: ActionGroupItem, key?: string) => ({
     name: key || '',
     type: 'Action group',
@@ -45,11 +45,11 @@ function tranformActionGroupsToListingFormat(
   }));
 }
 
-export async function fetchActionGroupListing(http: HttpStart): Promise<ActionGroupListingItem[]> {
+export async function fetchActionGroupListing(http: HttpStart): Promise<PermissionListingItem[]> {
   return tranformActionGroupsToListingFormat(await fetchActionGroups(http));
 }
 
-function getClusterSinglePermissions(): ActionGroupListingItem[] {
+function getClusterSinglePermissions(): PermissionListingItem[] {
   return CLUSTER_PERMISSIONS.map((permission) => ({
     name: permission,
     type: 'Single permission',
@@ -60,7 +60,7 @@ function getClusterSinglePermissions(): ActionGroupListingItem[] {
   }));
 }
 
-function getIndexSinglePermissions(): ActionGroupListingItem[] {
+function getIndexSinglePermissions(): PermissionListingItem[] {
   return INDEX_PERMISSIONS.map((permission) => ({
     name: permission,
     type: 'Single permission',
@@ -71,13 +71,13 @@ function getIndexSinglePermissions(): ActionGroupListingItem[] {
   }));
 }
 
-export async function getAllPermissionsListing(http: HttpStart): Promise<ActionGroupListingItem[]> {
+export async function getAllPermissionsListing(http: HttpStart): Promise<PermissionListingItem[]> {
   return getAllPermissionsListingLocal(await fetchActionGroups(http));
 }
 
 export async function getAllPermissionsListingLocal(
   actionGroups: DataObject<ActionGroupItem>
-): Promise<ActionGroupListingItem[]> {
+): Promise<PermissionListingItem[]> {
   return tranformActionGroupsToListingFormat(actionGroups)
     .concat(getClusterSinglePermissions())
     .concat(getIndexSinglePermissions());

--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -72,10 +72,10 @@ function getIndexSinglePermissions(): PermissionListingItem[] {
 }
 
 export async function getAllPermissionsListing(http: HttpStart): Promise<PermissionListingItem[]> {
-  return getAllPermissionsListingLocal(await fetchActionGroups(http));
+  return mergeAllPermissions(await fetchActionGroups(http));
 }
 
-export async function getAllPermissionsListingLocal(
+export async function mergeAllPermissions(
   actionGroups: DataObject<ActionGroupItem>
 ): Promise<PermissionListingItem[]> {
   return tranformActionGroupsToListingFormat(actionGroups)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On permission listing page, show a expansible permission tree when expanding a row.

Since there is no existing component similar to mockup, using `EuiTree` as an interim solution.

Since the backend doesn't block circular reference, set max depth to 5 to avoid infinite loop.

Mockup:
![image](https://user-images.githubusercontent.com/63078162/89451970-d1a6b200-d711-11ea-9e30-e94c0b35d689.png)

Implementation:
![image](https://user-images.githubusercontent.com/63078162/89451756-8b515300-d711-11ea-81b4-d2cfef983f5b.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
