### PR TITLE
[RoleMapping] redirect to read view with toast after save success

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -147,7 +147,7 @@ export function AppRouter(props: AppDependencies) {
               )}
             />
             <Route
-              path={buildUrl(ResourceType.roles, Action.view, ':roleName')}
+              path={buildUrl(ResourceType.roles, Action.view, ':roleName', ':prevAction?')}
               render={(match) => (
                 <RoleView
                   buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}

--- a/public/apps/configuration/panels/role-mapping/RoleEditMappedUser.tsx
+++ b/public/apps/configuration/panels/role-mapping/RoleEditMappedUser.tsx
@@ -41,6 +41,7 @@ import { ResourceType, RoleMappingDetail, SubAction, Action } from '../../types'
 import { fetchUserNameList } from '../../utils/internal-user-list-utils';
 import { updateRoleMapping, getRoleMappingData } from '../../utils/role-mapping-utils';
 import { createErrorToast, createUnknownErrorToast, useToastState } from '../../utils/toast-utils';
+import { DocLinks } from '../../constants';
 
 interface RoleEditMappedUserProps extends BreadcrumbsPageDependencies {
   roleName: string;
@@ -104,11 +105,12 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
         hosts,
       };
       await updateRoleMapping(props.coreStart.http, props.roleName, updateObject);
-      addToast({
-        id: 'updateRoleMappingSucceeded',
-        color: 'success',
-        title: props.roleName + ' saved.',
-      });
+      window.location.href = buildHashUrl(
+        ResourceType.roles,
+        Action.view,
+        props.roleName,
+        SubAction.mapuser
+      );
     } catch (e) {
       if (e.message) {
         addToast(createErrorToast('saveRoleMappingFailed', 'save error', e.message));
@@ -129,7 +131,7 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
           </EuiTitle>
           Map users to this role to inherit role permissions. Two types of users are supported:
           internal user, and external identity.{' '}
-          <EuiLink external href="/">
+          <EuiLink external href={DocLinks.MapUsersToRolesDoc} target="_blank">
             Learn More
           </EuiLink>
         </EuiText>

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -32,8 +32,6 @@ import {
   EuiEmptyPrompt,
   EuiCallOut,
   EuiGlobalToastList,
-  EuiOverlayMask,
-  EuiConfirmModal,
 } from '@elastic/eui';
 import { difference } from 'lodash';
 import { BreadcrumbsPageDependencies } from '../../../types';
@@ -169,7 +167,7 @@ export function RoleView(props: RoleViewProps) {
     closeDeleteConfirmModal,
     showDeleteConfirmModal,
     deleteConfirmModal,
-  ] = useDeleteConfirmState(handleRoleMappingDelete, selection, 'mappings');
+  ] = useDeleteConfirmState(handleRoleMappingDelete, selection.length, 'mappings');
 
   const message = (
     <EuiEmptyPrompt

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -64,6 +64,7 @@ import { TenantsPanel } from './tenants-panel';
 import { transformRoleIndexPermissions } from '../../utils/index-permission-utils';
 import { transformRoleTenantPermissions } from '../../utils/tenant-utils';
 import { DocLinks } from '../../constants';
+import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
 
 interface RoleViewProps extends BreadcrumbsPageDependencies {
   roleName: string;
@@ -97,9 +98,9 @@ export function RoleView(props: RoleViewProps) {
   const [roleTenantPermission, setRoleTenantPermission] = useState<RoleTenantPermissionView[]>([]);
   const [toasts, addToast, removeToast] = useToastState();
   const [isReserved, setIsReserved] = useState(false);
-  const [isDeleteConfirmModalVisible, setIsDeleteConfirmModalVisible] = useState(false);
-  const closeDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(false);
-  const showDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(true);
+
+  const PERMISSIONS_TAB_INDEX = 0;
+  const MAP_USER_TAB_INDEX = 1;
 
   useEffect(() => {
     const fetchData = async () => {
@@ -164,24 +165,11 @@ export function RoleView(props: RoleViewProps) {
     }
   };
 
-  let deleteConfirmModal;
-
-  if (isDeleteConfirmModalVisible) {
-    deleteConfirmModal = (
-      <EuiOverlayMask>
-        <EuiConfirmModal
-          title="Confirm Delete"
-          onCancel={closeDeleteConfirmModal}
-          onConfirm={handleRoleMappingDelete}
-          cancelButtonText="Cancel"
-          confirmButtonText="Confirm"
-          defaultFocusedButton="confirm"
-        >
-          <p>Do you really want to delete selected {selection.length} mappings?</p>
-        </EuiConfirmModal>
-      </EuiOverlayMask>
-    );
-  }
+  const [
+    closeDeleteConfirmModal,
+    showDeleteConfirmModal,
+    deleteConfirmModal,
+  ] = useDeleteConfirmState(handleRoleMappingDelete, selection, 'mappings');
 
   const message = (
     <EuiEmptyPrompt
@@ -362,7 +350,11 @@ export function RoleView(props: RoleViewProps) {
 
       <EuiTabbedContent
         tabs={tabs}
-        initialSelectedTab={props.prevAction === SubAction.mapuser ? tabs[1] : tabs[0]}
+        initialSelectedTab={
+          props.prevAction === SubAction.mapuser
+            ? tabs[MAP_USER_TAB_INDEX]
+            : tabs[PERMISSIONS_TAB_INDEX]
+        }
       />
 
       <EuiSpacer />

--- a/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
+++ b/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
@@ -19,16 +19,16 @@ import { EuiOverlayMask, EuiConfirmModal } from '@elastic/eui';
 /**
  *
  * @param handleDelete: [Type: func] delete function which needs to be execute on click of confirm button.
- * @param selection: Selected list of items.
+ * @param noOfSelectedItems: Count of selected Items for deletion.
  * @param entity: e.g. roles, tenants, users, mapping etc. This will display in confirmation text before deletion.
- * @param customText: If you want other than default confirm message, pass it as customText.
+ * @param customConfirmationText: If you want other than default confirm message, pass it as customConfirmationText.
  */
 export function useDeleteConfirmState(
   handleDelete: () => Promise<void>,
-  selection: any[],
+  noOfSelectedItems: number,
   entity: string,
-  customText = null
-): [() => void, () => void, any] {
+  customConfirmationText?: React.ReactNode
+): [() => void, () => void, React.ReactNode] {
   const [isDeleteConfirmModalVisible, setIsDeleteConfirmModalVisible] = useState(false);
   const closeDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(false);
   const showDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(true);
@@ -45,11 +45,13 @@ export function useDeleteConfirmState(
           confirmButtonText="Confirm"
           defaultFocusedButton="confirm"
         >
-          <p>
-            {customText !== null
-              ? customText
-              : `Do you really want to delete selected ${selection.length} mappings?`}
-          </p>
+          {customConfirmationText ? (
+            customConfirmationText
+          ) : (
+            <p>
+              Do you really want to delete selected {noOfSelectedItems} {entity}?
+            </p>
+          )}
         </EuiConfirmModal>
       </EuiOverlayMask>
     );

--- a/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
+++ b/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import { EuiOverlayMask, EuiConfirmModal } from '@elastic/eui';
+
+/**
+ *
+ * @param handleDelete: [Type: func] delete function which needs to be execute on click of confirm button.
+ * @param selection: Selected list of items.
+ * @param entity: e.g. roles, tenants, users, mapping etc. This will display in confirmation text before deletion.
+ * @param customText: If you want other than default confirm message, pass it as customText.
+ */
+export function useDeleteConfirmState(
+  handleDelete: () => Promise<void>,
+  selection: any[],
+  entity: string,
+  customText = null
+): [() => void, () => void, any] {
+  const [isDeleteConfirmModalVisible, setIsDeleteConfirmModalVisible] = useState(false);
+  const closeDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(false);
+  const showDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(true);
+
+  let deleteConfirmModal;
+  if (isDeleteConfirmModalVisible) {
+    deleteConfirmModal = (
+      <EuiOverlayMask>
+        <EuiConfirmModal
+          title="Confirm Delete"
+          onCancel={closeDeleteConfirmModal}
+          onConfirm={handleDelete}
+          cancelButtonText="Cancel"
+          confirmButtonText="Confirm"
+          defaultFocusedButton="confirm"
+        >
+          <p>
+            {customText !== null
+              ? customText
+              : `Do you really want to delete selected ${selection.length} mappings?`}
+          </p>
+        </EuiConfirmModal>
+      </EuiOverlayMask>
+    );
+  }
+  return [closeDeleteConfirmModal, showDeleteConfirmModal, deleteConfirmModal];
+}


### PR DESCRIPTION
… add delete confirm modal

*Issue #, if available:*

*Description of changes:*

- Before this change, the success toast was showing on the same edit page. This change will redirect to the read view of role mapping after a successful save and display the toast with a corresponding success message.

- Also added Delete confirm modal.

_Testing:_

> Show Success toast

![image](https://user-images.githubusercontent.com/63824432/90211434-8772a000-dda5-11ea-9c75-33b1cdb36551.png)

> Delete Confirm Modal

![image](https://user-images.githubusercontent.com/63824432/90211497-b25cf400-dda5-11ea-93fc-467690a3e55c.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
