### PR TITLE
[AuditLogging] remove callout from edit instructions

### DIFF
--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -13,9 +13,6 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiText } from '@elastic/eui';
-import React from 'react';
-
 export const CONFIG_LABELS = {
   AUDIT_LOGGING: 'Audit logging',
   GENERAL_SETTINGS: 'General settings',
@@ -49,7 +46,6 @@ export interface SettingContent {
   options?: string[];
   code?: string;
   error?: string;
-  callOut?: React.ReactNode;
 }
 
 const REST_LAYER: SettingContent = {
@@ -72,12 +68,6 @@ const REST_DISABLED_CATEGORIES: SettingContent = {
     'SSL_EXCEPTION',
     'AUTHENTICATED',
   ],
-  callOut: (
-    <EuiText>
-      We <i>highly</i> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. <br />
-      If enabled, these categories can result in a hugh number of logs.
-    </EuiText>
-  ),
 };
 
 const TRANSPORT_LAYER: SettingContent = {
@@ -100,12 +90,6 @@ const TRANSPORT_DISABLED_CATEGORIES: SettingContent = {
     'SSL_EXCEPTION',
     'AUTHENTICATED',
   ],
-  callOut: (
-    <EuiText>
-      We <i>highly</i> recommend excluding GRANTED_PRIVILEGES and AUTHENTICATED. <br />
-      If enabled, these categories can result in a hugh number of logs.
-    </EuiText>
-  ),
 };
 
 const BULK_REQUESTS: SettingContent = {
@@ -113,13 +97,6 @@ const BULK_REQUESTS: SettingContent = {
   path: 'audit.resolve_bulk_requests',
   description: 'Resolve bulk requests during auditing of requests.',
   type: 'bool',
-  callOut: (
-    <EuiText>
-      Enabling bulk requests generates one log per operation in the request. <br />
-      If you enable this setting, a single bulk request that indexes 10,000 documents results in
-      10,000 logs. If you disable this setting, that same request results in one log.
-    </EuiText>
-  ),
 };
 
 const REQUEST_BODY: SettingContent = {
@@ -204,12 +181,6 @@ const READ_WATCHED_FIELDS: SettingContent = {
   "twitter": ["id", "user*"]
 }`,
   error: 'Invalid content. Please check sample data content.',
-  callOut: (
-    <EuiText>
-      Adding watched fields generates one log each time a user accesses a document and could result
-      in a large number of logs. We don&apos;t recommend adding frequently accessed fields.
-    </EuiText>
-  ),
 };
 
 const WRITE_METADATA_ONLY: SettingContent = {
@@ -238,12 +209,6 @@ const WRITE_WATCHED_FIELDS: SettingContent = {
   path: 'compliance.write_watched_indices',
   description: 'List the indices to watch during write events.',
   type: 'array',
-  callOut: (
-    <EuiText>
-      Adding watched indices generates one log each time a user accesses a document and could result
-      in a large number of logs. We don&apos;t recommend adding frequently accessed indices.
-    </EuiText>
-  ),
 };
 
 const CONFIG = {

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -22,7 +22,6 @@ import {
   EuiSpacer,
   EuiSwitch,
   EuiTitle,
-  EuiCallOut,
 } from '@elastic/eui';
 import { get } from 'lodash';
 import { displayBoolean, displayObject } from '../../utils/display-utils';
@@ -39,10 +38,6 @@ const renderCodeBlock = (setting: SettingContent) => {
       </EuiCodeBlock>
     </>
   );
-};
-
-const renderCallOut = (setting: SettingContent) => {
-  return <EuiCallOut size={'s'}>{setting.callOut}</EuiCallOut>;
 };
 
 const displayLabel = (val: string) => {
@@ -148,7 +143,6 @@ export function EditSettingGroup(props: {
                 <div style={{ maxWidth: '450px' }}>
                   {setting.description}
                   {setting.code && renderCodeBlock(setting)}
-                  {setting.callOut && renderCallOut(setting)}
                 </div>
               }
               fullWidth


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change is to address latest UX changes. Specifically, this will remove the callout instruction from edit page.

*Test*:
**Current Mockup**
<img width="1420" alt="Screen Shot 2020-08-18 at 12 02 31 PM" src="https://user-images.githubusercontent.com/60111637/90554459-c197c500-e14a-11ea-887f-0ca7bde0c83c.png">

**new implementation**
<img width="2557" alt="Screen Shot 2020-08-18 at 11 56 33 AM" src="https://user-images.githubusercontent.com/60111637/90554508-d96f4900-e14a-11ea-82da-eea71d432526.png">

<img width="2541" alt="Screen Shot 2020-08-18 at 11 58 08 AM" src="https://user-images.githubusercontent.com/60111637/90554535-e1c78400-e14a-11ea-97ee-7dfe8d2c852c.png">

**Old implementation**

<img width="2532" alt="Screen Shot 2020-08-18 at 11 53 20 AM" src="https://user-images.githubusercontent.com/60111637/90554570-f015a000-e14a-11ea-95a9-43b271272754.png">
<img width="2503" alt="Screen Shot 2020-08-18 at 11 53 41 AM" src="https://user-images.githubusercontent.com/60111637/90554588-f73cae00-e14a-11ea-958f-6c443345bd13.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
