### PR TITLE
Skip unauthenticated routes in multitenancy pre auth

### DIFF
--- a/lib/multitenancy/headers.js
+++ b/lib/multitenancy/headers.js
@@ -39,6 +39,7 @@ export default function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT, auth
     const private_enabled = config.get('opendistro_security.multitenancy.tenants.enable_private');
     const preferredTenants = config.get('opendistro_security.multitenancy.tenants.preferred');
     const debugEnabled = config.get('opendistro_security.multitenancy.debug');
+    const unauthenticatedRoutes = config.get('opendistro_security.auth.unauthenticated_routes');
     const backend = server.plugins.opendistro_security.getSecurityBackend();
 
     const defaultSpaceId = 'default';
@@ -71,6 +72,12 @@ export default function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT, auth
                 request.log(['info', 'security', 'tenant_url_param'], selectedTenant);
             }
 
+        }
+
+        // skip unauthenticated paths which contains /api/status by default
+        // attempting to assign auth headers and requesting for authinfo will fail as unauthorized
+        if (unauthenticatedRoutes.includes(request.path)) {
+            return h.continue;
         }
 
         // MT is only relevant for these paths


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Issue:
- `/api/status` request call is triggering `_opendistro/_security/authinfo` which is for authenticated users. Though the former request succeeds, the latter request fails.
- `/api/status` is commonly used by monitoring systems and can trigger a lot of failed requests in security backend plugin.
- `/api/status` is added by default to unauthenticated routes https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/blob/master/index.js#L44 .

Fix:
- Skip auth and continue for unauthenticated routes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
