### PR TITLE
Role-view Permission tab UI fixes

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -146,3 +146,12 @@ export enum DocLinks {
   MapUsersToRolesDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles',
   AuditLogsDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/',
 }
+
+export enum ToolTipContent {
+  DocumentLevelSecurity = 'Document-level security lets you restrict a role to a subset of documents in an index.',
+  FieldLevelSecurity = 'Field-level security lets you control which document fields a user can see.',
+}
+
+export enum Widths {
+  width75 = '75%',
+}

--- a/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
@@ -22,7 +22,7 @@ export function ClusterPermissionPanel(props: {
   clusterPermissions: string[];
   actionGroups: DataObject<ActionGroupItem>;
 }) {
-  const headerText = 'Cluster permissions (' + props.clusterPermissions.length + ')';
+  const headerText = 'Cluster permissions';
 
   return (
     <PanelWithHeader
@@ -31,6 +31,7 @@ export function ClusterPermissionPanel(props: {
       specify permissions using both action groups or single permissions. An action
       group is a list of single permissions."
       helpLink="/"
+      count={props.clusterPermissions.length}
     >
       <PermissionTree permissions={props.clusterPermissions} actionGroups={props.actionGroups} />
     </PanelWithHeader>

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -21,6 +21,8 @@ import {
   EuiButtonIcon,
   EuiText,
   EuiFlexGroup,
+  EuiIcon,
+  EuiToolTip,
 } from '@elastic/eui';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import {
@@ -33,6 +35,7 @@ import { truncatedListView, displayArray } from '../../utils/display-utils';
 import { PermissionTree } from '../permission-tree';
 import { getFieldLevelSecurityMethod } from '../../utils/index-permission-utils';
 import { renderExpression } from '../../utils/display-utils';
+import { ToolTipContent } from '../../constants';
 
 function toggleRowDetails(
   item: RoleIndexPermissionView,
@@ -97,7 +100,14 @@ function getColumns(
     },
     {
       field: 'dls',
-      name: 'Document-level security',
+      name: (
+        <EuiToolTip content={ToolTipContent.DocumentLevelSecurity}>
+          <span>
+            Document-level security{' '}
+            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+          </span>
+        </EuiToolTip>
+      ),
       render: (dls: string) => {
         if (!dls) {
           return '-';
@@ -108,7 +118,14 @@ function getColumns(
     },
     {
       field: 'fls',
-      name: 'Field-level security',
+      name: (
+        <EuiToolTip content={ToolTipContent.FieldLevelSecurity}>
+          <span>
+            Field-level security{' '}
+            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+          </span>
+        </EuiToolTip>
+      ),
       render: renderFieldLevelSecurity(),
     },
     {
@@ -141,7 +158,7 @@ interface IndexPermissionPanelProps {
 export function IndexPermissionPanel(props: IndexPermissionPanelProps) {
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<ExpandedRowMapInterface>({});
 
-  const headerText = 'Index permissions (' + props.indexPermissions.length + ')';
+  const headerText = 'Index permissions';
   return (
     <PanelWithHeader
       headerText={headerText}
@@ -149,6 +166,7 @@ export function IndexPermissionPanel(props: IndexPermissionPanelProps) {
       and which document fields a user can see as well. If you use field-level security in conjunction with document-level security,
       make sure you don't restrict access to the fields that document-level security uses."
       helpLink="/"
+      count={props.indexPermissions.length}
     >
       <EuiInMemoryTable
         loading={props.indexPermissions === [] && !props.errorFlag}

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -147,7 +147,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
     },
   ];
 
-  const headerText = 'Tenants (' + tenantPermissionDetail.length + ')';
+  const headerText = 'Tenant permissions';
   return (
     <>
       <PanelWithHeader
@@ -156,6 +156,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
         Tenants are useful for safely sharing your work with other Kibana users. 
         You can control which roles have access to a tenant and whether those roles have read or write access."
         helpLink="/"
+        count={tenantPermissionDetail.length}
       >
         <EuiInMemoryTable
           loading={tenantPermissionDetail === [] && !errorFlag}

--- a/public/apps/configuration/utils/panel-with-header.tsx
+++ b/public/apps/configuration/utils/panel-with-header.tsx
@@ -15,6 +15,7 @@
 
 import React from 'react';
 import { EuiPanel, EuiTitle, EuiText, EuiLink, EuiHorizontalRule } from '@elastic/eui';
+import { Widths } from '../constants';
 
 interface PanelWithHeaderDeps {
   headerText: string;
@@ -22,6 +23,7 @@ interface PanelWithHeaderDeps {
   helpLink?: string;
   children?: React.ReactNode;
   optional?: boolean;
+  count?: number;
 }
 
 export function PanelWithHeader(props: PanelWithHeaderDeps) {
@@ -31,14 +33,17 @@ export function PanelWithHeader(props: PanelWithHeaderDeps) {
         <h3>
           {props.headerText}
           {props.optional && <i> - optional</i>}
+          {props.count?.toString() && (
+            <span style={{ color: '#687078', fontWeight: 'normal' }}> ({props.count})</span>
+          )}
         </h3>
       </EuiTitle>
-      <EuiText size="xs" color="subdued">
+      <EuiText size="xs" color="subdued" style={{ maxWidth: Widths.width75 }}>
         {props.headerSubText}
         {props.helpLink && (
           <>
             {' '}
-            <EuiLink href="{props.helpLink}" external>
+            <EuiLink href={props.helpLink} external>
               Learn more
             </EuiLink>
           </>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
UI fixes for Role-view.

- Set width of the description under title to 75% for better readability. 

- Added question mark and tooltip for Docuemnt-level security and Field-level security.

- Changed the style of count in header.

**Modified role-view:**
![image](https://user-images.githubusercontent.com/63824432/90707766-250a1b80-e24d-11ea-9570-8a91fd324f77.png)
![image](https://user-images.githubusercontent.com/63824432/90707784-2dfaed00-e24d-11ea-8eb0-d6614be45657.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
