### PR TITLE
Add tenant management

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -39,6 +39,7 @@ import {
 import { PermissionList } from './panels/permission-list/permission-list';
 import { GetStarted } from './panels/get-started';
 import { RoleEditMappedUser } from './panels/role-mapping/RoleEditMappedUser';
+import { TenantList } from './panels/tenant-list/tenant-list';
 
 const ROUTE_MAP: { [key: string]: RouteItem } = {
   getStarted: {
@@ -227,6 +228,9 @@ export function AppRouter(props: AppDependencies) {
             />
             <Route path={ROUTE_MAP.permissions.href}>
               <PermissionList {...props} />
+            </Route>
+            <Route path={ROUTE_MAP.tenants.href}>
+              <TenantList {...props} />
             </Route>
             <Route path={ROUTE_MAP.getStarted.href}>
               <GetStarted {...props} />

--- a/public/apps/configuration/configuration-app.tsx
+++ b/public/apps/configuration/configuration-app.tsx
@@ -18,15 +18,16 @@ import './_index.scss';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
-import { AppPluginStartDependencies } from '../../types';
+import { AppPluginStartDependencies, ClientConfigType } from '../../types';
 import { AppRouter } from './app-router';
 
 export function renderApp(
   coreStart: CoreStart,
   navigation: AppPluginStartDependencies,
-  params: AppMountParameters
+  params: AppMountParameters,
+  config: ClientConfigType
 ) {
-  const deps = { coreStart, navigation, params };
+  const deps = { coreStart, navigation, params, config };
   ReactDOM.render(<AppRouter {...deps} />, params.element);
   return () => ReactDOM.unmountComponentAtNode(params.element);
 }

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -20,6 +20,7 @@ export const API_ENDPOINT_ROLES = API_ENDPOINT + '/roles';
 export const API_ENDPOINT_ROLESMAPPING = API_ENDPOINT + '/rolesmapping';
 export const API_ENDPOINT_ACTIONGROUPS = API_ENDPOINT + '/actiongroups';
 export const API_ENDPOINT_TENANTS = API_ENDPOINT + '/tenants';
+export const API_ENDPOINT_MULTITENANCY = API_PREFIX + '/multitenancy/tenant';
 export const API_ENDPOINT_SECURITYCONFIG = API_ENDPOINT + '/securityconfig';
 export const API_ENDPOINT_INTERNALUSERS = API_ENDPOINT + '/internalusers';
 export const API_ENDPOINT_AUDITLOGGING = API_ENDPOINT + '/audit';

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -1,0 +1,106 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
+  EuiForm,
+  EuiFieldText,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+import { Action } from '../../types';
+import { FormRow } from '../../utils/form-row';
+
+interface TenantEditModalDeps {
+  tenantName: string;
+  tenantDescription: string;
+  action: Action;
+  handleClose: () => void;
+  handleSave: (tenantName: string, tenantDescription: string) => Promise<void>;
+}
+
+const TITLE_DICT: { [key: string]: string } = {
+  [Action.create]: 'Create tenant',
+  [Action.edit]: 'Edit tenant',
+  [Action.duplicate]: 'Duplicate tenant',
+};
+
+export function TenantEditModal(props: TenantEditModalDeps) {
+  const [tenantName, setTenantName] = useState<string>(props.tenantName);
+  const [tenantDescription, setTenantDescription] = useState<string>(props.tenantDescription);
+
+  const handleTenantNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTenantName(e.target.value);
+  };
+
+  const handleTenantDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTenantDescription(e.target.value);
+  };
+
+  return (
+    <EuiOverlayMask>
+      <EuiModal onClose={props.handleClose}>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>{TITLE_DICT[props.action]}</EuiModalHeaderTitle>
+        </EuiModalHeader>
+
+        <EuiModalBody>
+          <EuiForm>
+            <FormRow
+              headerText="Name"
+              headerSubText="Specify a descriptive and unique role name that is easy to recognize. You cannot edit the name once the tenant is created."
+              helpText="The tenant name must contain from m to n characters. Valid characters are lowercase a-z, 0-9, and -(hyphen)."
+            >
+              <EuiFieldText
+                disabled={props.action === 'edit'}
+                value={tenantName}
+                onChange={handleTenantNameChange}
+              />
+            </FormRow>
+            <FormRow
+              headerText="Description - optional"
+              headerSubText="Describe the purpose of the tenant."
+            >
+              <EuiFieldText
+                placeholder="Describe the tenant"
+                value={tenantDescription}
+                onChange={handleTenantDescriptionChange}
+              />
+            </FormRow>
+          </EuiForm>
+        </EuiModalBody>
+
+        <EuiModalFooter>
+          <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
+
+          <EuiButton
+            onClick={async () => {
+              await props.handleSave(tenantName, tenantDescription);
+            }}
+            fill
+          >
+            {props.action === Action.create ? 'Create' : 'Save'}
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
+}

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -24,6 +24,8 @@ import {
   EuiOverlayMask,
   EuiForm,
   EuiFieldText,
+  EuiTextArea,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { Action } from '../../types';
@@ -51,7 +53,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
     setTenantName(e.target.value);
   };
 
-  const handleTenantDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTenantDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTenantDescription(e.target.value);
   };
 
@@ -66,7 +68,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
           <EuiForm>
             <FormRow
               headerText="Name"
-              headerSubText="Specify a descriptive and unique role name that is easy to recognize. You cannot edit the name once the tenant is created."
+              headerSubText="Specify a descriptive and unique tenant name that is easy to recognize. You cannot edit the name once the tenant is created."
               helpText="The tenant name must contain from m to n characters. Valid characters are lowercase a-z, 0-9, and -(hyphen)."
             >
               <EuiFieldText
@@ -76,10 +78,11 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               />
             </FormRow>
             <FormRow
-              headerText="Description - optional"
+              headerText="Description"
               headerSubText="Describe the purpose of the tenant."
+              optional
             >
-              <EuiFieldText
+              <EuiTextArea
                 placeholder="Describe the tenant"
                 value={tenantDescription}
                 onChange={handleTenantDescriptionChange}
@@ -87,7 +90,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
             </FormRow>
           </EuiForm>
         </EuiModalBody>
-
+        <EuiHorizontalRule margin="xs" />
         <EuiModalFooter>
           <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
 

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -1,0 +1,371 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  EuiBadge,
+  EuiButton,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentHeader,
+  EuiPageContentHeaderSection,
+  EuiPageHeader,
+  EuiPopover,
+  EuiText,
+  EuiTitle,
+  EuiGlobalToastList,
+  EuiOverlayMask,
+  EuiConfirmModal,
+} from '@elastic/eui';
+import React, { ReactNode, useEffect, useState, useCallback } from 'react';
+import { difference } from 'lodash';
+import { getAuthInfo } from '../../../../utils/auth-info-utils';
+import { AppDependencies } from '../../../types';
+import { Action, Tenant } from '../../types';
+import { renderCustomization } from '../../utils/display-utils';
+import {
+  fetchTenants,
+  transformTenantData,
+  fetchCurrentTenant,
+  resolveTenantName,
+  updateTenant,
+  requestDeleteTenant,
+  selectTenant,
+} from '../../utils/tenant-utils';
+import { getNavLinkById } from '../../../../services/chrome_wrapper';
+import { TenantEditModal } from './edit-modal';
+import { useToastState } from '../../utils/toast-utils';
+
+const PAGEID_DICT: { [key: string]: string } = {
+  DashboardId: 'dashboards',
+  VisualizationId: 'visualize',
+};
+
+export function TenantList(props: AppDependencies) {
+  const [tenantData, setTenantData] = useState<Tenant[]>([]);
+  const [errorFlag, setErrorFlag] = useState(false);
+  const [selection, setSelection] = useState<Tenant[]>([]);
+  const [isActionsPopoverOpen, setActionsPopoverOpen] = useState(false);
+  const [currentTenant, setCurrentTenant] = useState('');
+  const [currentUsername, setCurrentUsername] = useState('');
+  // Modal state
+  const [editModal, setEditModal] = useState<ReactNode>(null);
+  const [toasts, addToast, removeToast] = useToastState();
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const closeModal = () => setIsModalVisible(false);
+  const showModal = () => setIsModalVisible(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const rawTenantData = await fetchTenants(props.coreStart.http);
+      const processedTenantData = transformTenantData(rawTenantData);
+      const activeTenant = await fetchCurrentTenant(props.coreStart.http);
+      setCurrentTenant(resolveTenantName(activeTenant, currentUsername));
+      setTenantData(processedTenantData);
+    } catch (e) {
+      console.log(e);
+      setErrorFlag(true);
+    }
+  }, [currentUsername, props.coreStart.http]);
+
+  useEffect(() => {
+    const fetchCurrentUser = async () => {
+      setCurrentUsername((await getAuthInfo(props.coreStart.http)).user_name);
+    };
+    fetchCurrentUser();
+    fetchData();
+  }, [props.coreStart.http, fetchData]);
+
+  const handleDelete = async () => {
+    const tenantsToDelete: string[] = selection.map((r) => r.tenant);
+    try {
+      await requestDeleteTenant(props.coreStart.http, tenantsToDelete);
+      setTenantData(difference(tenantData, selection));
+      setSelection([]);
+      closeModal();
+    } catch (e) {
+      console.log(e);
+    } finally {
+      setActionsPopoverOpen(false);
+    }
+  };
+
+  const handleTenantSelection = async (tenantname: string, redirectPageId: string) => {
+    try {
+      const selectedTenant = await selectTenant(props.coreStart.http, {
+        tenant: tenantname,
+        username: currentUsername,
+      });
+      setCurrentTenant(resolveTenantName(selectedTenant, currentUsername));
+      setSelection([]);
+      if (redirectPageId) {
+        window.location.href = getNavLinkById(props.coreStart, redirectPageId);
+      } else {
+        addToast({
+          id: 'selectSucceeded',
+          title: `Selected tenant is now ${tenantname}`,
+          color: 'success',
+        });
+      }
+    } catch (e) {
+      console.log(e);
+      addToast({
+        id: 'selectFailed',
+        title: `Failed to selet ${tenantname} tenant. You may refresh the page to retry or see browser console for more information.`,
+        color: 'danger',
+      });
+    } finally {
+      setActionsPopoverOpen(false);
+    }
+  };
+
+  const columns = [
+    {
+      field: 'tenant',
+      name: 'Name',
+      render: (tenantname: string) => (
+        <>
+          {tenantname}
+          {tenantname === currentTenant && (
+            <>
+              &nbsp;
+              <EuiBadge>Current</EuiBadge>
+            </>
+          )}
+        </>
+      ),
+      sortable: true,
+    },
+    {
+      field: 'description',
+      name: 'Description',
+      truncateText: true,
+    },
+    {
+      field: 'tenantValue',
+      name: 'View Dashboard',
+      render: (tenant: string) => (
+        <>
+          <EuiLink onClick={() => handleTenantSelection(tenant, PAGEID_DICT.DashboardId)}>
+            View Dashboard
+          </EuiLink>
+        </>
+      ),
+    },
+    {
+      field: 'tenantValue',
+      name: 'View Visualizations',
+      render: (tenant: string) => (
+        <>
+          <EuiLink onClick={() => handleTenantSelection(tenant, PAGEID_DICT.VisualizationId)}>
+            View Visualizations
+          </EuiLink>
+        </>
+      ),
+    },
+    {
+      field: 'reserved',
+      name: 'Customization',
+      render: renderCustomization,
+    },
+  ];
+
+  let deleteConfirmModal;
+
+  if (isModalVisible) {
+    deleteConfirmModal = (
+      <EuiOverlayMask>
+        <EuiConfirmModal
+          title="Confirm Delete"
+          onCancel={closeModal}
+          onConfirm={handleDelete}
+          cancelButtonText="Cancel"
+          confirmButtonText="Confirm"
+          defaultFocusedButton="confirm"
+        >
+          <p>Do you really want to delete selected {selection.length} tenants?</p>
+        </EuiConfirmModal>
+      </EuiOverlayMask>
+    );
+  }
+
+  const actionsMenuItems = [
+    <EuiContextMenuItem
+      key="switchTenant"
+      disabled={selection.length !== 1}
+      onClick={() => handleTenantSelection(selection[0].tenantValue, '')}
+    >
+      Switch to selected tenant
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="edit"
+      disabled={selection.length !== 1 || selection[0].reserved}
+      onClick={() => showEditModal(selection[0].tenant, Action.edit, selection[0].description)}
+    >
+      Edit
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="duplicate"
+      disabled={selection.length !== 1}
+      onClick={() =>
+        showEditModal(selection[0].tenant + '_copy', Action.duplicate, selection[0].description)
+      }
+    >
+      Duplicate
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="createDashboard"
+      disabled={selection.length !== 1}
+      onClick={() => handleTenantSelection(selection[0].tenantValue, PAGEID_DICT.DashboardId)}
+    >
+      Create dashboard
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="createVisualizations"
+      disabled={selection.length !== 1}
+      onClick={() => handleTenantSelection(selection[0].tenantValue, PAGEID_DICT.VisualizationId)}
+    >
+      Create visualizations
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="delete"
+      onClick={showModal}
+      disabled={selection.length === 0 || selection.some((tenant) => tenant.reserved)}
+    >
+      Delete
+    </EuiContextMenuItem>,
+  ];
+
+  const actionsButton = (
+    <EuiButton
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={() => {
+        setActionsPopoverOpen(true);
+      }}
+    >
+      Actions
+    </EuiButton>
+  );
+
+  const showEditModal = (
+    initialTenantName: string,
+    action: Action,
+    initialTenantDescription: string
+  ) => {
+    setEditModal(
+      <TenantEditModal
+        tenantName={initialTenantName}
+        tenantDescription={initialTenantDescription}
+        action={action}
+        handleClose={() => setEditModal(null)}
+        handleSave={async (tenantName: string, tenantDescription: string) => {
+          try {
+            await updateTenant(props.coreStart.http, tenantName, {
+              description: tenantDescription,
+            });
+            setEditModal(null);
+            fetchData();
+            addToast({
+              id: 'saveSucceeded',
+              title: `${tenantName} saved.`,
+              color: 'success',
+            });
+          } catch (e) {
+            console.log(e);
+            addToast({
+              id: 'saveFailed',
+              title: `Failed to save ${action} tenant. You may refresh the page to retry or see browser console for more information.`,
+              color: 'danger',
+            });
+          }
+        }}
+      />
+    );
+  };
+
+  return (
+    <>
+      <EuiPageHeader>
+        <EuiTitle size="l">
+          <h1>Tenants</h1>
+        </EuiTitle>
+      </EuiPageHeader>
+      <EuiPageContent>
+        <EuiPageContentHeader>
+          <EuiPageContentHeaderSection>
+            <EuiTitle size="s">
+              <h3>Tenants ({tenantData.length})</h3>
+            </EuiTitle>
+            <EuiText size="xs" color="subdued">
+              Tenants in Kibana are spaces for saving index patterns, visualizations, dashboards,
+              and other Kibana objects. Use tenants to safely share your work with other Kibana
+              users. You can control which roles have access to a tenant and whether those roles
+              have read or write access. The “Current” label indicates which tenant you are using
+              now. Switch to another tenant anytime from your user profile, which is located on the
+              top right of the screen.{' '}
+              <EuiLink external={true} href="/">
+                Learn More
+              </EuiLink>
+            </EuiText>
+          </EuiPageContentHeaderSection>
+          <EuiPageContentHeaderSection>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiPopover
+                  id="actionsMenu"
+                  button={actionsButton}
+                  isOpen={isActionsPopoverOpen}
+                  closePopover={() => {
+                    setActionsPopoverOpen(false);
+                  }}
+                  panelPaddingSize="s"
+                >
+                  <EuiContextMenuPanel items={actionsMenuItems} />
+                </EuiPopover>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiButton fill onClick={() => showEditModal('', Action.create, '')}>
+                  Create tenant
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPageContentHeaderSection>
+        </EuiPageContentHeader>
+        <EuiPageBody>
+          <EuiInMemoryTable
+            loading={tenantData === [] && !errorFlag}
+            columns={columns}
+            items={tenantData}
+            itemId={'tenant'}
+            pagination
+            search={{ box: { placeholder: 'Find tenant' } }}
+            selection={{ onSelectionChange: setSelection }}
+            sorting
+            error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
+          />
+        </EuiPageBody>
+      </EuiPageContent>
+      {editModal}
+      {deleteConfirmModal}
+      <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />
+    </>
+  );
+}

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -159,10 +159,10 @@ export function TenantList(props: AppDependencies) {
     {
       field: 'tenant',
       name: 'Name',
-      render: (tenantname: string) => (
+      render: (tenantName: string) => (
         <>
-          {tenantname}
-          {tenantname === currentTenant && (
+          {tenantName}
+          {tenantName === currentTenant && (
             <>
               &nbsp;
               <EuiBadge>Current</EuiBadge>

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -80,9 +80,21 @@ export interface RoleMappingDetail {
   users: string[];
 }
 
-export interface Tenant {
-  reserved: boolean;
+export interface TenantUpdate {
   description: string;
+}
+
+export interface TenantName {
+  tenant: string;
+}
+
+export interface Tenant extends TenantUpdate, TenantName {
+  reserved: boolean;
+  tenantValue: string;
+}
+
+export interface TenantSelect extends TenantName {
+  username: string;
 }
 
 export interface UserAttributes {

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -18,6 +18,7 @@ import { map } from 'lodash';
 import { API_ENDPOINT_TENANTS, API_ENDPOINT_MULTITENANCY } from '../constants';
 import { DataObject, ObjectsMessage, Tenant, TenantUpdate, TenantSelect } from '../types';
 
+const globalTenantName = 'global_tenant';
 const GLOBAL_USER_DICT: { [key: string]: string } = {
   Label: 'Global',
   Value: '',
@@ -38,20 +39,22 @@ export async function fetchTenantNameList(http: HttpStart): Promise<string[]> {
   return Object.keys(await fetchTenants(http));
 }
 
-export function transformTenantData(rawTenantData: any) {
+export function transformTenantData(rawTenantData: DataObject<Tenant>, isPrivateEnabled: boolean) {
   const tenantList = map(rawTenantData, (v: any, k: string) => ({
-    tenant: k.startsWith('global') ? GLOBAL_USER_DICT.Label : k,
+    tenant: k === globalTenantName ? GLOBAL_USER_DICT.Label : k,
     reserved: v.reserved,
-    description: k.startsWith('global') ? GLOBAL_USER_DICT.Description : v.description,
-    tenantValue: k.startsWith('global') ? GLOBAL_USER_DICT.Value : k,
+    description: k === globalTenantName ? GLOBAL_USER_DICT.Description : v.description,
+    tenantValue: k === globalTenantName ? GLOBAL_USER_DICT.Value : k,
   }));
-  // Insert Private Tenant in List
-  tenantList.splice(1, 0, {
-    tenant: PRIVATE_USER_DICT.Label,
-    reserved: true,
-    description: PRIVATE_USER_DICT.Description,
-    tenantValue: PRIVATE_USER_DICT.Value,
-  });
+  if (isPrivateEnabled) {
+    // Insert Private Tenant in List
+    tenantList.splice(1, 0, {
+      tenant: PRIVATE_USER_DICT.Label,
+      reserved: true,
+      description: PRIVATE_USER_DICT.Description,
+      tenantValue: PRIVATE_USER_DICT.Value,
+    });
+  }
   return tenantList;
 }
 

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -14,8 +14,21 @@
  */
 
 import { HttpStart } from 'kibana/public';
-import { API_ENDPOINT_TENANTS } from '../constants';
-import { DataObject, ObjectsMessage, Tenant } from '../types';
+import { map } from 'lodash';
+import { API_ENDPOINT_TENANTS, API_ENDPOINT_MULTITENANCY } from '../constants';
+import { DataObject, ObjectsMessage, Tenant, TenantUpdate, TenantSelect } from '../types';
+
+const GLOBAL_USER_DICT: { [key: string]: string } = {
+  Label: 'Global',
+  Value: '',
+  Description: 'Everyone can see it',
+};
+
+const PRIVATE_USER_DICT: { [key: string]: string } = {
+  Label: 'Private',
+  Value: '__user__',
+  Description: 'Only visible to the current logged in user',
+};
 
 export async function fetchTenants(http: HttpStart): Promise<DataObject<Tenant>> {
   return ((await http.get(API_ENDPOINT_TENANTS)) as ObjectsMessage<Tenant>).data;
@@ -23,4 +36,58 @@ export async function fetchTenants(http: HttpStart): Promise<DataObject<Tenant>>
 
 export async function fetchTenantNameList(http: HttpStart): Promise<string[]> {
   return Object.keys(await fetchTenants(http));
+}
+
+export function transformTenantData(rawTenantData: any) {
+  const tenantList = map(rawTenantData, (v: any, k: string) => ({
+    tenant: k.startsWith('global') ? GLOBAL_USER_DICT.Label : k,
+    reserved: v.reserved,
+    description: k.startsWith('global') ? GLOBAL_USER_DICT.Description : v.description,
+    tenantValue: k.startsWith('global') ? GLOBAL_USER_DICT.Value : k,
+  }));
+  // Insert Private Tenant in List
+  tenantList.splice(1, 0, {
+    tenant: PRIVATE_USER_DICT.Label,
+    reserved: true,
+    description: PRIVATE_USER_DICT.Description,
+    tenantValue: PRIVATE_USER_DICT.Value,
+  });
+  return tenantList;
+}
+
+export async function fetchCurrentTenant(http: HttpStart) {
+  return await http.get(API_ENDPOINT_MULTITENANCY);
+}
+
+export async function updateTenant(
+  http: HttpStart,
+  tenantName: string,
+  updateObject: TenantUpdate
+) {
+  return await http.post(`${API_ENDPOINT_TENANTS}/${tenantName}`, {
+    body: JSON.stringify(updateObject),
+  });
+}
+
+export async function requestDeleteTenant(http: HttpStart, tenants: string[]) {
+  for (const tenant of tenants) {
+    await http.delete(`${API_ENDPOINT_TENANTS}/${tenant}`);
+  }
+}
+
+export async function selectTenant(http: HttpStart, selectObject: TenantSelect) {
+  return await http.post(`${API_ENDPOINT_MULTITENANCY}`, {
+    body: JSON.stringify(selectObject),
+  });
+}
+
+export function resolveTenantName(tenant: string, userName: string) {
+  if (!tenant || tenant === 'undefined') {
+    return 'Global';
+  }
+  if (tenant === userName || tenant === '__user__') {
+    return 'Private';
+  } else {
+    return tenant;
+  }
 }

--- a/public/apps/types.ts
+++ b/public/apps/types.ts
@@ -14,12 +14,13 @@
  */
 
 import { AppMountParameters, CoreStart } from '../../../../src/core/public';
-import { AppPluginStartDependencies } from '../types';
+import { AppPluginStartDependencies, ClientConfigType } from '../types';
 
 export interface AppDependencies {
   coreStart: CoreStart;
   navigation: AppPluginStartDependencies;
   params: AppMountParameters;
+  config: ClientConfigType;
 }
 
 export interface BreadcrumbsPageDependencies extends AppDependencies {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -49,6 +49,8 @@ export class OpendistroSecurityPlugin
   public async setup(core: CoreSetup): Promise<OpendistroSecurityPluginSetup> {
     const apiPermission = await hasApiPermission(core);
 
+    const config = this.initializerContext.config.get<ClientConfigType>();
+
     if (apiPermission) {
       core.application.register({
         id: PLUGIN_NAME,
@@ -57,12 +59,10 @@ export class OpendistroSecurityPlugin
         mount: async (params: AppMountParameters) => {
           const { renderApp } = await import('./apps/configuration/configuration-app');
           const [coreStart, depsStart] = await core.getStartServices();
-          return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
+          return renderApp(coreStart, depsStart as AppPluginStartDependencies, params, config);
         },
       });
     }
-
-    const config = this.initializerContext.config.get<ClientConfigType>();
 
     core.application.register({
       id: 'login',

--- a/public/services/chrome_wrapper.ts
+++ b/public/services/chrome_wrapper.ts
@@ -1,0 +1,22 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { CoreStart } from 'kibana/public';
+
+export function getNavLinkById(coreStart: CoreStart, id: string) {
+  const navLink = coreStart.chrome.navLinks.get(id);
+  if (navLink) return navLink.baseUrl;
+  else return '/';
+}

--- a/public/types.ts
+++ b/public/types.ts
@@ -43,4 +43,10 @@ export interface ClientConfigType {
       };
     };
   };
+  multitenancy: {
+    enabled: boolean;
+    tenants: {
+      enable_private: boolean;
+    };
+  };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -189,6 +189,7 @@ export const config: PluginConfigDescriptor<SecurityPluginConfigType> = {
   exposeToBrowser: {
     enabled: true,
     ui: true,
+    multitenancy: true,
   },
   schema: configSchema,
   deprecations: ({ rename, unused }) => [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implement UI for tenant management. Only admin can access this page.

### **Screenshots:**

> Tenant List:

_Mockup:_
![image](https://user-images.githubusercontent.com/63824432/89485231-2f102280-d755-11ea-95e3-886d14ba6623.png)

_Implementation:_
![image](https://user-images.githubusercontent.com/63824432/89698178-ab7d3f80-d8d4-11ea-813e-ebbc78d20d2a.png)

> Create/edit/duplicate tenant modal:
_Mockup:_
![image](https://user-images.githubusercontent.com/63824432/89485529-d42afb00-d755-11ea-9f41-33f085f00a84.png)

_Implementation:_
![image](https://user-images.githubusercontent.com/63824432/89698203-d10a4900-d8d4-11ea-8bed-18166625c5dc.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
