### PR TITLE
add password reset function to user profile button

### DIFF
--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -30,6 +30,7 @@ import { CoreStart } from 'kibana/public';
 import React, { useState } from 'react';
 import { RoleInfoPanel } from './role-info-panel';
 import { logout } from './utils';
+import { PasswordResetPanel } from './password-reset-panel';
 
 export function AccountNavButton(props: {
   coreStart: CoreStart;
@@ -85,7 +86,20 @@ export function AccountNavButton(props: {
       }
       {props.isInternalUser && (
         <>
-          <EuiButtonEmpty size="xs">Reset password</EuiButtonEmpty>
+          <EuiButtonEmpty
+            size="xs"
+            onClick={() =>
+              setModal(
+                <PasswordResetPanel
+                  {...props}
+                  username={props.username}
+                  handleClose={() => setModal(null)}
+                />
+              )
+            }
+          >
+            Reset password
+          </EuiButtonEmpty>
           {horizontalRule}
         </>
       )}

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -1,0 +1,152 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldPassword,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiOverlayMask,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { FormRow } from '../configuration/utils/form-row';
+import { AppDependencies } from '../types';
+import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
+import { logout } from './utils';
+
+interface PasswordResetPanelProps extends AppDependencies {
+  username: string;
+  handleClose: () => void;
+}
+
+export function PasswordResetPanel(props: PasswordResetPanelProps) {
+  const [currentPassword, setCurrentPassword] = useState<string>('');
+  // reply on backend response of login call to verify
+  const [isCurrentPasswordInvalid, setIsCurrentPasswordInvalid] = useState<boolean>(false);
+  const [currentPasswordError, setCurrentPasswordError] = useState<string[]>([]);
+
+  const [newPassword, setNewPassword] = useState<string>('');
+  // reply on backend response of user update call to verify
+  const [isNewPasswordInvalid, setIsNewPasswordInvalid] = useState<boolean>(false);
+  const [newPasswordError, setNewPasswordError] = useState<string[]>([]);
+
+  const [repeatNewPassword, setRepeatNewPassword] = useState<string>('');
+  const [isRepeatNewPasswordInvalid, setIsRepeatNewPasswordInvalid] = useState<boolean>(false);
+
+  const handleReset = async () => {
+    const http = props.coreStart.http;
+    // validate the current password
+    try {
+      await http.post('/auth/login', {
+        body: JSON.stringify({
+          username: props.username,
+          password: currentPassword,
+        }),
+      });
+    } catch (e) {
+      setIsCurrentPasswordInvalid(true);
+      setCurrentPasswordError(['Invalid current password due to error: ' + e?.body?.message]);
+      return;
+    }
+
+    // update new password
+    try {
+      await http.post(`${API_ENDPOINT_ACCOUNT_INFO}`, {
+        body: JSON.stringify({
+          password: newPassword,
+          current_password: currentPassword,
+        }),
+      });
+
+      await logout(http);
+    } catch (e) {
+      setIsNewPasswordInvalid(true);
+      setNewPasswordError(['Invalid new password due to error: ' + e?.body?.message]);
+    }
+  };
+
+  // TODO: replace the instruction message for new password once UX provides it.
+  return (
+    <EuiOverlayMask>
+      <EuiModal onClose={props.handleClose}>
+        <EuiSpacer />
+        <EuiModalBody>
+          <EuiTitle>
+            <h4>Reset password for &quot;{props.username}&quot;</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          <FormRow
+            headerText="Current password"
+            helpText="Verify your account by entering your current password"
+            isInvalid={isCurrentPasswordInvalid}
+            error={currentPasswordError}
+          >
+            <EuiFieldPassword
+              onChange={function (e: React.ChangeEvent<HTMLInputElement>) {
+                setCurrentPassword(e.target.value);
+                setIsCurrentPasswordInvalid(false);
+              }}
+              isInvalid={isCurrentPasswordInvalid}
+            />
+          </FormRow>
+
+          <FormRow
+            headerText="New password"
+            helpText="The password must contain from m to n characters. Valid characters are [for example lowercase a-z
+            , 0-9, and - (hyphen)]"
+            isInvalid={isNewPasswordInvalid}
+            error={newPasswordError}
+          >
+            <EuiFieldPassword
+              onChange={function (e: React.ChangeEvent<HTMLInputElement>) {
+                setNewPassword(e.target.value);
+                setIsNewPasswordInvalid(false);
+                setIsRepeatNewPasswordInvalid(repeatNewPassword !== newPassword);
+              }}
+              isInvalid={isNewPasswordInvalid}
+            />
+          </FormRow>
+
+          <FormRow
+            headerText="Re-enter new password"
+            helpText="The password must be identical to what you entered above"
+          >
+            <EuiFieldPassword
+              isInvalid={isRepeatNewPasswordInvalid}
+              onChange={function (e: React.ChangeEvent<HTMLInputElement>) {
+                const value = e.target.value;
+                setRepeatNewPassword(value);
+                setIsRepeatNewPasswordInvalid(value !== newPassword);
+              }}
+            />
+          </FormRow>
+        </EuiModalBody>
+        <EuiModalFooter>
+          <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
+
+          <EuiButton fill disabled={isRepeatNewPasswordInvalid} onClick={handleReset}>
+            Reset
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
+}

--- a/public/apps/configuration/utils/form-row.tsx
+++ b/public/apps/configuration/utils/form-row.tsx
@@ -22,6 +22,8 @@ interface FormRowDeps {
   headerSubText?: string;
   helpLink?: string;
   helpText?: string;
+  isInvalid?: boolean;
+  error?: string[];
   children: React.ReactElement;
 }
 
@@ -47,6 +49,8 @@ export function FormRow(props: FormRowDeps) {
         </EuiText>
       }
       helpText={props.helpText}
+      isInvalid={props.isInvalid}
+      error={props.error}
     >
       {props.children}
     </EuiFormRow>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the password reset button is just a placeholder. With this change, the modal can show to allow the user to reset their password. We may need to sync up with UX for a better error handling in case the reset fails. For now, we just show the input box as invalid and print the detailed error to the console.

*Test*
Mockup
<img width="758" alt="Screen Shot 2020-08-11 at 10 39 31 AM" src="https://user-images.githubusercontent.com/60111637/89940744-d9ad9880-dbce-11ea-9c1c-2604bbff5dfb.png">

Implementation:
**Happy case:**
<img width="716" alt="Screen Shot 2020-08-11 at 10 39 55 AM" src="https://user-images.githubusercontent.com/60111637/89940804-f2b64980-dbce-11ea-9c13-da1a5c8818e5.png">

<img width="2530" alt="Screen Shot 2020-08-11 at 10 46 28 AM" src="https://user-images.githubusercontent.com/60111637/89940820-fb0e8480-dbce-11ea-9fb4-7f1f3abf90a4.png">

<img width="2546" alt="Screen Shot 2020-08-11 at 11 47 59 AM" src="https://user-images.githubusercontent.com/60111637/89940951-314c0400-dbcf-11ea-94c9-c531295a0b4c.png">

<img width="2542" alt="Screen Shot 2020-08-11 at 11 48 50 AM" src="https://user-images.githubusercontent.com/60111637/89940975-38731200-dbcf-11ea-9c75-b3c92aba9129.png">

**Current password invalid:**

<img width="895" alt="Screen Shot 2020-08-11 at 6 34 28 PM" src="https://user-images.githubusercontent.com/60111637/89969433-3a5ac680-dc0b-11ea-9199-6b22019fc699.png">


**New password invalid:**
<img width="1183" alt="Screen Shot 2020-08-11 at 7 39 40 PM" src="https://user-images.githubusercontent.com/60111637/89969455-46468880-dc0b-11ea-964e-6f62c11dae74.png">




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
