### PR TITLE
implement switching tenant function on user profile button

### DIFF
--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -18,8 +18,9 @@ import ReactDOM from 'react-dom';
 import { CoreStart } from 'kibana/public';
 import { AccountNavButton } from './account-nav-button';
 import { fetchAccountInfoSafe } from './utils';
+import { ClientConfigType } from '../../types';
 
-export async function setupTopNavButton(coreStart: CoreStart) {
+export async function setupTopNavButton(coreStart: CoreStart, config: ClientConfigType) {
   const accountInfo = (await fetchAccountInfoSafe(coreStart.http))?.data;
   if (accountInfo) {
     coreStart.chrome.navControls.registerRight({
@@ -32,6 +33,7 @@ export async function setupTopNavButton(coreStart: CoreStart) {
             isInternalUser={accountInfo.is_internal_user}
             username={accountInfo.user_name}
             tenant={accountInfo.user_requested_tenants}
+            config={config}
           />,
           element
         );

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -31,12 +31,15 @@ import React, { useState } from 'react';
 import { RoleInfoPanel } from './role-info-panel';
 import { logout } from './utils';
 import { PasswordResetPanel } from './password-reset-panel';
+import { TenantSwitchPanel } from './tenant-switch-panel';
+import { ClientConfigType } from '../../types';
 
 export function AccountNavButton(props: {
   coreStart: CoreStart;
   isInternalUser: boolean;
   username: string;
   tenant?: string;
+  config?: ClientConfigType;
 }) {
   const [isPopoverOpen, setPopoverOpen] = useState<boolean>(false);
   const [modal, setModal] = useState<React.ReactNode>(null);
@@ -76,14 +79,21 @@ export function AccountNavButton(props: {
         View roles
       </EuiButtonEmpty>
       {horizontalRule}
-      {
-        // TODO: show switch tenants modal
-      }
-      <EuiButtonEmpty size="xs">Switch tenants</EuiButtonEmpty>
+      <EuiButtonEmpty
+        size="xs"
+        onClick={() =>
+          setModal(
+            <TenantSwitchPanel
+              {...props}
+              username={props.username}
+              handleClose={() => setModal(null)}
+            />
+          )
+        }
+      >
+        Switch tenants
+      </EuiButtonEmpty>
       {horizontalRule}
-      {
-        // TODO: show reset-password modal
-      }
       {props.isInternalUser && (
         <>
           <EuiButtonEmpty

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -1,0 +1,249 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { CoreStart } from 'kibana/public';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiOverlayMask,
+  EuiRadioGroup,
+  EuiSpacer,
+  EuiSuperSelect,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { keys } from 'lodash';
+import { selectTenant } from '../configuration/utils/tenant-utils';
+import { fetchAccountInfo } from './utils';
+import { GENERIC_ERROR_INSTRUCTION } from '../apps-constants';
+
+interface TenantSwitchPanelProps {
+  coreStart: CoreStart;
+  handleClose: () => void;
+}
+
+const GLOBAL_TENANT_KEY_NAME = 'global_tenant';
+const GLOBAL_TENANT_RADIO_ID = 'global';
+const PRIVATE_TENANT_RADIO_ID = 'private';
+const CUSTOM_TENANT_RADIO_ID = 'custom';
+
+export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
+  const [tenants, setTenants] = useState<string[]>([]);
+  const [errorCallOut, setErrorCallOut] = useState<string>();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const tenantsInfo = (await fetchAccountInfo(props.coreStart.http)).data.tenants || {};
+        setTenants(keys(tenantsInfo).filter((tenantName) => tenantsInfo[tenantName]));
+      } catch (e) {
+        // TODO: switch to better error display.
+        console.error(e);
+      }
+    };
+
+    fetchData();
+  }, [props.coreStart.http]);
+
+  // Custom tenant super select related.
+  const [selectedCustomTenantOption, setSelectedCustomTenantOption] = useState<string>('');
+  const onCustomTenantChange = (selectedOption: string) => {
+    setSelectedCustomTenantOption(selectedOption);
+    setErrorCallOut('');
+  };
+  const customTenantOptions = tenants.filter((tenant) => {
+    return tenant !== GLOBAL_TENANT_KEY_NAME && tenant !== props.username;
+  });
+
+  const isMultiTenancyEnabled = props.config.multitenancy.enabled;
+  const isGlobalEnabled = props.config.multitenancy.tenants.enable_global;
+  const isPrivateEnabled = props.config.multitenancy.tenants.enable_private;
+
+  const shouldDisableGlobal = !isGlobalEnabled || !tenants.includes(GLOBAL_TENANT_KEY_NAME);
+  const getGlobalDisabledInstruction = () => {
+    if (!isGlobalEnabled) {
+      return 'Contact the administrator to enable global tenant.';
+    }
+
+    if (!tenants.includes(GLOBAL_TENANT_KEY_NAME)) {
+      return 'Contact the administrator to get access to global tenant.';
+    }
+  };
+
+  // The key for private tenant is the user name.
+  const shouldDisablePrivate = !isPrivateEnabled || !tenants.includes(props.username);
+  const getPrivateDisabledInstruction = () => {
+    if (!isPrivateEnabled) {
+      return 'Contact the administrator to enable private tenant.';
+    }
+
+    if (!tenants.includes(props.username)) {
+      return 'Contact the administrator to get access to private tenant.';
+    }
+  };
+
+  // Tenant switch radios related.
+  const tenantSwitchRadios = [
+    {
+      id: GLOBAL_TENANT_RADIO_ID,
+      label: (
+        <>
+          Global
+          <EuiText size="s">The global tenant is shared between every Kibana user.</EuiText>
+          {shouldDisableGlobal && <i>{getGlobalDisabledInstruction()}</i>}
+          <EuiSpacer />
+        </>
+      ),
+      disabled: shouldDisableGlobal,
+    },
+    {
+      id: PRIVATE_TENANT_RADIO_ID,
+      label: (
+        <>
+          Private
+          <EuiText size="s">
+            The private tenant is exclusive to each user and can&apos;t be shared. You might use the
+            private tenant for exploratory work.
+          </EuiText>
+          {shouldDisablePrivate && <i>{getPrivateDisabledInstruction()}</i>}
+          <EuiSpacer />
+        </>
+      ),
+      disabled: shouldDisablePrivate,
+    },
+    {
+      id: CUSTOM_TENANT_RADIO_ID,
+      label: (
+        <>
+          Choose from custom
+          <EuiSuperSelect
+            options={customTenantOptions.map((option: string) => ({
+              value: option,
+              inputDisplay: option,
+            }))}
+            valueOfSelected={selectedCustomTenantOption}
+            onChange={onCustomTenantChange}
+            style={{ width: 400 }}
+          />
+        </>
+      ),
+      disabled: customTenantOptions.length === 0,
+    },
+  ];
+
+  const [tenantSwitchRadioIdSelected, setTenantSwitchRadioIdSelected] = useState<string>();
+  const onTenantSwitchRadioChange = (radioId: string) => {
+    setTenantSwitchRadioIdSelected(radioId);
+    setErrorCallOut('');
+  };
+
+  const changeTenant = async (tenantName: string) => {
+    await selectTenant(props.coreStart.http, {
+      tenant: tenantName,
+      username: props.username,
+    });
+  };
+
+  const handleTenantConfirmation = async function () {
+    let tenantName;
+
+    if (tenantSwitchRadioIdSelected === GLOBAL_TENANT_RADIO_ID) {
+      tenantName = '';
+    } else if (tenantSwitchRadioIdSelected === PRIVATE_TENANT_RADIO_ID) {
+      tenantName = '__user__';
+    } else if (tenantSwitchRadioIdSelected === CUSTOM_TENANT_RADIO_ID) {
+      if (selectedCustomTenantOption) {
+        tenantName = selectedCustomTenantOption;
+      }
+    }
+
+    // check tenant name before calling backend
+    if (tenantName === undefined) {
+      setErrorCallOut('No target tenant is specified!');
+    } else {
+      try {
+        await changeTenant(tenantName);
+        props.handleClose();
+      } catch (e) {
+        if (e.body) {
+          setErrorCallOut('Failed to switch tenant due to ' + e.body?.message);
+        } else {
+          setErrorCallOut('Failed to switch tenant. ' + GENERIC_ERROR_INSTRUCTION);
+        }
+      }
+    }
+  };
+
+  let content;
+
+  if (isMultiTenancyEnabled) {
+    content = (
+      <>
+        <EuiRadioGroup
+          options={tenantSwitchRadios}
+          idSelected={tenantSwitchRadioIdSelected}
+          onChange={(radioId) => onTenantSwitchRadioChange(radioId)}
+          name="tenantSwitchRadios"
+        />
+
+        <EuiSpacer />
+
+        {errorCallOut && (
+          <EuiCallOut color="danger" iconType="alert">
+            {errorCallOut}
+          </EuiCallOut>
+        )}
+      </>
+    );
+  } else {
+    content = <>Contact the administrator to enable multi tenancy.</>;
+  }
+
+  return (
+    <EuiOverlayMask>
+      <EuiModal onClose={props.handleClose}>
+        <EuiSpacer />
+        <EuiModalBody>
+          <EuiTitle>
+            <h4>Select your tenant</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          <EuiText size="s" color="subdued">
+            Tenants are useful for safely sharing your work with other Kibana users. You can switch
+            your tenant anytime by clicking the user avatar on top right.
+          </EuiText>
+
+          <EuiSpacer />
+
+          {content}
+        </EuiModalBody>
+        <EuiModalFooter>
+          <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
+
+          <EuiButton fill disabled={!isMultiTenancyEnabled} onClick={handleTenantConfirmation}>
+            Confirm
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
+}

--- a/public/apps/apps-constants.tsx
+++ b/public/apps/apps-constants.tsx
@@ -1,0 +1,18 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+// TODO: use this constant for wherever the generic error instruction is used.
+export const GENERIC_ERROR_INSTRUCTION =
+  'You may refresh the page to retry or see browser console for more information.';

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -83,7 +83,9 @@ export class OpendistroSecurityPlugin
   }
 
   public start(core: CoreStart): OpendistroSecurityPluginStart {
-    setupTopNavButton(core);
+    const config = this.initializerContext.config.get<ClientConfigType>();
+
+    setupTopNavButton(core, config);
 
     return {};
   }

--- a/public/types.ts
+++ b/public/types.ts
@@ -47,6 +47,7 @@ export interface ClientConfigType {
     enabled: boolean;
     tenants: {
       enable_private: boolean;
+      enable_global: boolean;
     };
   };
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds the function to switch tenant on the user profile button. Note that the mockup only shows the happy case. However, there are different cases we need to handle depending on different combinations of configuration.

*Test*
**Mockup**
<img width="788" alt="Screen Shot 2020-08-13 at 7 55 50 PM" src="https://user-images.githubusercontent.com/60111637/90208965-044e4b80-dd9f-11ea-8595-690fb294ac8c.png">

**Happy case**
<img width="2547" alt="Screen Shot 2020-08-13 at 7 18 39 PM" src="https://user-images.githubusercontent.com/60111637/90209003-19c37580-dd9f-11ea-8242-42b400a2aaa6.png">

<img width="2550" alt="Screen Shot 2020-08-13 at 7 19 24 PM" src="https://user-images.githubusercontent.com/60111637/90209019-221bb080-dd9f-11ea-8054-d3053be3da93.png">

Verified from network call that the right parameters are passed to backend.

**No target tenant is selected.**
<img width="2552" alt="Screen Shot 2020-08-13 at 7 22 01 PM" src="https://user-images.githubusercontent.com/60111637/90209049-35c71700-dd9f-11ea-9cd2-4f104ad9bf41.png">

**Multi tenancy is disabled**
<img width="2531" alt="Screen Shot 2020-08-13 at 7 23 23 PM" src="https://user-images.githubusercontent.com/60111637/90209090-4b3c4100-dd9f-11ea-8faa-8b3beb79391e.png">


**Global and private disabled by config**
<img width="2542" alt="Screen Shot 2020-08-13 at 7 25 16 PM" src="https://user-images.githubusercontent.com/60111637/90209126-5d1de400-dd9f-11ea-9198-2e8d1589197f.png">


**Global and private have no access**
<img width="977" alt="Screen Shot 2020-08-13 at 7 31 49 PM" src="https://user-images.githubusercontent.com/60111637/90209147-69a23c80-dd9f-11ea-9c5d-d9076ce0cce1.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
