### PR TITLE
UI fixes for Get started

### DIFF
--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -26,7 +26,6 @@ import {
   EuiFlexGroup,
   EuiLink,
   EuiPanel,
-  EuiButtonEmpty,
 } from '@elastic/eui';
 import React from 'react';
 import { AppDependencies } from '../../types';
@@ -52,7 +51,7 @@ const setOfSteps = [
           </EuiLink>
         </EuiText>
 
-        <EuiSpacer />
+        <EuiSpacer size="m" />
 
         <EuiFlexGroup gutterSize="s">
           <EuiFlexItem grow={false}>
@@ -67,15 +66,17 @@ const setOfSteps = [
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
+            <EuiButton
               onClick={() => {
                 window.location.href = buildHashUrl(ResourceType.auth);
               }}
             >
               Review authentication and authorization
-            </EuiButtonEmpty>
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
+
+        <EuiSpacer size="l" />
       </>
     ),
   },
@@ -91,7 +92,7 @@ const setOfSteps = [
           </EuiLink>
         </EuiText>
 
-        <EuiSpacer />
+        <EuiSpacer size="m" />
 
         <EuiFlexGroup gutterSize="s">
           <EuiFlexItem grow={false}>
@@ -105,15 +106,17 @@ const setOfSteps = [
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
+            <EuiButton
               onClick={() => {
                 window.location.href = buildHashUrl(ResourceType.roles, Action.create);
               }}
             >
               Create new role
-            </EuiButtonEmpty>
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
+
+        <EuiSpacer size="l" />
       </>
     ),
   },
@@ -129,7 +132,7 @@ const setOfSteps = [
           </EuiLink>
         </EuiText>
 
-        <EuiSpacer />
+        <EuiSpacer size="m" />
 
         <EuiFlexGroup gutterSize="s">
           <EuiFlexItem grow={false}>
@@ -143,13 +146,13 @@ const setOfSteps = [
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
+            <EuiButton
               onClick={() => {
                 window.location.href = buildHashUrl(ResourceType.users, Action.create);
               }}
             >
               Create internal user
-            </EuiButtonEmpty>
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </>
@@ -165,9 +168,9 @@ export function GetStarted(props: AppDependencies) {
         <EuiTitle size="l">
           <h1>Get started</h1>
         </EuiTitle>
-        <EuiButtonEmpty iconType="popout" iconSide="right" href={buildHashUrl()} target="_blank">
+        <EuiButton iconType="popout" iconSide="right" href={buildHashUrl()} target="_blank">
           Open in new window
-        </EuiButtonEmpty>
+        </EuiButton>
       </EuiPageHeader>
 
       <EuiPanel paddingSize="l" style={{ maxWidth: panelMaxWidth }}>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Address comments from UX team on Get started page. 

- Outline button with blue border

- Modified the space between steps so that title, description and actions appears as same visual group.
_Please note: I can not modify the space between step title and step content. In order to do that I need to override euistep_content style. To be consistent with other existing steps, I have added extra space between two steps._

**Get started with these modification:**
![image](https://user-images.githubusercontent.com/63824432/90683458-6bdf1d80-e21b-11ea-8fe7-298d5d477bbf.png)

![image](https://user-images.githubusercontent.com/63824432/90683427-5f5ac500-e21b-11ea-914a-c440b1183dc7.png)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
