### PR TITLE
Add Permissions tab in role-view

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -135,3 +135,5 @@ export const INDEX_PERMISSIONS = [
 
 export const TENANT_READ_PERMISSION = 'kibana_all_read';
 export const TENANT_WRITE_PERMISSION = 'kibana_all_write';
+
+export const RoleViewTenantInvalidText = 'N/A';

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -132,3 +132,6 @@ export const INDEX_PERMISSIONS = [
   'indices:monitor/stats',
   'indices:monitor/upgrade',
 ];
+
+export const TENANT_READ_PERMISSION = 'kibana_all_read';
+export const TENANT_WRITE_PERMISSION = 'kibana_all_write';

--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -15,20 +15,9 @@
 
 import React from 'react';
 import { EuiInMemoryTable } from '@elastic/eui';
-import { isEmpty, keys, map, get } from 'lodash';
+import { keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
-
-import { ExpressionModal } from './expression-modal';
-
-const renderExpression = (title: string) => {
-  return (expression: string) => {
-    if (isEmpty(expression)) {
-      return '-';
-    }
-
-    return <ExpressionModal title={title} expression={expression} />;
-  };
-};
+import { renderExpression } from '../../utils/display-utils';
 
 const columns = [
   {

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -15,20 +15,9 @@
 
 import React from 'react';
 import { EuiInMemoryTable } from '@elastic/eui';
-import { isEmpty, keys, map, get } from 'lodash';
+import { keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
-
-import { ExpressionModal } from './expression-modal';
-
-const renderExpression = (title: string) => {
-  return (expression: string) => {
-    if (isEmpty(expression)) {
-      return '-';
-    }
-
-    return <ExpressionModal title={title} expression={expression} />;
-  };
-};
+import { renderExpression } from '../../utils/display-utils';
 
 const columns = [
   {

--- a/public/apps/configuration/panels/expression-modal.tsx
+++ b/public/apps/configuration/panels/expression-modal.tsx
@@ -43,7 +43,7 @@ export function ExpressionModal(props: { title: string; expression: string }) {
 
           <EuiModalBody>
             <EuiCodeBlock fontSize="m" paddingSize="m" color="dark" overflowHeight={300} isCopyable>
-              {JSON.stringify(props.expression, null, 2)}
+              {JSON.stringify(JSON.parse(props.expression), null, 2)}
             </EuiCodeBlock>
           </EuiModalBody>
         </EuiModal>

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -46,7 +46,7 @@ import React, {
   useState,
 } from 'react';
 import { AppDependencies } from '../../../types';
-import { Action, DataObject, ActionGroupItem } from '../../types';
+import { Action, DataObject, ActionGroupItem, ExpandedRowMapInterface } from '../../types';
 import {
   PermissionListingItem,
   requestDeleteActionGroups,
@@ -59,10 +59,6 @@ import { renderCustomization } from '../../utils/display-utils';
 import { useToastState } from '../../utils/toast-utils';
 import { PermissionEditModal } from './edit-modal';
 import { PermissionTree } from '../permission-tree';
-
-interface ExpandedRowMapInterface {
-  [key: string]: React.ReactNode;
-}
 
 function renderBooleanToCheckMark(value: boolean): React.ReactNode {
   return value ? <EuiIcon type="check" /> : '';

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -38,8 +38,8 @@ import {
 } from '../../utils/combo-box-utils';
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
-import { FieldLevelSecurityMethod, RoleIndexPermissionStateClass } from './types';
-import { ComboBoxOptions } from '../../types';
+import { RoleIndexPermissionStateClass } from './types';
+import { FieldLevelSecurityMethod, ComboBoxOptions } from '../../types';
 import { getFieldLevelSecurityMethod } from '../../utils/index-permission-utils';
 
 export function getEmptyIndexPermission(): RoleIndexPermissionStateClass {

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -40,6 +40,7 @@ import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { FieldLevelSecurityMethod, RoleIndexPermissionStateClass } from './types';
 import { ComboBoxOptions } from '../../types';
+import { getFieldLevelSecurityMethod } from '../../utils/index-permission-utils';
 
 export function getEmptyIndexPermission(): RoleIndexPermissionStateClass {
   return {
@@ -50,19 +51,6 @@ export function getEmptyIndexPermission(): RoleIndexPermissionStateClass {
     fieldLevelSecurityFields: [],
     maskedFields: [],
   };
-}
-
-/**
- * Identify the method is whether exclude or include.
- * @param fieldLevelSecurityRawFields fields fetched from backend
- * ["~field1", "~field2"] => exclude
- * ["field1", "field2"] => include
- */
-function getFieldLevelSecurityMethod(
-  fieldLevelSecurityRawFields: string[]
-): FieldLevelSecurityMethod {
-  // Leading ~ indicates exclude.
-  return fieldLevelSecurityRawFields.some((s: string) => s.startsWith('~')) ? 'exclude' : 'include';
 }
 
 /**

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -30,9 +30,7 @@ import {
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { ComboBoxOptions, RoleTenantPermissionStateClass, TenantPermissionType } from './types';
-
-const TENANT_READ_PERMISSION = 'kibana_all_read';
-const TENANT_WRITE_PERMISSION = 'kibana_all_write';
+import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../../constants';
 
 export function buildTenantPermissionState(
   permissions: RoleTenantPermission[]

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -16,7 +16,7 @@
 import { EuiButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSuperSelect } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction } from 'react';
 import { isEmpty } from 'lodash';
-import { RoleTenantPermission } from '../../types';
+import { RoleTenantPermission, TenantPermissionType } from '../../types';
 import {
   appendElementToArray,
   removeElementFromArray,
@@ -29,23 +29,15 @@ import {
 } from '../../utils/combo-box-utils';
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
-import { ComboBoxOptions, RoleTenantPermissionStateClass, TenantPermissionType } from './types';
+import { ComboBoxOptions, RoleTenantPermissionStateClass } from './types';
 import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../../constants';
+import { getTenantPermissionType } from '../../utils/tenant-utils';
 
 export function buildTenantPermissionState(
   permissions: RoleTenantPermission[]
 ): RoleTenantPermissionStateClass[] {
   return permissions.map((permission) => {
-    const readable = permission.allowed_actions.includes(TENANT_READ_PERMISSION);
-    const writable = permission.allowed_actions.includes(TENANT_WRITE_PERMISSION);
-    let permissionType = TenantPermissionType.None;
-    if (readable && writable) {
-      permissionType = TenantPermissionType.Full;
-    } else if (readable) {
-      permissionType = TenantPermissionType.Read;
-    } else if (writable) {
-      permissionType = TenantPermissionType.Write;
-    }
+    const permissionType = getTenantPermissionType(permission.allowed_actions);
     return {
       tenantPatterns: permission.tenant_patterns.map(stringToComboBoxOption),
       permissionType,
@@ -109,9 +101,9 @@ function generateTenantPermissionPanels(
               valueOfSelected={tenantPermission.permissionType}
               onChange={onValueChangeHandler('permissionType')}
               options={[
-                { inputDisplay: 'Read only', value: TenantPermissionType.Read },
-                { inputDisplay: 'Write only', value: TenantPermissionType.Write },
-                { inputDisplay: 'Read and Write', value: TenantPermissionType.Full },
+                { inputDisplay: TenantPermissionType.Read, value: TenantPermissionType.Read },
+                { inputDisplay: TenantPermissionType.Write, value: TenantPermissionType.Write },
+                { inputDisplay: TenantPermissionType.Full, value: TenantPermissionType.Full },
               ]}
             />
           </EuiFlexItem>

--- a/public/apps/configuration/panels/role-edit/types.tsx
+++ b/public/apps/configuration/panels/role-edit/types.tsx
@@ -13,9 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-import { ComboBoxOptions } from '../../types';
+import { ComboBoxOptions, FieldLevelSecurityMethod, TenantPermissionType } from '../../types';
 
-export type FieldLevelSecurityMethod = 'exclude' | 'include';
 export interface RoleIndexPermissionStateClass {
   indexPatterns: ComboBoxOptions;
   docLevelSecurity: string;
@@ -23,13 +22,6 @@ export interface RoleIndexPermissionStateClass {
   fieldLevelSecurityFields: ComboBoxOptions;
   maskedFields: ComboBoxOptions;
   allowedActions: ComboBoxOptions;
-}
-
-export enum TenantPermissionType {
-  None = '',
-  Read = 'r',
-  Write = 'w',
-  Full = 'rw',
 }
 
 export interface RoleTenantPermissionStateClass {

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -41,38 +41,7 @@ import {
 import { API_ENDPOINT_ROLES, API_ENDPOINT_ROLESMAPPING } from '../constants';
 import { ResourceType, Action } from '../types';
 import { buildHashUrl } from '../utils/url-builder';
-import { renderCustomization } from '../utils/display-utils';
-
-function truncatedListView(limit = 3) {
-  return (items: string[]) => {
-    // Show - to indicate empty
-    if (items === undefined || items.length === 0) {
-      return (
-        <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
-          <EuiText key={'-'} size="xs">
-            -
-          </EuiText>
-        </EuiFlexGroup>
-      );
-    }
-
-    // If number of items over than limit, truncate and show ...
-    return (
-      <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
-        {items.slice(0, limit).map((item) => (
-          <EuiText key={item} size="xs">
-            {item}
-          </EuiText>
-        ))}
-        {items.length > limit && (
-          <EuiText key={'...'} size="xs">
-            ...
-          </EuiText>
-        )}
-      </EuiFlexGroup>
-    );
-  };
-}
+import { renderCustomization, truncatedListView } from '../utils/display-utils';
 
 const columns = [
   {

--- a/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
@@ -1,0 +1,38 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { PanelWithHeader } from '../../utils/panel-with-header';
+import { PermissionTree } from '../permission-tree';
+import { ActionGroupItem, DataObject } from '../../types';
+
+export function ClusterPermissionPanel(props: {
+  clusterPermissions: string[];
+  actionGroups: DataObject<ActionGroupItem>;
+}) {
+  const headerText = 'Cluster permissions (' + props.clusterPermissions.length + ')';
+
+  return (
+    <PanelWithHeader
+      headerText={headerText}
+      headerSubText="Cluster permissions specify how users in this role can access the cluster. You can
+      specify permissions using both action groups or single permissions. An action
+      group is a list of single permissions."
+      helpLink="/"
+    >
+      <PermissionTree permissions={props.clusterPermissions} actionGroups={props.actionGroups} />
+    </PanelWithHeader>
+  );
+}

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -126,11 +126,13 @@ function getColumns(
   ];
 }
 
-export function IndexPermissionPanel(props: {
+interface IndexPermissionPanelProps {
   indexPermissions: RoleIndexPermissionView[];
   actionGroups: DataObject<ActionGroupItem>;
   errorFlag: boolean;
-}) {
+}
+
+export function IndexPermissionPanel(props: IndexPermissionPanelProps) {
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<ExpandedRowMapInterface>({});
 
   const headerText = 'Index permissions (' + props.indexPermissions.length + ')';

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -1,0 +1,157 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useState, Dispatch, SetStateAction } from 'react';
+import {
+  EuiInMemoryTable,
+  EuiBasicTableColumn,
+  RIGHT_ALIGNMENT,
+  EuiButtonIcon,
+  EuiText,
+  EuiFlexGroup,
+} from '@elastic/eui';
+import { PanelWithHeader } from '../../utils/panel-with-header';
+import {
+  DataObject,
+  ActionGroupItem,
+  ExpandedRowMapInterface,
+  RoleIndexPermissionView,
+} from '../../types';
+import { truncatedListView, displayArray } from '../../utils/display-utils';
+import { PermissionTree } from '../permission-tree';
+import { getFieldLevelSecurityMethod } from '../../utils/index-permission-utils';
+import { renderExpression } from '../../utils/display-utils';
+
+function toggleRowDetails(
+  item: RoleIndexPermissionView,
+  actionGroupDict: DataObject<ActionGroupItem>,
+  setItemIdToExpandedRowMap: Dispatch<SetStateAction<ExpandedRowMapInterface>>
+) {
+  setItemIdToExpandedRowMap((prevState) => {
+    const itemIdToExpandedRowMapValues = { ...prevState };
+    if (itemIdToExpandedRowMapValues[item.id]) {
+      delete itemIdToExpandedRowMapValues[item.id];
+    } else {
+      itemIdToExpandedRowMapValues[item.id] = (
+        <PermissionTree permissions={item.allowed_actions} actionGroups={actionGroupDict} />
+      );
+    }
+    return itemIdToExpandedRowMapValues;
+  });
+}
+
+export function renderFieldLevelSecurity() {
+  return (items: string[]) => {
+    // Show - to indicate empty
+    if (items === undefined || items.length === 0) {
+      return (
+        <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
+          <EuiText key={'-'} size="xs">
+            -
+          </EuiText>
+        </EuiFlexGroup>
+      );
+    }
+
+    return (
+      <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
+        <EuiText size="xs">
+          {getFieldLevelSecurityMethod(items) === 'exclude' ? 'Exclude' : 'Include'}:{' '}
+          {displayArray(items.map((s: string) => s.replace(/^~/, '')))}
+        </EuiText>
+      </EuiFlexGroup>
+    );
+  };
+}
+
+function getColumns(
+  itemIdToExpandedRowMap: ExpandedRowMapInterface,
+  actionGroupDict: DataObject<ActionGroupItem>,
+  setItemIdToExpandedRowMap: Dispatch<SetStateAction<ExpandedRowMapInterface>>
+): Array<EuiBasicTableColumn<RoleIndexPermissionView>> {
+  return [
+    {
+      field: 'index_patterns',
+      name: 'Index',
+      sortable: true,
+      render: truncatedListView(),
+      truncateText: true,
+    },
+    {
+      field: 'allowed_actions',
+      name: 'Permissions',
+      render: truncatedListView(),
+      truncateText: true,
+    },
+    {
+      field: 'dls',
+      name: 'Document-level security',
+      render: renderExpression('Document-level security'),
+    },
+    {
+      field: 'fls',
+      name: 'Field-level security',
+      render: renderFieldLevelSecurity(),
+    },
+    {
+      field: 'masked_fields',
+      name: 'Anonymizations',
+      render: truncatedListView(),
+      truncateText: true,
+    },
+    {
+      align: RIGHT_ALIGNMENT,
+      width: '40px',
+      isExpander: true,
+      render: (item: RoleIndexPermissionView) => (
+        <EuiButtonIcon
+          onClick={() => toggleRowDetails(item, actionGroupDict, setItemIdToExpandedRowMap)}
+          aria-label={itemIdToExpandedRowMap[item.id] ? 'Collapse' : 'Expand'}
+          iconType={itemIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
+        />
+      ),
+    },
+  ];
+}
+
+export function IndexPermissionPanel(props: {
+  indexPermissions: RoleIndexPermissionView[];
+  actionGroups: DataObject<ActionGroupItem>;
+  errorFlag: boolean;
+}) {
+  const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<ExpandedRowMapInterface>({});
+
+  const headerText = 'Index permissions (' + props.indexPermissions.length + ')';
+  return (
+    <PanelWithHeader
+      headerText={headerText}
+      headerSubText="Index permissions allow you to specify how users in this role can access the indices. You can restrict a role to a subset of documents in an index, 
+      and which document fields a user can see as well. If you use field-level security in conjunction with document-level security, 
+      make sure you don't restrict access to the fields that document-level security uses."
+      helpLink="/"
+    >
+      <EuiInMemoryTable
+        loading={props.indexPermissions === [] && !props.errorFlag}
+        columns={getColumns(itemIdToExpandedRowMap, props.actionGroups, setItemIdToExpandedRowMap)}
+        items={props.indexPermissions}
+        itemId={'id'}
+        sorting={{ sort: { field: 'type', direction: 'asc' } }}
+        error={props.errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
+        isExpandable={true}
+        itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+      />
+    </PanelWithHeader>
+  );
+}

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -59,10 +59,8 @@ import { getRoleDetail } from '../../utils/role-detail-utils';
 import { ClusterPermissionPanel } from '../role-view/cluster-permission-panel';
 import { IndexPermissionPanel } from './index-permission-panel';
 import { TenantsPanel } from './tenants-panel';
-import {
-  transformRoleIndexPermissions,
-  transformRoleTenantPermissions,
-} from '../../utils/index-permission-utils';
+import { transformRoleIndexPermissions } from '../../utils/index-permission-utils';
+import { transformRoleTenantPermissions } from '../../utils/tenant-utils';
 
 interface RoleViewProps extends BreadcrumbsPageDependencies {
   roleName: string;
@@ -231,7 +229,11 @@ export function RoleView(props: RoleViewProps) {
 
           <EuiSpacer size="m" />
 
-          <TenantsPanel tenantPermissions={roleTenantPermission} errorFlag={errorFlag} />
+          <TenantsPanel
+            tenantPermissions={roleTenantPermission}
+            errorFlag={errorFlag}
+            coreStart={props.coreStart}
+          />
         </>
       ),
     },

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -13,48 +13,159 @@
  *   permissions and limitations under the License.
  */
 
-import React from 'react';
-import { EuiInMemoryTable } from '@elastic/eui';
+import React, { useState, useEffect } from 'react';
+import { EuiInMemoryTable, EuiLink, EuiText, EuiGlobalToastList } from '@elastic/eui';
+import { CoreStart } from 'kibana/public';
+import { getAuthInfo } from '../../../../utils/auth-info-utils';
 import { PanelWithHeader } from '../../utils/panel-with-header';
-import { RoleTenantPermissionView } from '../../types';
+import { RoleTenantPermissionView, RoleTenantPermissionDetail } from '../../types';
 import { truncatedListView } from '../../utils/display-utils';
+import {
+  fetchTenants,
+  transformTenantData,
+  transformRoleTenantPermissionData,
+  selectTenant,
+} from '../../utils/tenant-utils';
+import { RoleViewTenantInvalidText } from '../../constants';
+import { PageId } from '../../types';
+import { getNavLinkById } from '../../../../services/chrome_wrapper';
+import { useToastState, createUnknownErrorToast } from '../../utils/toast-utils';
 
-const columns = [
-  {
-    field: 'tenant_patterns',
-    name: 'Name',
-    render: truncatedListView(),
-    truncateText: true,
-    sortable: true,
-  },
-  {
-    field: 'permissionType',
-    name: 'Read/write permission',
-  },
-];
-
-export function TenantsPanel(props: {
+interface RoleViewTenantsPanelProps {
   tenantPermissions: RoleTenantPermissionView[];
   errorFlag: boolean;
-}) {
-  const headerText = 'Tenants (' + props.tenantPermissions.length + ')';
+  coreStart: CoreStart;
+}
 
+export function TenantsPanel(props: RoleViewTenantsPanelProps) {
+  const [tenantPermissionDetail, setTenantPermissionDetail] = useState<
+    RoleTenantPermissionDetail[]
+  >([]);
+  const [currentUsername, setCurrentUsername] = useState('');
+  const [toasts, addToast, removeToast] = useToastState();
+  const [errorFlag, setErrorFlag] = useState(props.errorFlag);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const rawTenantData = await fetchTenants(props.coreStart.http);
+        const processedTenantData = transformTenantData(rawTenantData, false);
+        setTenantPermissionDetail(
+          transformRoleTenantPermissionData(props.tenantPermissions, processedTenantData)
+        );
+        const currentUser = (await getAuthInfo(props.coreStart.http)).user_name;
+        setCurrentUsername(currentUser);
+      } catch (e) {
+        console.log(e);
+        setErrorFlag(true);
+      }
+    };
+
+    fetchData();
+  }, [props]);
+
+  const viewDashboard = async (tenantName: string) => {
+    try {
+      await selectTenant(props.coreStart.http, {
+        tenant: tenantName,
+        username: currentUsername,
+      });
+      window.location.href = getNavLinkById(props.coreStart, PageId.dashboardId);
+    } catch (e) {
+      console.log(e);
+      addToast(createUnknownErrorToast('viewDashboard', `view dashboard for ${tenantName} tenant`));
+    }
+  };
+
+  const viewVisualization = async (tenantName: string) => {
+    try {
+      await selectTenant(props.coreStart.http, {
+        tenant: tenantName,
+        username: currentUsername,
+      });
+      window.location.href = getNavLinkById(props.coreStart, PageId.visualizationId);
+    } catch (e) {
+      console.log(e);
+      addToast(
+        createUnknownErrorToast('viewVisualization', `view visualization for ${tenantName} tenant`)
+      );
+    }
+  };
+
+  const columns = [
+    {
+      field: 'tenant_patterns',
+      name: 'Name',
+      render: truncatedListView(),
+      truncateText: true,
+      sortable: true,
+    },
+    {
+      field: 'description',
+      name: 'Description',
+      truncateText: true,
+    },
+    {
+      field: 'permissionType',
+      name: 'Read/write permission',
+    },
+    {
+      field: 'tenantValue',
+      name: 'Dashboard',
+      render: (tenant: string) => {
+        if (tenant === RoleViewTenantInvalidText) {
+          return (
+            <>
+              <EuiText size="s">{RoleViewTenantInvalidText}</EuiText>
+            </>
+          );
+        }
+        return (
+          <>
+            <EuiLink onClick={() => viewDashboard(tenant)}>View dashboard</EuiLink>
+          </>
+        );
+      },
+    },
+    {
+      field: 'tenantValue',
+      name: 'Visualizations',
+      render: (tenant: string) => {
+        if (tenant === RoleViewTenantInvalidText) {
+          return (
+            <>
+              <EuiText size="s">{RoleViewTenantInvalidText}</EuiText>
+            </>
+          );
+        }
+        return (
+          <>
+            <EuiLink onClick={() => viewVisualization(tenant)}>View visualizations</EuiLink>
+          </>
+        );
+      },
+    },
+  ];
+
+  const headerText = 'Tenants (' + tenantPermissionDetail.length + ')';
   return (
-    <PanelWithHeader
-      headerText={headerText}
-      headerSubText="Tenants in Kibana are spaces for saving index patterns, visualizations, dashboards, and other Kibana objects. 
-      Tenants are useful for safely sharing your work with other Kibana users. 
-      You can control which roles have access to a tenant and whether those roles have read or write access."
-      helpLink="/"
-    >
-      <EuiInMemoryTable
-        loading={props.tenantPermissions === [] && !props.errorFlag}
-        columns={columns}
-        items={props.tenantPermissions}
-        // itemId={'name'}
-        sorting={{ sort: { field: 'type', direction: 'asc' } }}
-        error={props.errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
-      />
-    </PanelWithHeader>
+    <>
+      <PanelWithHeader
+        headerText={headerText}
+        headerSubText="Tenants in Kibana are spaces for saving index patterns, visualizations, dashboards, and other Kibana objects. 
+        Tenants are useful for safely sharing your work with other Kibana users. 
+        You can control which roles have access to a tenant and whether those roles have read or write access."
+        helpLink="/"
+      >
+        <EuiInMemoryTable
+          loading={tenantPermissionDetail === [] && !errorFlag}
+          columns={columns}
+          items={tenantPermissionDetail}
+          sorting={{ sort: { field: 'type', direction: 'asc' } }}
+          error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
+        />
+      </PanelWithHeader>
+      <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />
+    </>
   );
 }

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -1,0 +1,60 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiInMemoryTable } from '@elastic/eui';
+import { PanelWithHeader } from '../../utils/panel-with-header';
+import { RoleTenantPermissionView } from '../../types';
+import { truncatedListView } from '../../utils/display-utils';
+
+const columns = [
+  {
+    field: 'tenant_patterns',
+    name: 'Name',
+    render: truncatedListView(),
+    truncateText: true,
+    sortable: true,
+  },
+  {
+    field: 'permissionType',
+    name: 'Read/write permission',
+  },
+];
+
+export function TenantsPanel(props: {
+  tenantPermissions: RoleTenantPermissionView[];
+  errorFlag: boolean;
+}) {
+  const headerText = 'Tenants (' + props.tenantPermissions.length + ')';
+
+  return (
+    <PanelWithHeader
+      headerText={headerText}
+      headerSubText="Tenants in Kibana are spaces for saving index patterns, visualizations, dashboards, and other Kibana objects. 
+      Tenants are useful for safely sharing your work with other Kibana users. 
+      You can control which roles have access to a tenant and whether those roles have read or write access."
+      helpLink="/"
+    >
+      <EuiInMemoryTable
+        loading={props.tenantPermissions === [] && !props.errorFlag}
+        columns={columns}
+        items={props.tenantPermissions}
+        // itemId={'name'}
+        sorting={{ sort: { field: 'type', direction: 'asc' } }}
+        error={props.errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
+      />
+    </PanelWithHeader>
+  );
+}

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -52,11 +52,7 @@ import {
 import { getNavLinkById } from '../../../../services/chrome_wrapper';
 import { TenantEditModal } from './edit-modal';
 import { useToastState, createUnknownErrorToast } from '../../utils/toast-utils';
-
-enum PageId {
-  dashboardId = 'dashboards',
-  visualizationId = 'visualize',
-}
+import { PageId } from '../../types';
 
 export function TenantList(props: AppDependencies) {
   const [tenantData, setTenantData] = useState<Tenant[]>([]);

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -59,9 +59,20 @@ export interface RoleIndexPermission {
   allowed_actions: string[];
 }
 
-export interface RoleTenantPermission {
+export interface RoleIndexPermissionView extends RoleIndexPermission {
+  id: number;
+}
+
+export interface RoleTenantPatterns {
   tenant_patterns: string[];
+}
+
+export interface RoleTenantPermission extends RoleTenantPatterns {
   allowed_actions: string[];
+}
+
+export interface RoleTenantPermissionView extends RoleTenantPatterns {
+  permissionType: string;
 }
 
 export interface RoleUpdate {
@@ -117,4 +128,8 @@ export interface ActionGroupUpdate {
 export interface ActionGroupItem extends ActionGroupUpdate {
   reserved: boolean;
   type: 'cluster' | 'index' | 'all' | 'kibana' | undefined;
+}
+
+export interface ExpandedRowMapInterface {
+  [key: string]: React.ReactNode;
 }

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -17,6 +17,8 @@ import { EuiComboBoxOptionOption } from '@elastic/eui';
 
 export type ComboBoxOptions = EuiComboBoxOptionOption[];
 
+export type FieldLevelSecurityMethod = 'exclude' | 'include';
+
 export enum ResourceType {
   roles = 'roles',
   users = 'users',
@@ -35,6 +37,18 @@ export enum Action {
 
 export enum SubAction {
   mapuser = 'mapuser',
+}
+
+export enum PageId {
+  dashboardId = 'dashboards',
+  visualizationId = 'visualize',
+}
+
+export enum TenantPermissionType {
+  None = '',
+  Read = 'Read only',
+  Write = 'Write only',
+  Full = 'Read and Write',
 }
 
 export interface RouteItem {
@@ -107,6 +121,8 @@ export interface Tenant extends TenantUpdate, TenantName {
 export interface TenantSelect extends TenantName {
   username: string;
 }
+
+export interface RoleTenantPermissionDetail extends RoleTenantPermissionView, Tenant {}
 
 export interface UserAttributes {
   [key: string]: string;

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -15,10 +15,11 @@
 
 // TODO: call the util functions from wherever applicable.
 
-import { EuiFlexItem, EuiText, EuiIcon } from '@elastic/eui';
+import { EuiFlexItem, EuiText, EuiIcon, EuiFlexGroup } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 
 import React from 'react';
+import { ExpressionModal } from '../panels/expression-modal';
 
 export function renderTextFlexItem(header: string, value: string) {
   return (
@@ -51,3 +52,44 @@ export function renderCustomization(reserved: boolean) {
     </EuiText>
   );
 }
+
+export function truncatedListView(limit = 3) {
+  return (items: string[]) => {
+    // Show - to indicate empty
+    if (items === undefined || items.length === 0) {
+      return (
+        <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
+          <EuiText key={'-'} size="xs">
+            -
+          </EuiText>
+        </EuiFlexGroup>
+      );
+    }
+
+    // If number of items over than limit, truncate and show ...
+    return (
+      <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
+        {items.slice(0, limit).map((item) => (
+          <EuiText key={item} size="xs">
+            {item}
+          </EuiText>
+        ))}
+        {items.length > limit && (
+          <EuiText key={'...'} size="xs">
+            ...
+          </EuiText>
+        )}
+      </EuiFlexGroup>
+    );
+  };
+}
+
+export const renderExpression = (title: string) => {
+  return (expression: string) => {
+    if (isEmpty(expression)) {
+      return '-';
+    }
+
+    return <ExpressionModal title={title} expression={expression} />;
+  };
+};

--- a/public/apps/configuration/utils/index-permission-utils.tsx
+++ b/public/apps/configuration/utils/index-permission-utils.tsx
@@ -1,0 +1,78 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { map } from 'lodash';
+import { FieldLevelSecurityMethod, TenantPermissionType } from '../panels/role-edit/types';
+import {
+  RoleIndexPermission,
+  RoleIndexPermissionView,
+  RoleTenantPermission,
+  RoleTenantPermissionView,
+} from '../types';
+import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../constants';
+
+/**
+ * Identify the method is whether exclude or include.
+ * @param fieldLevelSecurityRawFields fields fetched from backend
+ * ["~field1", "~field2"] => exclude
+ * ["field1", "field2"] => include
+ */
+export function getFieldLevelSecurityMethod(
+  fieldLevelSecurityRawFields: string[]
+): FieldLevelSecurityMethod {
+  // Leading ~ indicates exclude.
+  return fieldLevelSecurityRawFields.some((s: string) => s.startsWith('~')) ? 'exclude' : 'include';
+}
+
+export function transformRoleIndexPermissions(
+  roleIndexPermission: RoleIndexPermission[]
+): RoleIndexPermissionView[] {
+  return map(roleIndexPermission, (indexPermission: RoleIndexPermission, arrayIndex: number) => ({
+    id: arrayIndex,
+    index_patterns: indexPermission.index_patterns,
+    dls: indexPermission.dls,
+    fls: indexPermission.fls,
+    masked_fields: indexPermission.masked_fields,
+    allowed_actions: indexPermission.allowed_actions,
+  }));
+}
+
+const PermissionTypeDisplay = {
+  rw: 'Read and Write',
+  r: 'Read only',
+  w: 'Write only',
+  '': '',
+};
+
+export function transformRoleTenantPermissions(
+  roleTenantPermission: RoleTenantPermission[]
+): RoleTenantPermissionView[] {
+  return roleTenantPermission.map((tenantPermission) => {
+    const readable = tenantPermission.allowed_actions.includes(TENANT_READ_PERMISSION);
+    const writable = tenantPermission.allowed_actions.includes(TENANT_WRITE_PERMISSION);
+    let permissionType = TenantPermissionType.None;
+    if (readable && writable) {
+      permissionType = TenantPermissionType.Full;
+    } else if (readable) {
+      permissionType = TenantPermissionType.Read;
+    } else if (writable) {
+      permissionType = TenantPermissionType.Write;
+    }
+    return {
+      tenant_patterns: tenantPermission.tenant_patterns,
+      permissionType: PermissionTypeDisplay[permissionType],
+    };
+  });
+}

--- a/public/apps/configuration/utils/index-permission-utils.tsx
+++ b/public/apps/configuration/utils/index-permission-utils.tsx
@@ -14,14 +14,7 @@
  */
 
 import { map } from 'lodash';
-import { FieldLevelSecurityMethod, TenantPermissionType } from '../panels/role-edit/types';
-import {
-  RoleIndexPermission,
-  RoleIndexPermissionView,
-  RoleTenantPermission,
-  RoleTenantPermissionView,
-} from '../types';
-import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../constants';
+import { RoleIndexPermission, RoleIndexPermissionView, FieldLevelSecurityMethod } from '../types';
 
 /**
  * Identify the method is whether exclude or include.
@@ -41,38 +34,6 @@ export function transformRoleIndexPermissions(
 ): RoleIndexPermissionView[] {
   return map(roleIndexPermission, (indexPermission: RoleIndexPermission, arrayIndex: number) => ({
     id: arrayIndex,
-    index_patterns: indexPermission.index_patterns,
-    dls: indexPermission.dls,
-    fls: indexPermission.fls,
-    masked_fields: indexPermission.masked_fields,
-    allowed_actions: indexPermission.allowed_actions,
+    ...indexPermission,
   }));
-}
-
-const PermissionTypeDisplay = {
-  rw: 'Read and Write',
-  r: 'Read only',
-  w: 'Write only',
-  '': '',
-};
-
-export function transformRoleTenantPermissions(
-  roleTenantPermission: RoleTenantPermission[]
-): RoleTenantPermissionView[] {
-  return roleTenantPermission.map((tenantPermission) => {
-    const readable = tenantPermission.allowed_actions.includes(TENANT_READ_PERMISSION);
-    const writable = tenantPermission.allowed_actions.includes(TENANT_WRITE_PERMISSION);
-    let permissionType = TenantPermissionType.None;
-    if (readable && writable) {
-      permissionType = TenantPermissionType.Full;
-    } else if (readable) {
-      permissionType = TenantPermissionType.Read;
-    } else if (writable) {
-      permissionType = TenantPermissionType.Write;
-    }
-    return {
-      tenant_patterns: tenantPermission.tenant_patterns,
-      permissionType: PermissionTypeDisplay[permissionType],
-    };
-  });
 }

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -120,7 +120,11 @@ export function transformRoleTenantPermissionData(
   tenantList: Tenant[]
 ): RoleTenantPermissionDetail[] {
   return map(tenantPermissions, (tenantPermission: RoleTenantPermissionView) => {
-    const tenantNames: string[] = tenantList.map((t: Tenant) => t.tenant); // Global
+    const tenantNames: string[] = tenantList.map((t: Tenant) => t.tenant);
+    /**
+     * Here we only consider the case that containing one tenant and
+     * for other case (multiple tenants, tenant pattern) we return N/A.
+     */
     let tenantItem = null;
     if (
       tenantPermission.tenant_patterns.length === 1 &&
@@ -133,9 +137,9 @@ export function transformRoleTenantPermissionData(
     return {
       tenant_patterns: tenantPermission.tenant_patterns,
       permissionType: tenantPermission.permissionType,
-      tenant: tenantItem ? tenantItem.tenant : RoleViewTenantInvalidText,
-      reserved: tenantItem ? tenantItem.reserved : false,
-      description: tenantItem ? tenantItem.description : RoleViewTenantInvalidText,
+      tenant: tenantItem?.tenant || RoleViewTenantInvalidText,
+      reserved: tenantItem?.reserved || false,
+      description: tenantItem?.description || RoleViewTenantInvalidText,
       tenantValue: tenantItem ? tenantItem.tenantValue : RoleViewTenantInvalidText,
     };
   });
@@ -158,11 +162,8 @@ export function getTenantPermissionType(tenantPermissions: string[]) {
 export function transformRoleTenantPermissions(
   roleTenantPermission: RoleTenantPermission[]
 ): RoleTenantPermissionView[] {
-  return roleTenantPermission.map((tenantPermission) => {
-    const permissionType = getTenantPermissionType(tenantPermission.allowed_actions);
-    return {
-      tenant_patterns: tenantPermission.tenant_patterns,
-      permissionType,
-    };
-  });
+  return roleTenantPermission.map((tenantPermission) => ({
+    tenant_patterns: tenantPermission.tenant_patterns,
+    permissionType: getTenantPermissionType(tenantPermission.allowed_actions),
+  }));
 }

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -15,8 +15,23 @@
 
 import { HttpStart } from 'kibana/public';
 import { map } from 'lodash';
-import { API_ENDPOINT_TENANTS, API_ENDPOINT_MULTITENANCY } from '../constants';
-import { DataObject, ObjectsMessage, Tenant, TenantUpdate, TenantSelect } from '../types';
+import {
+  API_ENDPOINT_TENANTS,
+  API_ENDPOINT_MULTITENANCY,
+  RoleViewTenantInvalidText,
+} from '../constants';
+import {
+  DataObject,
+  ObjectsMessage,
+  Tenant,
+  TenantUpdate,
+  TenantSelect,
+  RoleTenantPermissionView,
+  RoleTenantPermissionDetail,
+  TenantPermissionType,
+  RoleTenantPermission,
+} from '../types';
+import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../constants';
 
 const globalTenantName = 'global_tenant';
 const GLOBAL_USER_DICT: { [key: string]: string } = {
@@ -93,4 +108,61 @@ export function resolveTenantName(tenant: string, userName: string) {
   } else {
     return tenant;
   }
+}
+
+function formatTenantName(tenantName: string): string {
+  if (tenantName === globalTenantName) return GLOBAL_USER_DICT.Label;
+  return tenantName;
+}
+
+export function transformRoleTenantPermissionData(
+  tenantPermissions: RoleTenantPermissionView[],
+  tenantList: Tenant[]
+): RoleTenantPermissionDetail[] {
+  return map(tenantPermissions, (tenantPermission: RoleTenantPermissionView) => {
+    const tenantNames: string[] = tenantList.map((t: Tenant) => t.tenant); // Global
+    let tenantItem = null;
+    if (
+      tenantPermission.tenant_patterns.length === 1 &&
+      tenantNames.includes(formatTenantName(tenantPermission.tenant_patterns[0]))
+    ) {
+      tenantItem = tenantList.filter((t) => {
+        return t.tenant === formatTenantName(tenantPermission.tenant_patterns[0]);
+      })[0];
+    }
+    return {
+      tenant_patterns: tenantPermission.tenant_patterns,
+      permissionType: tenantPermission.permissionType,
+      tenant: tenantItem ? tenantItem.tenant : RoleViewTenantInvalidText,
+      reserved: tenantItem ? tenantItem.reserved : false,
+      description: tenantItem ? tenantItem.description : RoleViewTenantInvalidText,
+      tenantValue: tenantItem ? tenantItem.tenantValue : RoleViewTenantInvalidText,
+    };
+  });
+}
+
+export function getTenantPermissionType(tenantPermissions: string[]) {
+  const readable = tenantPermissions.includes(TENANT_READ_PERMISSION);
+  const writable = tenantPermissions.includes(TENANT_WRITE_PERMISSION);
+  let permissionType = TenantPermissionType.None;
+  if (readable && writable) {
+    permissionType = TenantPermissionType.Full;
+  } else if (readable) {
+    permissionType = TenantPermissionType.Read;
+  } else if (writable) {
+    permissionType = TenantPermissionType.Write;
+  }
+  return permissionType;
+}
+
+export function transformRoleTenantPermissions(
+  roleTenantPermission: RoleTenantPermission[]
+): RoleTenantPermissionView[] {
+  return roleTenantPermission.map((tenantPermission) => {
+    const permissionType = getTenantPermissionType(tenantPermission.allowed_actions);
+    return {
+      tenant_patterns: tenantPermission.tenant_patterns,
+      permissionType,
+    };
+  });
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added permission tab in Role view page to show cluster, index and tenant permission associated to the selected role.

- Optimize code - moved common code used by multiple pages to single place.

**Screenshots:**

> Cluster permissions:

_Mockup:_
![image](https://user-images.githubusercontent.com/63824432/89951822-f81c8f80-dbe0-11ea-9a46-9650d939b59a.png)

_Implementation:_
![image](https://user-images.githubusercontent.com/63824432/89951974-3c0f9480-dbe1-11ea-9a75-e89e6459726c.png)

> If role is reserved
![image](https://user-images.githubusercontent.com/63824432/89952130-855fe400-dbe1-11ea-93de-73a1b2b26a5c.png)

> Index permissions:

_Mockup:_
![image](https://user-images.githubusercontent.com/63824432/89952285-cd7f0680-dbe1-11ea-9dcf-af4c67f809eb.png)

_Implementation:_
![image](https://user-images.githubusercontent.com/63824432/89952388-0323ef80-dbe2-11ea-8e9f-903cb07c5094.png)

> View Expression:
![image](https://user-images.githubusercontent.com/63824432/89952437-1b940a00-dbe2-11ea-87a5-a25f5fa263b4.png)


> Tenants:

_Mockup:_
![image](https://user-images.githubusercontent.com/63824432/90075834-31bdcb00-dcb3-11ea-99db-0831f0288cd4.png)

_Implementation:_
![image](https://user-images.githubusercontent.com/63824432/90075621-b3f9bf80-dcb2-11ea-9ab0-81777f46ca1f.png)

_Entire page mockup:_
![image](https://user-images.githubusercontent.com/63824432/89952988-1f745c00-dbe3-11ea-829d-9901cefbaaee.png)

_Entire page implementation:_
![image](https://user-images.githubusercontent.com/63824432/90075682-d7bd0580-dcb2-11ea-8d58-11c333f72b52.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.