### PR TITLE
update response for unauthenticated APIs

### DIFF
--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -120,7 +120,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
         // clear cookie
         this.sessionStorageFactory.asScoped(request).clear();
         // send to auth workflow
-        return this.redirectToAuth(request, response, toolkit);
+        return this.handleUnauthedRequest(request, response, toolkit);
       }
 
       // extend cookie expiration time
@@ -157,7 +157,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
       } catch (error) {
         this.logger.error(`Failed to resolve user tenant: ${error}`);
         if (error instanceof UnauthenticatedError) {
-          return this.redirectToAuth(request, response, toolkit);
+          return this.handleUnauthedRequest(request, response, toolkit);
         }
         throw error;
       }
@@ -214,7 +214,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
   protected abstract getAdditionalAuthHeader(request: KibanaRequest): any;
   protected abstract getCookie(request: KibanaRequest, authInfo: any): SecuritySessionCookie;
   protected abstract isValidCookie(cookie: SecuritySessionCookie): boolean;
-  protected abstract redirectToAuth(
+  protected abstract handleUnauthedRequest(
     request: KibanaRequest,
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -125,18 +125,28 @@ export class BasicAuthentication extends AuthenticationType {
     );
   }
 
-  redirectToAuth(
+  handleUnauthedRequest(
     request: KibanaRequest,
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit
   ): KibanaResponse {
-    const nextUrlParam = this.composeNextUrlQeuryParam(request);
-    const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}${LOGIN_PAGE_URI}?${nextUrlParam}`;
-    return response.redirected({
-      headers: {
-        location: `${redirectLocation}`,
-      },
-    });
+    // TODO: do the samething for other auth types? 
+    // return 302 for /app
+    const pathname = request.url.pathname || '';
+    if (pathname.startsWith('/app/') || pathname === '/') {
+      const nextUrlParam = this.composeNextUrlQeuryParam(request);
+      const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}${LOGIN_PAGE_URI}?${nextUrlParam}`;
+      return response.redirected({
+        headers: {
+          location: `${redirectLocation}`,
+        },
+      });
+    } else {
+      return response.unauthorized({
+        body: `Authentication required`,
+      })
+    }
+
   }
 
   buildAuthHeaderFromCookie(cookie: SecuritySessionCookie): any {

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -130,7 +130,7 @@ export class BasicAuthentication extends AuthenticationType {
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit
   ): KibanaResponse {
-    // TODO: do the samething for other auth types? 
+    // TODO: do the samething for other auth types?
     // return 302 for /app
     const pathname = request.url.pathname || '';
     if (pathname.startsWith('/app/') || pathname === '/') {
@@ -144,9 +144,8 @@ export class BasicAuthentication extends AuthenticationType {
     } else {
       return response.unauthorized({
         body: `Authentication required`,
-      })
+      });
     }
-
   }
 
   buildAuthHeaderFromCookie(cookie: SecuritySessionCookie): any {

--- a/server/auth/types/jwt/jwt_auth.ts
+++ b/server/auth/types/jwt/jwt_auth.ts
@@ -112,7 +112,7 @@ export class JwtAuthentication extends AuthenticationType {
     );
   }
 
-  redirectToAuth(
+  handleUnauthedRequest(
     request: KibanaRequest,
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -128,7 +128,7 @@ export class OpenIdAuthentication extends AuthenticationType {
     );
   }
 
-  redirectToAuth(
+  handleUnauthedRequest(
     request: KibanaRequest,
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit

--- a/server/auth/types/proxy/proxy_auth.ts
+++ b/server/auth/types/proxy/proxy_auth.ts
@@ -120,7 +120,7 @@ export class ProxyAuthentication extends AuthenticationType {
     );
   }
 
-  redirectToAuth(
+  handleUnauthedRequest(
     request: KibanaRequest,
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -99,7 +99,7 @@ export class SamlAuthentication extends AuthenticationType {
     );
   }
 
-  redirectToAuth(
+  handleUnauthedRequest(
     request: KibanaRequest,
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* in the past, when Kibana receives any unauthenticated request, it returns `302` to redirect user to login page, which doesn't work well for XHR request. the change is to let Kibana to return `302` when the unauthenticated request is to access `/app/xxx` URLs, while for rest URL paths, it returns `401` instead

*test*
request root url `/`
```
% curl -H 'kbn-version: 8.0.0' --include --header "Content-Type: application/json" http://localhost:5601/hgy/
HTTP/1.1 302 Found
location: /hgy/app/login?nextUrl=%2Fhgy%2F
kbn-name: f8ffc2227bb6.ant.amazon.com
vary: origin
cache-control: private, no-cache, no-store, must-revalidate
set-cookie: security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/hgy
content-length: 0
date: Thu, 06 Aug 2020 04:53:41 GMT
Connection: keep-alive
```

request `/app/kibana`
```
% curl -H 'kbn-version: 8.0.0' --include --header "Content-Type: application/json" http://localhost:5601/hgy/app/kibana
HTTP/1.1 302 Found
location: /hgy/app/login?nextUrl=%2Fhgy%2Fapp%2Fkibana
kbn-name: f8ffc2227bb6.ant.amazon.com
vary: origin
cache-control: private, no-cache, no-store, must-revalidate
set-cookie: security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/hgy
content-length: 0
date: Thu, 06 Aug 2020 04:49:12 GMT
Connection: keep-alive
```
request API
```
% curl -H 'kbn-version: 8.0.0' --include --header "Content-Type: application/json" http://localhost:5601/hgy/api/v1/multitenancy/tenant
HTTP/1.1 401 Unauthorized
kbn-name: f8ffc2227bb6.ant.amazon.com
content-type: application/json; charset=utf-8
vary: origin
cache-control: private, no-cache, no-store, must-revalidate
set-cookie: security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/hgy
content-length: 77
date: Thu, 06 Aug 2020 04:48:56 GMT
Connection: keep-alive

{"statusCode":401,"error":"Unauthorized","message":"Authentication required"}%
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
