### PR TITLE
limit security configuration pages to users with API permission only

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -24,6 +24,7 @@ export const API_ENDPOINT_SECURITYCONFIG = API_ENDPOINT + '/securityconfig';
 export const API_ENDPOINT_INTERNALUSERS = API_ENDPOINT + '/internalusers';
 export const API_ENDPOINT_AUDITLOGGING = API_ENDPOINT + '/audit';
 export const API_ENDPOINT_AUDITLOGGING_UPDATE = API_ENDPOINT_AUDITLOGGING + '/config';
+export const API_ENDPOINT_PERMISSIONS_INFO = API_ENDPOINT + '/permissionsinfo';
 
 export const CLUSTER_PERMISSIONS = [
   'cluster:admin/ingest/pipeline/delete',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds some permission control about the security configuration pages. During plugin setup, it will check the user's permission information and only register configuration app if the user has "has_api_access" set to true. The reason to use this field to control access is that if the user has API access, then they will be able to configure the security setup by calling APIs either through dev tools or ES directly. Thus use the same logic to control the UX. (This is the same strategy for 6.x and 7.x experiences.)

*Test*:
If this field is false, this is how the UI looks like.

Side bar: note that the security icon is no longer shown.
<img width="1274" alt="Screen Shot 2020-08-05 at 4 31 11 PM" src="https://user-images.githubusercontent.com/60111637/89473992-37f2fb00-d739-11ea-9da9-b60c4a12231f.png">

If the user knows the URL, this is how it looks like if they enter URL directly.
<img width="2551" alt="Screen Shot 2020-08-05 at 4 31 22 PM" src="https://user-images.githubusercontent.com/60111637/89474003-40e3cc80-d739-11ea-83d3-bbc89e836ad0.png">





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
