### PR TITLE
Integ test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 .eslintcache
 yarn.lock
 /coverage/
+.es/
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:sass": "node ../../scripts/sasslint",
     "lint": "yarn run lint:es && yarn run lint:sass",
     "test:jest": "NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "test:jest_integ": "NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.integration.js"
+    "test:jest_integ": "node ./test/jest_integ_test.js"
   },
   "devDependencies": {
     "typescript": "3.9.5"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:es": "node ../../scripts/eslint",
     "lint:sass": "node ../../scripts/sasslint",
     "lint": "yarn run lint:es && yarn run lint:sass",
-    "test:jest": "NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js"
+    "test:jest": "NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js",
+    "test:jest_integ": "NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.integration.js"
   },
   "devDependencies": {
     "typescript": "3.9.5"

--- a/test/constant.ts
+++ b/test/constant.ts
@@ -15,3 +15,6 @@
 
 export const KIBANA_SERVER_USER: string = 'kibanaserver';
 export const KIBANA_SERVER_PASSWORD: string = 'kibanaserver';
+
+export const ELASTICSEARCH_VERSION: string = '7.8.0';
+export const SECURITY_ES_PLUGIN_VERSION: string = '1.9.0.0';

--- a/test/constant.ts
+++ b/test/constant.ts
@@ -1,0 +1,17 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export const KIBANA_SERVER_USER: string = 'kibanaserver';
+export const KIBANA_SERVER_PASSWORD: string = 'kibanaserver';

--- a/test/es/elasticsearch_helper.ts
+++ b/test/es/elasticsearch_helper.ts
@@ -1,0 +1,122 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import wreck from '@hapi/wreck';
+import { sleep } from '../helper/sleep';
+import { KIBANA_SERVER_USER, KIBANA_SERVER_PASSWORD } from '../constant';
+
+const PLUGIN_ROOT_DIR = path.resolve(__dirname, '../..');
+const ES_INSTALL_DIR = path.resolve(PLUGIN_ROOT_DIR, '.es');
+let esRootDir: string;
+
+export function downloadElasticsearch(esVersion: string): string {
+  if (fs.existsSync(ES_INSTALL_DIR)) {
+    childProcess.execSync(`rm -rf .es`, { cwd: PLUGIN_ROOT_DIR });
+  }
+  fs.mkdirSync(ES_INSTALL_DIR);
+
+  console.log(`Downloading Elasticsearch...`);
+  const esDownloadURL = `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${esVersion}-darwin-x86_64.tar.gz`;
+  // https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistro-elasticsearch/opendistroforelasticsearch-1.9.0.tar.gz`;
+  childProcess.execSync(`curl -o elasticsearch-oss-${esVersion}.tar.gz ${esDownloadURL}`, {
+    cwd: ES_INSTALL_DIR,
+  });
+  childProcess.execSync(`tar -zxvf elasticsearch-oss-${esVersion}.tar.gz`, { cwd: ES_INSTALL_DIR });
+  esRootDir = path.resolve(ES_INSTALL_DIR, `elasticsearch-${esVersion}`);
+  return esRootDir;
+}
+
+export function installEsSecurityPlugin(pluginVersion: string) {
+  const pluginDir = path.resolve(esRootDir, 'plugins');
+
+  if (!fs.existsSync(pluginDir)) {
+    fs.mkdirSync(pluginDir);
+  }
+  childProcess.execSync(
+    `yes | bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-security/opendistro_security-${pluginVersion}.zip`,
+    {
+      cwd: path.resolve(esRootDir),
+    }
+  );
+  const installDemoScript = path.resolve(
+    pluginDir,
+    'opendistro_security/tools/install_demo_configuration.sh'
+  );
+  childProcess.execSync(`chmod a+x ${installDemoScript}`, { cwd: pluginDir });
+  childProcess.execSync(`yes | ${installDemoScript}`, { cwd: pluginDir });
+}
+
+export async function startElasticsearch() {
+  // start ES process
+  if (!esRootDir) {
+    esRootDir = path.resolve(ES_INSTALL_DIR, 'elasticsearch-7.8.0');
+    console.log(`Using esRootDir: ${esRootDir}`);
+  }
+
+  console.log(`Starting Elasticsearch...`);
+  const esCmd = path.resolve(esRootDir, 'bin/elasticsearch');
+  const esProcess = childProcess.exec(esCmd);
+  console.log(`Elasticsearch pid: ${esProcess.pid}`);
+
+  // ping ES to make sure ES is up
+  let countdown = 30;
+  let pingError;
+  console.log(`Waiting for Elasticsearch to start`);
+  const kbnServerCredentials = Buffer.from(`${KIBANA_SERVER_USER}:${KIBANA_SERVER_PASSWORD}`);
+  while (countdown > 0) {
+    countdown = countdown - 1;
+    await sleep(5000);
+    try {
+      console.log('pinging ES');
+      const response = await wreck.get('https://localhost:9200', {
+        // agent: false,
+        rejectUnauthorized: false,
+        headers: {
+          authorization: `Basic ${kbnServerCredentials.toString('base64')}`,
+        },
+      });
+      if (
+        response.res.statusCode &&
+        response.res.statusCode >= 200 &&
+        response.res.statusCode < 300
+      ) {
+        return esProcess;
+      }
+    } catch (error) {
+      pingError = error;
+    }
+  }
+  esProcess.kill('SIGINT');
+  throw new Error(`Failed to launch Elasticsearch process. Error: ${pingError}`);
+}
+
+export async function stopElasticsearch(process: childProcess.ChildProcess) {
+  console.log('Stopping Elasticsearch');
+  process.kill('SIGTERM');
+  let countdown = 5;
+  while (countdown > 0) {
+    countdown = countdown - 1;
+    if (!process.killed) {
+      await sleep(1000);
+    } else {
+      return;
+    }
+  }
+  console.log(`Force killing Elasticsearch process`);
+  process.kill('SIGINT');
+}

--- a/test/es/elasticsearch_helper.ts
+++ b/test/es/elasticsearch_helper.ts
@@ -18,37 +18,47 @@ import * as path from 'path';
 import * as childProcess from 'child_process';
 import wreck from '@hapi/wreck';
 import { sleep } from '../helper/sleep';
-import { KIBANA_SERVER_USER, KIBANA_SERVER_PASSWORD } from '../constant';
+import {
+  KIBANA_SERVER_USER,
+  KIBANA_SERVER_PASSWORD,
+  ELASTICSEARCH_VERSION,
+  SECURITY_ES_PLUGIN_VERSION,
+} from '../constant';
 
 const PLUGIN_ROOT_DIR = path.resolve(__dirname, '../..');
 const ES_INSTALL_DIR = path.resolve(PLUGIN_ROOT_DIR, '.es');
 let esRootDir: string;
 
-export function downloadElasticsearch(esVersion: string): string {
+export function downloadElasticsearch(): string {
   if (fs.existsSync(ES_INSTALL_DIR)) {
     childProcess.execSync(`rm -rf .es`, { cwd: PLUGIN_ROOT_DIR });
   }
   fs.mkdirSync(ES_INSTALL_DIR);
 
   console.log(`Downloading Elasticsearch...`);
-  const esDownloadURL = `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${esVersion}-darwin-x86_64.tar.gz`;
+  const esDownloadURL = `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ELASTICSEARCH_VERSION}-darwin-x86_64.tar.gz`;
   // https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistro-elasticsearch/opendistroforelasticsearch-1.9.0.tar.gz`;
-  childProcess.execSync(`curl -o elasticsearch-oss-${esVersion}.tar.gz ${esDownloadURL}`, {
+  childProcess.execSync(
+    `curl -o elasticsearch-oss-${ELASTICSEARCH_VERSION}.tar.gz ${esDownloadURL}`,
+    {
+      cwd: ES_INSTALL_DIR,
+    }
+  );
+  childProcess.execSync(`tar -zxvf elasticsearch-oss-${ELASTICSEARCH_VERSION}.tar.gz`, {
     cwd: ES_INSTALL_DIR,
   });
-  childProcess.execSync(`tar -zxvf elasticsearch-oss-${esVersion}.tar.gz`, { cwd: ES_INSTALL_DIR });
-  esRootDir = path.resolve(ES_INSTALL_DIR, `elasticsearch-${esVersion}`);
+  esRootDir = path.resolve(ES_INSTALL_DIR, `elasticsearch-${ELASTICSEARCH_VERSION}`);
   return esRootDir;
 }
 
-export function installEsSecurityPlugin(pluginVersion: string) {
+export function installEsSecurityPlugin() {
   const pluginDir = path.resolve(esRootDir, 'plugins');
 
   if (!fs.existsSync(pluginDir)) {
     fs.mkdirSync(pluginDir);
   }
   childProcess.execSync(
-    `yes | bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-security/opendistro_security-${pluginVersion}.zip`,
+    `yes | bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-security/opendistro_security-${SECURITY_ES_PLUGIN_VERSION}.zip`,
     {
       cwd: path.resolve(esRootDir),
     }
@@ -57,14 +67,14 @@ export function installEsSecurityPlugin(pluginVersion: string) {
     pluginDir,
     'opendistro_security/tools/install_demo_configuration.sh'
   );
-  childProcess.execSync(`chmod a+x ${installDemoScript}`, { cwd: pluginDir });
-  childProcess.execSync(`yes | ${installDemoScript}`, { cwd: pluginDir });
+  childProcess.execSync(`chmod a+x ${installDemoScript}`, { cwd: esRootDir });
+  childProcess.execSync(`yes | ${installDemoScript}`, { cwd: esRootDir });
 }
 
 export async function startElasticsearch() {
   // start ES process
   if (!esRootDir) {
-    esRootDir = path.resolve(ES_INSTALL_DIR, 'elasticsearch-7.8.0');
+    esRootDir = path.resolve(ES_INSTALL_DIR, `elasticsearch-${ELASTICSEARCH_VERSION}`);
     console.log(`Using esRootDir: ${esRootDir}`);
   }
 

--- a/test/es/setup_es.js
+++ b/test/es/setup_es.js
@@ -16,5 +16,5 @@
 import { downloadElasticsearch, installEsSecurityPlugin } from './elasticsearch_helper';
 
 console.log('Preparing Elasticsearch for testing');
-downloadElasticsearch('7.8.0');
-installEsSecurityPlugin('1.9.0.0');
+downloadElasticsearch();
+installEsSecurityPlugin();

--- a/test/es/setup_es.js
+++ b/test/es/setup_es.js
@@ -1,0 +1,20 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { downloadElasticsearch, installEsSecurityPlugin } from './elasticsearch_helper';
+
+console.log('Preparing Elasticsearch for testing');
+downloadElasticsearch('7.8.0');
+installEsSecurityPlugin('1.9.0.0');

--- a/test/helper/sleep.ts
+++ b/test/helper/sleep.ts
@@ -1,0 +1,20 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/test/jest.config.integration.js
+++ b/test/jest.config.integration.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+module.exports = {
+  rootDir: '../',
+  setupFiles: ['<rootDir>/test/setupTests.ts'],
+  // setupFilesAfterEnv: ["<rootDir>/test/setup.jest.ts"],
+  roots: ['<rootDir>'],
+  coverageDirectory: './coverage',
+  moduleNameMapper: {
+    // "\\.(css|less|scss)$": "<rootDir>/test/mocks/styleMock.ts",
+    // "^ui/(.*)": "<rootDir>/../../src/legacy/ui/public/$1/",
+  },
+  modulePathIgnorePatterns: ['<rootDir>/target/'],
+  coverageReporters: ['lcov', 'text', 'cobertura'],
+  testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
+  collectCoverageFrom: [
+    '**/*.ts',
+    '**/*.tsx',
+    '**/*.js',
+    '**/*.jsx',
+    '!**/models/**',
+    '!**/node_modules/**',
+    // "!**/index.ts",
+    // "!<rootDir>/index.js",
+    // "!<rootDir>/public/app.js",
+    // "!<rootDir>/public/temporary/**",
+    '!<rootDir>/babel.config.js',
+    '!<rootDir>/test/**',
+    // "!<rootDir>/server/**",
+    '!<rootDir>/coverage/**',
+    '!<rootDir>/scripts/**',
+    '!<rootDir>/build/**',
+    '!**/vendor/**',
+  ],
+  clearMocks: true,
+  testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+};

--- a/test/jest.config.integration.js
+++ b/test/jest.config.integration.js
@@ -13,38 +13,21 @@
  * permissions and limitations under the License.
  */
 
-module.exports = {
-  rootDir: '../',
-  setupFiles: ['<rootDir>/test/setupTests.ts'],
-  // setupFilesAfterEnv: ["<rootDir>/test/setup.jest.ts"],
-  roots: ['<rootDir>'],
-  coverageDirectory: './coverage',
-  moduleNameMapper: {
-    // "\\.(css|less|scss)$": "<rootDir>/test/mocks/styleMock.ts",
-    // "^ui/(.*)": "<rootDir>/../../src/legacy/ui/public/$1/",
-  },
-  modulePathIgnorePatterns: ['<rootDir>/target/'],
-  coverageReporters: ['lcov', 'text', 'cobertura'],
-  testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
-  collectCoverageFrom: [
-    '**/*.ts',
-    '**/*.tsx',
-    '**/*.js',
-    '**/*.jsx',
-    '!**/models/**',
-    '!**/node_modules/**',
-    // "!**/index.ts",
-    // "!<rootDir>/index.js",
-    // "!<rootDir>/public/app.js",
-    // "!<rootDir>/public/temporary/**",
-    '!<rootDir>/babel.config.js',
-    '!<rootDir>/test/**',
-    // "!<rootDir>/server/**",
-    '!<rootDir>/coverage/**',
-    '!<rootDir>/scripts/**',
-    '!<rootDir>/build/**',
-    '!**/vendor/**',
+import config from '../../../src/dev/jest/config';
+
+export default {
+  ...config,
+  roots: ['<rootDir>/plugins/opendistro_security'],
+  testMatch: ['**/test/jest_integration/**/*.test.ts'],
+  testPathIgnorePatterns: config.testPathIgnorePatterns.filter(
+    (pattern) => !pattern.includes('integration_tests')
+  ),
+  reporters: [
+    'default',
+    ['<rootDir>/src/dev/jest/junit_reporter.js', { reportName: 'Jest Integration Tests' }],
   ],
-  clearMocks: true,
-  testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+  setupFilesAfterEnv: [
+    '<rootDir>/src/dev/jest/setup/after_env.integration.js',
+    '<rootDir>/plugins/opendistro_security/test/es/setup_es.js',
+  ],
 };

--- a/test/jest_integ_test.js
+++ b/test/jest_integ_test.js
@@ -1,0 +1,23 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+const resolve = require('path').resolve;
+
+process.argv.push('--config', resolve(__dirname, './jest.config.integration.js'));
+process.argv.push('--runInBand');
+process.argv.push('--no-cache');
+
+require('../../../src/setup_node_env');
+require('../../../src/dev/jest/cli');

--- a/test/jest_integration/integration.test.ts
+++ b/test/jest_integration/integration.test.ts
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import * as kbnTestServer from '../../../../src/test_utils/kbn_server';
+import { Root } from '../../../../src/core/server/root';
+import { resolve } from 'path';
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
+
+describe(`start kibana server`, () => {
+  let root: Root;
+
+  beforeAll(async () => {
+    // root = knbTestServer.createRootWithSettings({
+    //   plugins: {
+    //     scanDirs: [resolve(__dirname, '../..')],
+    //   },
+    //   elasticsearch: {
+    //     username: 'kibanaserver',
+    //     password: 'kibanaserver',
+    //   },
+    // });
+    
+    // root = kbnTestServer.
+    await root.setup();
+    await root.start();
+  });
+
+  afterAll(async () => {
+    await root.shutdown();
+  });
+
+  it(`dummy test`, () => {
+    expect(1).toEqual(302);
+  });
+});

--- a/test/jest_integration/integration.test.ts
+++ b/test/jest_integration/integration.test.ts
@@ -17,31 +17,67 @@ import * as kbnTestServer from '../../../../src/test_utils/kbn_server';
 import { Root } from '../../../../src/core/server/root';
 import { resolve } from 'path';
 import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
+import { sleep } from '../helper/sleep';
+import { startElasticsearch, stopElasticsearch } from '../es/elasticsearch_helper';
+import { ChildProcess } from 'child_process';
 
 describe(`start kibana server`, () => {
   let root: Root;
+  let esProcess: ChildProcess;
 
   beforeAll(async () => {
-    // root = knbTestServer.createRootWithSettings({
-    //   plugins: {
-    //     scanDirs: [resolve(__dirname, '../..')],
-    //   },
-    //   elasticsearch: {
-    //     username: 'kibanaserver',
-    //     password: 'kibanaserver',
-    //   },
-    // });
-    
-    // root = kbnTestServer.
+    esProcess = await startElasticsearch();
+    console.log('Started Elasticsearch');
+
+    root = kbnTestServer.createRootWithSettings(
+      {
+        plugins: {
+          scanDirs: [resolve(__dirname, '../..')],
+        },
+        elasticsearch: {
+          hosts: ['https://localhost:9200'],
+          ignoreVersionMismatch: true,
+          ssl: { verificationMode: 'none' },
+          username: 'kibanaserver',
+          password: 'kibanaserver',
+        },
+      },
+      {
+        // to make ignoreVersionMismatch setting work
+        // can be removed when we have corresponding ES version
+        dev: true,
+      }
+    );
+
     await root.setup();
     await root.start();
   });
 
   afterAll(async () => {
-    await root.shutdown();
+    // shutdown Kibana server
+    root.shutdown();
+    // shutdown Elasticsearch
+    await stopElasticsearch(esProcess);
   });
 
-  it(`dummy test`, () => {
-    expect(1).toEqual(302);
+  it(`can access login page without credentials`, async () => {
+    const response = await kbnTestServer.request.get(root, '/app/login');
+    expect(response.status).toEqual(200);
+  });
+
+  it(`call authinfo API as admin`, async () => {
+    const testUserCredentials = Buffer.from(`admin:admin`);
+    const response = await kbnTestServer.request
+      .get(root, '/api/v1/auth/authinfo')
+      .set('Authorization', `Basic ${testUserCredentials.toString('base64')}`);
+    expect(response.status).toEqual(200);
+  });
+
+  it(`call authinfo API without credentials`, async () => {
+    const testUserCredentials = Buffer.from(`admin:admin`);
+    const response = await kbnTestServer.request
+      .get(root, '/api/v1/auth/authinfo')
+      .unset('Authorization');
+    expect(response.status).toEqual(401);
   });
 });

--- a/test/jest_integration/integration.test.ts
+++ b/test/jest_integration/integration.test.ts
@@ -21,7 +21,7 @@ import { sleep } from '../helper/sleep';
 import { startElasticsearch, stopElasticsearch } from '../es/elasticsearch_helper';
 import { ChildProcess } from 'child_process';
 
-describe(`start kibana server`, () => {
+describe('start kibana server', () => {
   let root: Root;
   let esProcess: ChildProcess;
 
@@ -60,12 +60,12 @@ describe(`start kibana server`, () => {
     await stopElasticsearch(esProcess);
   });
 
-  it(`can access login page without credentials`, async () => {
+  it('can access login page without credentials', async () => {
     const response = await kbnTestServer.request.get(root, '/app/login');
     expect(response.status).toEqual(200);
   });
 
-  it(`call authinfo API as admin`, async () => {
+  it('call authinfo API as admin', async () => {
     const testUserCredentials = Buffer.from(`admin:admin`);
     const response = await kbnTestServer.request
       .get(root, '/api/v1/auth/authinfo')
@@ -73,7 +73,7 @@ describe(`start kibana server`, () => {
     expect(response.status).toEqual(200);
   });
 
-  it(`call authinfo API without credentials`, async () => {
+  it('call authinfo API without credentials', async () => {
     const testUserCredentials = Buffer.from(`admin:admin`);
     const response = await kbnTestServer.request
       .get(root, '/api/v1/auth/authinfo')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* add integ test command and one test suite

```
% yarn test:jest_integ
yarn run v1.22.0
$ node ./test/jest_integ_test.js
  console.log
    Using esRootDir: /Users/zengyan/kibana-security-workspace/kibana/plugins/opendistro_security/.es/elasticsearch-7.8.0

      at startElasticsearch (plugins/opendistro_security/test/es/elasticsearch_helper.ts:53:13)

  console.log
    Starting Elasticsearch...

      at startElasticsearch (plugins/opendistro_security/test/es/elasticsearch_helper.ts:56:11)

  console.log
    Elasticsearch pid: 99403

      at startElasticsearch (plugins/opendistro_security/test/es/elasticsearch_helper.ts:59:11)

  console.log
    Waiting for Elasticsearch to start

      at startElasticsearch (plugins/opendistro_security/test/es/elasticsearch_helper.ts:64:11)

  console.log
    pinging ES

      at startElasticsearch (plugins/opendistro_security/test/es/elasticsearch_helper.ts:70:15)

  console.log
    pinging ES

      at startElasticsearch (plugins/opendistro_security/test/es/elasticsearch_helper.ts:70:15)

  console.log
    Started Elasticsearch

      at Object.<anonymous> (plugins/opendistro_security/test/jest_integration/integration.test.ts:30:13)

 PASS  test/jest_integration/integration.test.ts (50.15s)
  start kibana server
    ✓ can access login page without credentials (37ms)
    ✓ call authinfo API as admin (275ms)
    ✓ call authinfo API without credentials (4ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        51.081s
Ran all test suites.
  console.log
    Stopping Elasticsearch

      at stopElasticsearch (plugins/opendistro_security/test/es/elasticsearch_helper.ts:94:11)

✨  Done in 57.30s.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
