### PR TITLE
default to API permission call to false

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -35,10 +35,9 @@ async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
     const permissions = await core.http.get(API_ENDPOINT_PERMISSIONS_INFO);
     return permissions?.data?.has_api_access || false;
   } catch (e) {
-    // ignore 401 and continue to login page.
-    if (e?.body.statusCode !== 401) {
-      throw e;
-    }
+    console.error(e);
+    // ignore exceptions and default to no security related access.
+    return false;
   }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During testing, 500 errors from backend may lead the APP to an error status. Thus make the call default to false by assuming that user has no API permission (admin).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
