### PR TITLE
modify password instruction message

### DIFF
--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -29,6 +29,7 @@ import { CoreStart } from 'kibana/public';
 import { FormRow } from '../configuration/utils/form-row';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
 import { logout } from './utils';
+import { PASSWORD_INSTRUCTION } from '../apps-constants';
 
 interface PasswordResetPanelProps {
   coreStart: CoreStart;
@@ -111,8 +112,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
 
           <FormRow
             headerText="New password"
-            helpText="The password must contain from m to n characters. Valid characters are [for example lowercase a-z
-            , 0-9, and - (hyphen)]"
+            helpText={PASSWORD_INSTRUCTION}
             isInvalid={isNewPasswordInvalid}
             error={newPasswordError}
           >

--- a/public/apps/apps-constants.tsx
+++ b/public/apps/apps-constants.tsx
@@ -16,3 +16,7 @@
 // TODO: use this constant for wherever the generic error instruction is used.
 export const GENERIC_ERROR_INSTRUCTION =
   'You may refresh the page to retry or see browser console for more information.';
+
+export const PASSWORD_INSTRUCTION =
+  'Password should be at least 8 characters long and contain at least one uppercase ' +
+  'letter, one lowercase letter, one digit, and one special character.';

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -16,6 +16,7 @@
 import React, { useState, useEffect } from 'react';
 import { EuiFieldText, EuiIcon } from '@elastic/eui';
 import { FormRow } from './form-row';
+import { PASSWORD_INSTRUCTION } from '../../apps-constants';
 
 export function PasswordEditPanel(props: {
   updatePassword: (p: string) => void;
@@ -42,10 +43,7 @@ export function PasswordEditPanel(props: {
 
   return (
     <>
-      <FormRow
-        headerText="Password"
-        helpText="A good password will be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
-      >
+      <FormRow headerText="Password" helpText={PASSWORD_INSTRUCTION}>
         <EuiFieldText
           prepend={<EuiIcon type="lock" />}
           type="password"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modify password instruction message per UX feedback. Use "should" instead of "must" since this is not enforced in ODFE.

*Test*
<img width="918" alt="Screen Shot 2020-08-24 at 9 58 49 AM" src="https://user-images.githubusercontent.com/60111637/91074139-fe533880-e5f0-11ea-95b3-3133c0c005e4.png">

<img width="2119" alt="Screen Shot 2020-08-24 at 10 00 11 AM" src="https://user-images.githubusercontent.com/60111637/91074149-01e6bf80-e5f1-11ea-9079-8bf96ddaf84e.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
