### PR TITLE
Fix login popup when access login page for the fisrt time

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -19,6 +19,7 @@ export const PLUGIN_NAME = 'opendistro_security';
 export const API_PREFIX = '/api/v1';
 export const CONFIGURATION_API_PREFIX = 'configuration';
 export const API_ENDPOINT_AUTHINFO = API_PREFIX + '/auth/authinfo';
+export const LOGIN_PAGE_URI = '/app/login';
 
 export enum AuthType {
   BASIC = 'basicauth',

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -26,7 +26,7 @@ import {
   AppPluginStartDependencies,
   ClientConfigType,
 } from './types';
-import { PLUGIN_NAME } from '../common';
+import { LOGIN_PAGE_URI, PLUGIN_NAME } from '../common';
 
 export class OpendistroSecurityPlugin
   implements Plugin<OpendistroSecurityPluginSetup, OpendistroSecurityPluginStart> {
@@ -50,7 +50,7 @@ export class OpendistroSecurityPlugin
       id: 'login',
       title: 'Security',
       chromeless: true,
-      appRoute: '/app/login',
+      appRoute: `${LOGIN_PAGE_URI}`,
       mount: async (params: AppMountParameters) => {
         const { renderApp } = await import('./apps/login/login-app');
         // @ts-ignore depsStart not used.

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -72,6 +72,12 @@ export abstract class AuthenticationType implements IAuthenticationType {
   }
 
   public authHandler: AuthenticationHandler = async (request, response, toolkit) => {
+    // allow access to assets
+    if (request.url.pathname && request.url.pathname.startsWith('/bundles/')) {
+      return toolkit.notHandled();
+    }
+
+    // skip auth for APIs that do not require auth
     if (this.authNotRequired(request)) {
       return toolkit.authenticated();
     }
@@ -170,10 +176,6 @@ export abstract class AuthenticationType implements IAuthenticationType {
     const pathname = request.url.pathname;
     if (!pathname) {
       return false;
-    }
-    // allow access to assets
-    if (pathname!.startsWith('/bundles/')) {
-      return true;
     }
     // allow requests to ignored routes
     if (AuthenticationType.ROUTES_TO_IGNORE.includes(pathname!)) {

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -32,6 +32,7 @@ import { SecurityPluginConfigType } from '../../..';
 import { SecuritySessionCookie } from '../../../session/security_cookie';
 import { BasicAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
+import { LOGIN_PAGE_URI } from '../../../../common';
 
 // TODO: change to interface
 export class AuthConfig {
@@ -130,7 +131,7 @@ export class BasicAuthentication extends AuthenticationType {
     toolkit: AuthToolkit
   ): KibanaResponse {
     const nextUrlParam = this.composeNextUrlQeuryParam(request);
-    const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}/app/login?${nextUrlParam}`;
+    const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}${LOGIN_PAGE_URI}?${nextUrlParam}`;
     return response.redirected({
       headers: {
         location: `${redirectLocation}`,

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -22,6 +22,7 @@ import { filterAuthHeaders } from '../../../utils/filter_auth_headers';
 import { User } from '../../user';
 import { SecurityClient } from '../../../backend/opendistro_security_client';
 import { CoreSetup } from '../../../../../../src/core/server';
+import { LOGIN_PAGE_URI } from '../../../../common';
 
 export class BasicAuthRoutes {
   constructor(
@@ -36,6 +37,21 @@ export class BasicAuthRoutes {
   ) {}
 
   public setupRoutes() {
+    // bootstrap an empty page so that browser app can render the login page
+    // using client side routing.
+    this.coreSetup.http.resources.register(
+      {
+        path: `${LOGIN_PAGE_URI}`,
+        validate: false,
+        options: {
+          authRequired: false,
+        },
+      },
+      async (context, request, response) => {
+        return response.renderAnonymousCoreApp();
+      }
+    );
+
     // login using username and password
     this.router.post(
       {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* since we are now depending on client side rendering for login page, we need to bootstrap the client app before the browser side routing/rendering can work.

Register `/app/login` as resource and bootstrap an empty page, to prevent login popup when accessing kibana for the fisrt time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
