### PR TITLE
Fix a bug that permission group and anonymization fields don't load

### DIFF
--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -90,11 +90,11 @@ export function buildIndexPermissionState(
 ): RoleIndexPermissionStateClass[] {
   return indexPerm.map((perm) => ({
     indexPatterns: perm.index_patterns.map(stringToComboBoxOption),
-    allowedActions: [],
+    allowedActions: perm.allowed_actions.map(stringToComboBoxOption),
     docLevelSecurity: perm.dls,
     fieldLevelSecurityMethod: getFieldLevelSecurityMethod(perm.fls),
     fieldLevelSecurityFields: getFieldLevelSecurityFields(perm.fls),
-    maskedFields: [],
+    maskedFields: perm.masked_fields.map(stringToComboBoxOption),
   }));
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a bug that permission group and anonymization fields don't load on role edit page - index permission panel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
