### PR TITLE
Showing Missing Role page if SAML auth fails due to missing role

### DIFF
--- a/lib/auth/types/saml/routes.js
+++ b/lib/auth/types/saml/routes.js
@@ -32,6 +32,7 @@
 import Boom from 'boom';
 import {parseNextUrl} from '../../parseNextUrl'
 import MissingTenantError from "../../errors/missing_tenant_error";
+import MissingRoleError from "../../errors/missing_role_error";
 import AuthenticationError from "../../errors/authentication_error";
 
 module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
@@ -112,6 +113,8 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
             } catch (error) {
                 if (error instanceof AuthenticationError) {
                     return h.redirect(basePath + '/customerror?type=samlAuthError');
+                } else if (error instanceof MissingRoleError) {
+                    return h.redirect(basePath + '/customerror?type=missingRole');
                 } else if (error instanceof MissingTenantError) {
                     return h.redirect(basePath + '/customerror?type=missingTenant');
                 } else {
@@ -145,6 +148,8 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
             } catch (error) {
                 if (error instanceof AuthenticationError) {
                     return h.redirect(basePath + '/customerror?type=samlAuthError');
+                } else if (error instanceof MissingRoleError) {
+                    return h.redirect(basePath + '/customerror?type=missingRole');
                 } else if (error instanceof MissingTenantError) {
                     return h.redirect(basePath + '/customerror?type=missingTenant');
                 } else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Redirecting to Missing Role Error Page in case saml auth failed due to missing role
Tested locally with SAML idp.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
