### PR TITLE
stringify http expression before passing to expression render

### DIFF
--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -48,7 +48,7 @@ const columns = [
   {
     field: 'http_configuration',
     name: 'HTTP configuration',
-    render: renderExpression('HTTP configuration'),
+    render: (config: object) => renderExpression('HTTP configuration', config),
   },
   {
     field: 'backend_type',
@@ -57,7 +57,7 @@ const columns = [
   {
     field: 'backend_configuration',
     name: 'Backend configuration',
-    render: renderExpression('Backend configuration'),
+    render: (config: object) => renderExpression('Backend configuration', config),
   },
 ];
 

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -39,7 +39,7 @@ const columns = [
   {
     field: 'backend_configuration',
     name: 'Backend configuration',
-    render: renderExpression('Backend configuration'),
+    render: (config: object) => renderExpression('Backend configuration', config),
   },
 ];
 

--- a/public/apps/configuration/panels/expression-modal.tsx
+++ b/public/apps/configuration/panels/expression-modal.tsx
@@ -24,7 +24,7 @@ import {
   EuiOverlayMask,
 } from '@elastic/eui';
 
-export function ExpressionModal(props: { title: string; expression: string }) {
+export function ExpressionModal(props: { title: string; expression: object }) {
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   const closeModal = () => setIsModalVisible(false);
@@ -43,7 +43,7 @@ export function ExpressionModal(props: { title: string; expression: string }) {
 
           <EuiModalBody>
             <EuiCodeBlock fontSize="m" paddingSize="m" color="dark" overflowHeight={300} isCopyable>
-              {JSON.stringify(JSON.parse(props.expression), null, 2)}
+              {JSON.stringify(props.expression, null, 2)}
             </EuiCodeBlock>
           </EuiModalBody>
         </EuiModal>

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -98,7 +98,13 @@ function getColumns(
     {
       field: 'dls',
       name: 'Document-level security',
-      render: renderExpression('Document-level security'),
+      render: (dls: string) => {
+        if (!dls) {
+          return '-';
+        }
+
+        return renderExpression('Document-level security', JSON.parse(dls));
+      },
     },
     {
       field: 'fls',
@@ -139,8 +145,8 @@ export function IndexPermissionPanel(props: IndexPermissionPanelProps) {
   return (
     <PanelWithHeader
       headerText={headerText}
-      headerSubText="Index permissions allow you to specify how users in this role can access the indices. You can restrict a role to a subset of documents in an index, 
-      and which document fields a user can see as well. If you use field-level security in conjunction with document-level security, 
+      headerSubText="Index permissions allow you to specify how users in this role can access the indices. You can restrict a role to a subset of documents in an index,
+      and which document fields a user can see as well. If you use field-level security in conjunction with document-level security,
       make sure you don't restrict access to the fields that document-level security uses."
       helpLink="/"
     >

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -84,12 +84,10 @@ export function truncatedListView(limit = 3) {
   };
 }
 
-export const renderExpression = (title: string) => {
-  return (expression: string) => {
-    if (isEmpty(expression)) {
-      return '-';
-    }
+export const renderExpression = (title: string, expression: object) => {
+  if (isEmpty(expression)) {
+    return '-';
+  }
 
-    return <ExpressionModal title={title} expression={expression} />;
-  };
+  return <ExpressionModal title={title} expression={expression} />;
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Stringify input to the expression modal to fix the broken display in current authc & authz page.

*Test*
Current error
<img width="1596" alt="Screen Shot 2020-08-18 at 5 53 53 PM" src="https://user-images.githubusercontent.com/60111637/90580848-b494c900-e17e-11ea-8950-bd451f7c9392.png">

After the fix
<img width="2104" alt="Screen Shot 2020-08-18 at 5 54 16 PM" src="https://user-images.githubusercontent.com/60111637/90580863-beb6c780-e17e-11ea-8a5e-45ed5eb9c4df.png">

Also verify that the fix didn't impact the role view page.
<img width="2161" alt="Screen Shot 2020-08-18 at 5 54 33 PM" src="https://user-images.githubusercontent.com/60111637/90580886-ce361080-e17e-11ea-8250-9c3e0aba3894.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
