### PR TITLE
Add account role info modal

### DIFF
--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -15,12 +15,12 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CoreStart } from '../../../../../src/core/public';
+import { CoreStart } from 'kibana/public';
 import { AccountNavButton } from './account-nav-button';
 import { fetchAccountInfoSafe } from './utils';
 
 export async function setupTopNavButton(coreStart: CoreStart) {
-  const accountInfo = (await fetchAccountInfoSafe(coreStart))?.data;
+  const accountInfo = (await fetchAccountInfoSafe(coreStart.http))?.data;
   if (accountInfo) {
     coreStart.chrome.navControls.registerRight({
       // Pin to rightmost, since newsfeed plugin is using 1000, here needs a number > 1000
@@ -28,6 +28,7 @@ export async function setupTopNavButton(coreStart: CoreStart) {
       mount: (element: HTMLElement) => {
         ReactDOM.render(
           <AccountNavButton
+            coreStart={coreStart}
             isInternalUser={accountInfo.is_internal_user}
             username={accountInfo.user_name}
             tenant={accountInfo.user_requested_tenants}

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -14,29 +14,30 @@
  */
 
 import {
-  EuiContextMenuItem,
-  EuiContextMenuPanel,
-  EuiHeaderSectionItemButton,
-  EuiIcon,
-  EuiPopover,
-  EuiButtonEmpty,
   EuiAvatar,
-  EuiHorizontalRule,
+  EuiButtonEmpty,
+  EuiContextMenuPanel,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiTitle,
-  EuiText,
-  EuiListGroupItem,
+  EuiHeaderSectionItemButton,
+  EuiHorizontalRule,
   EuiListGroup,
+  EuiListGroupItem,
+  EuiPopover,
+  EuiText,
 } from '@elastic/eui';
+import { CoreStart } from 'kibana/public';
 import React, { useState } from 'react';
+import { RoleInfoPanel } from './role-info-panel';
 
 export function AccountNavButton(props: {
+  coreStart: CoreStart;
   isInternalUser: boolean;
   username: string;
   tenant?: string;
 }) {
   const [isPopoverOpen, setPopoverOpen] = useState<boolean>(false);
+  const [modal, setModal] = useState<React.ReactNode>(null);
   const horizontalRule = <EuiHorizontalRule margin="xs" />;
   const username = props.username;
   const contextMenuPanel = (
@@ -48,6 +49,7 @@ export function AccountNavButton(props: {
         <EuiFlexItem>
           <EuiListGroup gutterSize="none">
             <EuiListGroupItem
+              key="username"
               wrapText
               label={
                 <EuiText size="s">
@@ -57,13 +59,20 @@ export function AccountNavButton(props: {
             />
           </EuiListGroup>
           {/* Resolve global and private tenant name. */}
-          <EuiListGroupItem label={<EuiText size="xs">{props.tenant || ''}</EuiText>} />
+          <EuiListGroupItem
+            key="tenant"
+            label={<EuiText size="xs">{props.tenant || ''}</EuiText>}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
 
       {horizontalRule}
-      {/* TODO: show view roles modal */}
-      <EuiButtonEmpty size="xs">View roles</EuiButtonEmpty>
+      <EuiButtonEmpty
+        size="xs"
+        onClick={() => setModal(<RoleInfoPanel {...props} handleClose={() => setModal(null)} />)}
+      >
+        View roles
+      </EuiButtonEmpty>
       {horizontalRule}
       {
         // TODO: show switch tenants modal
@@ -104,6 +113,7 @@ export function AccountNavButton(props: {
       >
         <EuiContextMenuPanel>{contextMenuPanel}</EuiContextMenuPanel>
       </EuiPopover>
+      {modal}
     </EuiHeaderSectionItemButton>
   );
 }

--- a/public/apps/account/role-info-panel.tsx
+++ b/public/apps/account/role-info-panel.tsx
@@ -53,7 +53,9 @@ export function RoleInfoPanel(props: { coreStart: CoreStart; handleClose: () => 
           <EuiTitle>
             <h4>Roles ({roles.length})</h4>
           </EuiTitle>
-          <EuiText color="subdued">Roles you are currently mapped to by your administrator.</EuiText>
+          <EuiText color="subdued">
+            Roles you are currently mapped to by your administrator.
+          </EuiText>
           <EuiSpacer />
           {roles.map((item) => (
             <EuiText>

--- a/public/apps/account/role-info-panel.tsx
+++ b/public/apps/account/role-info-panel.tsx
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+import {
+  EuiListGroup,
+  EuiModal,
+  EuiModalBody,
+  EuiOverlayMask,
+  EuiPanel,
+  EuiText,
+  EuiTitle,
+  EuiHorizontalRule,
+  EuiSpacer,
+} from '@elastic/eui';
+import React, { useCallback, useEffect, useState } from 'react';
+import { CoreStart } from 'kibana/public';
+import { fetchAccountInfo } from './utils';
+
+export function RoleInfoPanel(props: { coreStart: CoreStart; handleClose: () => void }) {
+  const [roles, setRoles] = useState<string[]>([]);
+  const [backendRoles, setBackendRoles] = useState<string[]>([]);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const accountInfo = await fetchAccountInfo(props.coreStart.http);
+      setRoles(accountInfo?.data.roles || []);
+      setBackendRoles(accountInfo?.data.backend_roles || []);
+    } catch (e) {
+      console.log(e);
+    }
+  }, [props.coreStart.http]);
+
+  useEffect(() => {
+    fetchData();
+  }, [props.coreStart.http, fetchData]);
+
+  return (
+    <EuiOverlayMask>
+      <EuiModal onClose={props.handleClose}>
+        <EuiSpacer />
+        <EuiModalBody>
+          <EuiTitle>
+            <h4>Roles ({roles.length})</h4>
+          </EuiTitle>
+          <EuiText color="subdued">Roles you are currently mapped to by your administrator</EuiText>
+          <EuiSpacer />
+          {roles.map((item) => (
+            <EuiText>
+              {item}
+              <br />
+            </EuiText>
+          ))}
+          <EuiHorizontalRule />
+          <EuiTitle>
+            <h4>Backend roles ({backendRoles.length})</h4>
+          </EuiTitle>
+          <EuiText color="subdued">
+            Backend roles you are currently mapped to by your administrator
+          </EuiText>
+          <EuiSpacer />
+          <EuiListGroup>
+            {backendRoles.map((item) => (
+              <EuiText>
+                {item}
+                <br />
+              </EuiText>
+            ))}
+          </EuiListGroup>
+        </EuiModalBody>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
+}

--- a/public/apps/account/role-info-panel.tsx
+++ b/public/apps/account/role-info-panel.tsx
@@ -53,7 +53,7 @@ export function RoleInfoPanel(props: { coreStart: CoreStart; handleClose: () => 
           <EuiTitle>
             <h4>Roles ({roles.length})</h4>
           </EuiTitle>
-          <EuiText color="subdued">Roles you are currently mapped to by your administrator</EuiText>
+          <EuiText color="subdued">Roles you are currently mapped to by your administrator.</EuiText>
           <EuiSpacer />
           {roles.map((item) => (
             <EuiText>
@@ -63,10 +63,10 @@ export function RoleInfoPanel(props: { coreStart: CoreStart; handleClose: () => 
           ))}
           <EuiHorizontalRule />
           <EuiTitle>
-            <h4>Backend roles ({backendRoles.length})</h4>
+            <h4>External identities ({backendRoles.length})</h4>
           </EuiTitle>
           <EuiText color="subdued">
-            Backend roles you are currently mapped to by your administrator
+            External identities you are currently mapped to by your administrator.
           </EuiText>
           <EuiSpacer />
           <EuiListGroup>

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -13,17 +13,17 @@
  *   permissions and limitations under the License.
  */
 
-import { CoreStart } from 'kibana/public';
+import { HttpStart } from 'kibana/public';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
 import { AccountInfo } from './types';
 
-export function fetchAccountInfo(core: CoreStart): Promise<AccountInfo> {
-  return core.http.get(API_ENDPOINT_ACCOUNT_INFO);
+export function fetchAccountInfo(http: HttpStart): Promise<AccountInfo> {
+  return http.get(API_ENDPOINT_ACCOUNT_INFO);
 }
 
-export async function fetchAccountInfoSafe(core: CoreStart): Promise<AccountInfo | undefined> {
+export async function fetchAccountInfoSafe(http: HttpStart): Promise<AccountInfo | undefined> {
   try {
-    const accountInfo = await fetchAccountInfo(core);
+    const accountInfo = await fetchAccountInfo(http);
     return accountInfo;
   } catch (e) {
     // ignore 401 and continue to login page.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add account role info modal.

Diff from mockup:
* Confirmed with UX designer that backend role should be shown.

Mockup:
![image](https://user-images.githubusercontent.com/63078162/89839845-99dda700-db23-11ea-9d81-b0e2268644d2.png)

Implementation:
![image](https://user-images.githubusercontent.com/63078162/89839832-91856c00-db23-11ea-9039-ad4e82662e22.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
