### PR TITLE
Improve delete modal and apply to all listing pages

### DIFF
--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -59,6 +59,7 @@ import { renderCustomization } from '../../utils/display-utils';
 import { useToastState } from '../../utils/toast-utils';
 import { PermissionEditModal } from './edit-modal';
 import { PermissionTree } from '../permission-tree';
+import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
 
 function renderBooleanToCheckMark(value: boolean): React.ReactNode {
   return value ? <EuiIcon type="check" /> : '';
@@ -209,6 +210,11 @@ export function PermissionList(props: AppDependencies) {
     }
   };
 
+  const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
+    handleDelete,
+    'user(s)'
+  );
+
   const actionsMenuItems = [
     <EuiContextMenuItem
       key="edit"
@@ -228,7 +234,7 @@ export function PermissionList(props: AppDependencies) {
     </EuiContextMenuItem>,
     <EuiContextMenuItem
       key="delete"
-      onClick={handleDelete}
+      onClick={showDeleteConfirmModal}
       disabled={selection.length === 0 || selection.some((group) => group.reserved)}
     >
       Delete
@@ -390,6 +396,7 @@ export function PermissionList(props: AppDependencies) {
         </EuiPageBody>
       </EuiPageContent>
       {editModal}
+      {deleteConfirmModal}
       <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />
     </>
   );

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -212,7 +212,7 @@ export function PermissionList(props: AppDependencies) {
 
   const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
     handleDelete,
-    'user(s)'
+    'action group(s)'
   );
 
   const actionsMenuItems = [

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -30,6 +30,7 @@ import {
   EuiContextMenuItem,
   EuiPopover,
   EuiContextMenuPanel,
+  EuiBasicTableColumn,
 } from '@elastic/eui';
 import { difference } from 'lodash';
 import { AppDependencies } from '../../types';
@@ -43,8 +44,9 @@ import { API_ENDPOINT_ROLES, API_ENDPOINT_ROLESMAPPING } from '../constants';
 import { ResourceType, Action } from '../types';
 import { buildHashUrl } from '../utils/url-builder';
 import { renderCustomization, truncatedListView } from '../utils/display-utils';
+import { useDeleteConfirmState } from '../utils/delete-confirm-modal-utils';
 
-const columns = [
+const columns: Array<EuiBasicTableColumn<RoleListing>> = [
   {
     field: 'roleName',
     name: 'Role',
@@ -92,6 +94,7 @@ export function RoleList(props: AppDependencies) {
   const [errorFlag, setErrorFlag] = useState(false);
   const [selection, setSelection] = useState<RoleListing[]>([]);
   const [isActionsPopoverOpen, setActionsPopoverOpen] = useState(false);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -124,6 +127,11 @@ export function RoleList(props: AppDependencies) {
     }
   };
 
+  const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
+    handleDelete,
+    'role(s)'
+  );
+
   const actionsMenuItems = [
     <EuiContextMenuItem
       key="edit"
@@ -150,7 +158,7 @@ export function RoleList(props: AppDependencies) {
     </EuiContextMenuItem>,
     <EuiContextMenuItem
       key="delete"
-      onClick={handleDelete}
+      onClick={showDeleteConfirmModal}
       disabled={selection.length === 0 || selection.some((e) => e.reserved)}
     >
       Delete
@@ -259,12 +267,7 @@ export function RoleList(props: AppDependencies) {
                 </EuiPopover>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiButton
-                  fill
-                  onClick={() => {
-                    window.location.href = buildHashUrl(ResourceType.roles, Action.create);
-                  }}
-                >
+                <EuiButton fill href={buildHashUrl(ResourceType.roles, Action.create)}>
                   Create role
                 </EuiButton>
               </EuiFlexItem>
@@ -284,6 +287,7 @@ export function RoleList(props: AppDependencies) {
             error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
           />
         </EuiPageBody>
+        {deleteConfirmModal}
       </EuiPageContent>
     </>
   );

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -159,17 +159,15 @@ export function RoleView(props: RoleViewProps) {
 
       setMappedUsers(difference(mappedUsers, selection));
       setSelection([]);
-      closeDeleteConfirmModal();
     } catch (e) {
       console.log(e);
     }
   };
 
-  const [
-    closeDeleteConfirmModal,
-    showDeleteConfirmModal,
-    deleteConfirmModal,
-  ] = useDeleteConfirmState(handleRoleMappingDelete, selection.length, 'mappings');
+  const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
+    handleRoleMappingDelete,
+    'mapping(s)'
+  );
 
   const message = (
     <EuiEmptyPrompt

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -92,18 +92,16 @@ export function TenantList(props: AppDependencies) {
       await requestDeleteTenant(props.coreStart.http, tenantsToDelete);
       setTenantData(difference(tenantData, selection));
       setSelection([]);
-      closeDeleteConfirmModal();
     } catch (e) {
       console.log(e);
     } finally {
       setActionsPopoverOpen(false);
     }
   };
-  const [
-    closeDeleteConfirmModal,
-    showDeleteConfirmModal,
-    deleteConfirmModal,
-  ] = useDeleteConfirmState(handleDelete, selection.length, 'tenants');
+  const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
+    handleDelete,
+    'tenant(s)'
+  );
 
   const changeTenant = async (tenantName: string) => {
     const selectedTenant = await selectTenant(props.coreStart.http, {

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -43,6 +43,7 @@ import {
 } from '../utils/internal-user-list-utils';
 import { buildHashUrl } from '../utils/url-builder';
 import { API_ENDPOINT_INTERNALUSERS } from '../constants';
+import { useDeleteConfirmState } from '../utils/delete-confirm-modal-utils';
 
 function dictView() {
   return (items: Dictionary<string>) => {
@@ -126,6 +127,11 @@ export function UserList(props: AppDependencies) {
     }
   };
 
+  const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
+    handleDelete,
+    'user(s)'
+  );
+
   const actionsMenuItems = [
     <EuiContextMenuItem
       key="edit"
@@ -163,7 +169,7 @@ export function UserList(props: AppDependencies) {
     </EuiContextMenuItem>,
     <EuiContextMenuItem
       key="delete"
-      onClick={handleDelete}
+      onClick={showDeleteConfirmModal}
       disabled={selection.length === 0 || selection.some((e) => e.username === currentUsername)}
     >
       Delete
@@ -254,6 +260,7 @@ export function UserList(props: AppDependencies) {
             error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
           />
         </EuiPageBody>
+        {deleteConfirmModal}
       </EuiPageContent>
     </>
   );

--- a/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
+++ b/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
@@ -19,19 +19,22 @@ import { EuiOverlayMask, EuiConfirmModal } from '@elastic/eui';
 /**
  *
  * @param handleDelete: [Type: func] delete function which needs to be execute on click of confirm button.
- * @param noOfSelectedItems: Count of selected Items for deletion.
- * @param entity: e.g. roles, tenants, users, mapping etc. This will display in confirmation text before deletion.
+ * @param entity: e.g. role(s), tenant(s), user(s), mapping etc. This will display in confirmation text before deletion.
  * @param customConfirmationText: If you want other than default confirm message, pass it as customConfirmationText.
  */
 export function useDeleteConfirmState(
   handleDelete: () => Promise<void>,
-  noOfSelectedItems: number,
   entity: string,
   customConfirmationText?: React.ReactNode
-): [() => void, () => void, React.ReactNode] {
+): [() => void, React.ReactNode] {
   const [isDeleteConfirmModalVisible, setIsDeleteConfirmModalVisible] = useState(false);
   const closeDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(false);
   const showDeleteConfirmModal = () => setIsDeleteConfirmModalVisible(true);
+
+  const handleConfirm = async () => {
+    await handleDelete();
+    closeDeleteConfirmModal();
+  };
 
   let deleteConfirmModal;
   if (isDeleteConfirmModalVisible) {
@@ -40,7 +43,7 @@ export function useDeleteConfirmState(
         <EuiConfirmModal
           title="Confirm Delete"
           onCancel={closeDeleteConfirmModal}
-          onConfirm={handleDelete}
+          onConfirm={handleConfirm}
           cancelButtonText="Cancel"
           confirmButtonText="Confirm"
           defaultFocusedButton="confirm"
@@ -48,13 +51,11 @@ export function useDeleteConfirmState(
           {customConfirmationText ? (
             customConfirmationText
           ) : (
-            <p>
-              Do you really want to delete selected {noOfSelectedItems} {entity}?
-            </p>
+            <p>Do you really want to delete selected {entity}?</p>
           )}
         </EuiConfirmModal>
       </EuiOverlayMask>
     );
   }
-  return [closeDeleteConfirmModal, showDeleteConfirmModal, deleteConfirmModal];
+  return [showDeleteConfirmModal, deleteConfirmModal];
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update the delete confirmation message to 'Do you really want to delete selected {entity(s)}?' from 'Do you really want to delete selected {count} {entity}?'
2. Remove the returning `closeDeleteConfirmModal` function
3. Add delete confirmation modal to deletion on both role listing and internal user listing page.

|Before|After|
|--|--|
|N/A|![image](https://user-images.githubusercontent.com/63078162/90944354-0cc40900-e3d3-11ea-9cec-cae287bf0540.png)|
|N/A|![image](https://user-images.githubusercontent.com/63078162/90944343-fb7afc80-e3d2-11ea-8510-6adfe63a3905.png)|
|N/A|![image](https://user-images.githubusercontent.com/63078162/91095163-be03b280-e610-11ea-812b-865602ec2d9e.png)|
|![image](https://user-images.githubusercontent.com/63078162/90944475-e2268000-e3d3-11ea-9965-b40303bc2bd1.png)|![image](https://user-images.githubusercontent.com/63078162/90944386-41d05b80-e3d3-11ea-8335-42cbdec16300.png)|


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
