### PR TITLE
add current tenant to tenant selection panel as default

### DIFF
--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -99,12 +99,15 @@ export async function selectTenant(http: HttpStart, selectObject: TenantSelect) 
   });
 }
 
+export const RESOLVED_GLOBAL_TENANT = 'Global';
+export const RESOLVED_PRIVATE_TENANT = 'Private';
+
 export function resolveTenantName(tenant: string, userName: string) {
   if (!tenant || tenant === 'undefined') {
-    return 'Global';
+    return RESOLVED_GLOBAL_TENANT;
   }
   if (tenant === userName || tenant === '__user__') {
-    return 'Private';
+    return RESOLVED_PRIVATE_TENANT;
   } else {
     return tenant;
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add the current tenant as the default selection on tenant selection panel. This helps users know their current tenant.

*Test*
Case 1: current is global
<img width="2484" alt="Screen Shot 2020-08-20 at 5 08 26 PM" src="https://user-images.githubusercontent.com/60111637/90837810-f4d38300-e307-11ea-9ca2-fb181102c4c1.png">

Case 2: current is private
<img width="2469" alt="Screen Shot 2020-08-20 at 5 08 41 PM" src="https://user-images.githubusercontent.com/60111637/90837816-f8ffa080-e307-11ea-8035-fe16f44d4b1a.png">


Case 3: current is custom
<img width="2318" alt="Screen Shot 2020-08-20 at 5 08 59 PM" src="https://user-images.githubusercontent.com/60111637/90837835-0157db80-e308-11ea-8914-d6e66b604bf3.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
