### PR TITLE
Add success toast for role/user update. Refactor cross page toast.

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -21,8 +21,6 @@ import { AppDependencies } from '../types';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';
 import {
-  FROM_COMPLIANCE_SAVE_SUCCESS,
-  FROM_GENERAL_SAVE_SUCCESS,
   SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
   SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
 } from './panels/audit-logging/constants';
@@ -39,6 +37,7 @@ import { TenantList } from './panels/tenant-list/tenant-list';
 import { UserList } from './panels/user-list';
 import { Action, ResourceType, RouteItem, SubAction } from './types';
 import { buildHashUrl, buildUrl } from './utils/url-builder';
+import { CrossPageToast } from './cross-page-toast';
 
 const LANDING_PAGE_URL = '/getstarted';
 
@@ -86,8 +85,6 @@ const ROUTE_LIST = [
 const allNavPanelUrls = ROUTE_LIST.map((route) => route.href).concat([
   buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
   buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
-  buildUrl(ResourceType.auditLogging) + FROM_GENERAL_SAVE_SUCCESS,
-  buildUrl(ResourceType.auditLogging) + FROM_COMPLIANCE_SAVE_SUCCESS,
 ]);
 
 export function getBreadcrumbs(
@@ -241,6 +238,7 @@ export function AppRouter(props: AppDependencies) {
             <Redirect exact from="/" to={LANDING_PAGE_URL} />
           </Switch>
         </EuiPageBody>
+        <CrossPageToast />
       </EuiPage>
     </Router>
   );

--- a/public/apps/configuration/cross-page-toast.tsx
+++ b/public/apps/configuration/cross-page-toast.tsx
@@ -1,0 +1,35 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { EuiGlobalToastList } from '@elastic/eui';
+import { useToastState } from './utils/toast-utils';
+import { getAndClearCrossPageToast } from './utils/storage-utils';
+
+export function CrossPageToast() {
+  // For cross page toast
+  const [toasts, addToast, removeToast] = useToastState();
+
+  const location = useLocation();
+  React.useEffect(() => {
+    const toast = getAndClearCrossPageToast(location.pathname);
+    if (toast) {
+      addToast(toast);
+    }
+  }, [addToast, location]);
+
+  return <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />;
+}

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -27,19 +27,15 @@ import {
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import { cloneDeep, set, without } from 'lodash';
 import { AppDependencies } from '../../../types';
-import {
-  FROM_COMPLIANCE_SAVE_SUCCESS,
-  FROM_GENERAL_SAVE_SUCCESS,
-  SETTING_GROUPS,
-  SettingMapItem,
-} from './constants';
+import { SETTING_GROUPS, SettingMapItem } from './constants';
 import { EditSettingGroup } from './edit-setting-group';
 import { AuditLoggingSettings } from './types';
-import { buildHashUrl } from '../../utils/url-builder';
+import { buildHashUrl, buildUrl } from '../../utils/url-builder';
 import { ResourceType } from '../../types';
 import { updateAuditLogging } from '../../utils/audit-logging-utils';
 import { API_ENDPOINT_AUDITLOGGING } from '../../constants';
 import { useToastState } from '../../utils/toast-utils';
+import { setCrossPageToast } from '../../utils/storage-utils';
 
 interface AuditLoggingEditSettingProps extends AppDependencies {
   setting: 'general' | 'compliance';
@@ -112,9 +108,25 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
     try {
       await updateAuditLogging(props.coreStart.http, configToUpdate);
 
-      window.location.href =
-        buildHashUrl(ResourceType.auditLogging) +
-        (props.setting === 'general' ? FROM_GENERAL_SAVE_SUCCESS : FROM_COMPLIANCE_SAVE_SUCCESS);
+      const addSuccessToast = (text: string) => {
+        const successToast: Toast = {
+          id: 'update-result',
+          color: 'success',
+          iconType: 'check',
+          title: 'Success',
+          text,
+        };
+
+        setCrossPageToast(buildUrl(ResourceType.auditLogging), successToast);
+      };
+
+      if (props.setting === 'general') {
+        addSuccessToast('General settings saved');
+      } else {
+        addSuccessToast('Compliance settings saved');
+      }
+
+      window.location.href = buildHashUrl(ResourceType.auditLogging);
     } catch (e) {
       const failureToast: Toast = {
         id: 'update-result',

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -13,8 +13,6 @@
  *   permissions and limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-
 import {
   EuiButton,
   EuiCode,
@@ -23,7 +21,6 @@ import {
   EuiFlexItem,
   EuiForm,
   EuiFormRow,
-  EuiGlobalToastList,
   EuiHorizontalRule,
   EuiLink,
   EuiPanel,
@@ -32,23 +29,20 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
+import React, { useEffect, useState } from 'react';
 import { AppDependencies } from '../../../types';
 import { API_ENDPOINT_AUDITLOGGING } from '../../constants';
-import { AuditLoggingSettings } from './types';
+import { ResourceType } from '../../types';
+import { updateAuditLogging } from '../../utils/audit-logging-utils';
+import { displayBoolean } from '../../utils/display-utils';
+import { buildHashUrl } from '../../utils/url-builder';
 import {
-  FROM_COMPLIANCE_SAVE_SUCCESS,
-  FROM_GENERAL_SAVE_SUCCESS,
   SETTING_GROUPS,
   SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT,
   SUB_URL_FOR_GENERAL_SETTINGS_EDIT,
 } from './constants';
-import { buildHashUrl } from '../../utils/url-builder';
-import { ResourceType } from '../../types';
-import { useToastState } from '../../utils/toast-utils';
-import { displayBoolean } from '../../utils/display-utils';
+import { AuditLoggingSettings } from './types';
 import { ViewSettingGroup } from './view-setting-group';
-import { updateAuditLogging } from '../../utils/audit-logging-utils';
 import './_index.scss';
 
 interface AuditLoggingProps extends AppDependencies {
@@ -138,7 +132,6 @@ function renderComplianceSettings(config: AuditLoggingSettings) {
 
 export function AuditLogging(props: AuditLoggingProps) {
   const [configuration, setConfiguration] = useState<AuditLoggingSettings>({});
-  const [toasts, addToast, removeToast] = useToastState();
 
   const onSwitchChange = async () => {
     try {
@@ -164,30 +157,8 @@ export function AuditLogging(props: AuditLoggingProps) {
       }
     };
 
-    const addSuccessToast = (text: string) => {
-      const successToast: Toast = {
-        id: 'update-result',
-        color: 'success',
-        iconType: 'check',
-        title: 'Success',
-        text,
-      };
-
-      addToast(successToast);
-    };
-
     fetchData();
-
-    if (props.fromType) {
-      // Need to display success toast
-
-      if (FROM_GENERAL_SAVE_SUCCESS.endsWith(props.fromType)) {
-        addSuccessToast('General settings saved');
-      } else if (FROM_COMPLIANCE_SAVE_SUCCESS.endsWith(props.fromType)) {
-        addSuccessToast('Compliance settings saved');
-      }
-    }
-  }, [addToast, props.coreStart.http, props.fromType]);
+  }, [props.coreStart.http, props.fromType]);
 
   const statusPanel = renderStatusPanel(onSwitchChange, configuration.enabled || false);
 
@@ -247,8 +218,6 @@ export function AuditLogging(props: AuditLoggingProps) {
         <EuiHorizontalRule />
         {renderComplianceSettings(configuration)}
       </EuiPanel>
-
-      <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />
     </>
   );
 }

--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -337,6 +337,3 @@ export const SETTING_GROUPS = {
 
 export const SUB_URL_FOR_GENERAL_SETTINGS_EDIT = '/edit/generalSettings';
 export const SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT = '/edit/complianceSettings';
-
-export const FROM_GENERAL_SAVE_SUCCESS = '/generalSuccess';
-export const FROM_COMPLIANCE_SAVE_SUCCESS = '/complianceSuccess';

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -34,9 +34,10 @@ import { getUserDetail, updateUser } from '../../utils/internal-user-detail-util
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { PasswordEditPanel } from '../../utils/password-edit-panel';
 import { createErrorToast, createUnknownErrorToast, useToastState } from '../../utils/toast-utils';
-import { buildHashUrl } from '../../utils/url-builder';
+import { buildHashUrl, buildUrl } from '../../utils/url-builder';
 import { AttributePanel, buildAttributeState, unbuildAttributeState } from './attribute-panel';
 import { UserAttributeStateClass } from './types';
+import { setCrossPageToast } from '../../utils/storage-utils';
 
 interface InternalUserEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -107,12 +108,13 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
       };
       await updateUser(props.coreStart.http, userName, updateObject);
 
-      addToast({
+      setCrossPageToast(buildUrl(ResourceType.users), {
         id: 'updateUserSucceeded',
         color: 'success',
         title: UPDATE_TEXT_DICT[props.action],
       });
-      // TODO: redirect to somewhere?
+      // Redirect to user listing
+      window.location.href = buildHashUrl(ResourceType.users);
     } catch (e) {
       if (e.message) {
         addToast(createErrorToast('updateUserFailed', 'Update error', e.message));

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -273,6 +273,7 @@ export function PermissionList(props: AppDependencies) {
             });
           } catch (e) {
             console.log(e);
+            setEditModal(null);
             addToast({
               id: 'saveFailed',
               title: `Failed to save ${action} group. You may refresh the page to retry or see browser console for more information.`,

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -160,7 +160,7 @@ export function RoleEdit(props: RoleEditDeps) {
         color: 'success',
         title: UPDATE_TEXT_DICT[props.action],
       });
-      // Redirect to user listing
+      // Redirect to role view
       window.location.href = buildHashUrl(ResourceType.roles, Action.view, roleName);
     } catch (e) {
       addToast(createUnknownErrorToast('updateRole', `${props.action} role`));

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -48,9 +48,10 @@ import {
   unbuildTenantPermissionState,
 } from './tenant-panel';
 import { RoleIndexPermissionStateClass, RoleTenantPermissionStateClass } from './types';
-import { buildHashUrl } from '../../utils/url-builder';
+import { buildHashUrl, buildUrl } from '../../utils/url-builder';
 import { ComboBoxOptions, ResourceType, Action } from '../../types';
 import { useToastState, createUnknownErrorToast } from '../../utils/toast-utils';
+import { setCrossPageToast } from '../../utils/storage-utils';
 
 interface RoleEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -64,6 +65,12 @@ const TITLE_TEXT_DICT = {
   create: 'Create Role',
   edit: 'Edit Role',
   duplicate: 'Duplicate Role',
+};
+
+const UPDATE_TEXT_DICT = {
+  create: 'Role successfully created',
+  edit: 'Role successfully updated',
+  duplicate: 'Role successfully duplicated',
 };
 
 export function RoleEdit(props: RoleEditDeps) {
@@ -147,6 +154,13 @@ export function RoleEdit(props: RoleEditDeps) {
         index_permissions: unbuildIndexPermissionState(validIndexPermission),
         tenant_permissions: unbuildTenantPermissionState(validTenantPermission),
       });
+
+      setCrossPageToast(buildUrl(ResourceType.roles, Action.view, roleName), {
+        id: 'updateRoleSucceeded',
+        color: 'success',
+        title: UPDATE_TEXT_DICT[props.action],
+      });
+      // Redirect to user listing
       window.location.href = buildHashUrl(ResourceType.roles, Action.view, roleName);
     } catch (e) {
       addToast(createUnknownErrorToast('updateRole', `${props.action} role`));

--- a/public/apps/configuration/panels/role-mapping/RoleEditMappedUser.tsx
+++ b/public/apps/configuration/panels/role-mapping/RoleEditMappedUser.tsx
@@ -36,12 +36,13 @@ import {
 import { ExternalIdentityStateClass } from './types';
 import { ComboBoxOptions } from '../../types';
 import { stringToComboBoxOption, comboBoxOptionToString } from '../../utils/combo-box-utils';
-import { buildHashUrl } from '../../utils/url-builder';
+import { buildHashUrl, buildUrl } from '../../utils/url-builder';
 import { ResourceType, RoleMappingDetail, SubAction, Action } from '../../types';
 import { fetchUserNameList } from '../../utils/internal-user-list-utils';
 import { updateRoleMapping, getRoleMappingData } from '../../utils/role-mapping-utils';
 import { createErrorToast, createUnknownErrorToast, useToastState } from '../../utils/toast-utils';
 import { DocLinks } from '../../constants';
+import { setCrossPageToast } from '../../utils/storage-utils';
 
 interface RoleEditMappedUserProps extends BreadcrumbsPageDependencies {
   roleName: string;
@@ -104,13 +105,14 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
         backend_roles: unbuildExternalIdentityState(validExternalIdentities),
         hosts,
       };
+
       await updateRoleMapping(props.coreStart.http, props.roleName, updateObject);
-      window.location.href = buildHashUrl(
-        ResourceType.roles,
-        Action.view,
-        props.roleName,
-        SubAction.mapuser
-      );
+      setCrossPageToast(buildUrl(ResourceType.roles, Action.view, props.roleName), {
+        id: 'updateRoleMappingSucceeded',
+        color: 'success',
+        title: props.roleName + ' saved.',
+      });
+      window.location.href = buildHashUrl(ResourceType.roles, Action.view, props.roleName);
     } catch (e) {
       if (e.message) {
         addToast(createErrorToast('saveRoleMappingFailed', 'save error', e.message));

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -131,19 +131,7 @@ export function RoleView(props: RoleViewProps) {
       }
     };
 
-    const addSuccessToast = () => {
-      addToast({
-        id: 'updateRoleMappingSucceeded',
-        color: 'success',
-        title: props.roleName + ' saved.',
-      });
-    };
-
     fetchData();
-
-    if (props.prevAction === SubAction.mapuser) {
-      addSuccessToast();
-    }
   }, [addToast, props.coreStart.http, props.roleName, props.prevAction]);
 
   const handleRoleMappingDelete = async () => {

--- a/public/apps/configuration/utils/storage-utils.tsx
+++ b/public/apps/configuration/utils/storage-utils.tsx
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
+
+/*
+ * This file leverage storage for frontend data. Currently it is for cross page toasts only,
+ * so session storage is in use (no need to hold the toast message to until next session)
+ */
+
+export function getValue<T>(category: string, key: string): T | null {
+  const item = sessionStorage.getItem(`${category}::${key}`);
+  if (!item) {
+    return null;
+  }
+  return JSON.parse(item) as T;
+}
+
+export function setValue(category: string, key: string, value: any) {
+  sessionStorage.setItem(`${category}::${key}`, JSON.stringify(value));
+}
+
+const TOAST_CATEGORY = 'toast';
+
+export function setCrossPageToast(targetUrl: string, toast: Toast) {
+  setValue(TOAST_CATEGORY, targetUrl, toast);
+}
+
+export function getAndClearCrossPageToast(targetUrl: string): Toast | null {
+  const result = getValue<Toast>(TOAST_CATEGORY, targetUrl);
+  setValue(TOAST_CATEGORY, targetUrl, null);
+  return result;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Refactor cross page toast. The current method for audit logging and role mapping is appending some additional constant to the url. In this way, on a success toast page, if user refreshes, or user nav to another page and use backward button to go back, the toast shows again. This PR migrate to a session storage so 1) the toast only shows once; 2) lift the cross page up to show at app router level to avoid the rendering on each page component.
* Add success toast for role/user update. 

Screenshot:
Role mapping and audit logging: manually verified and found no change.
![image](https://user-images.githubusercontent.com/63078162/91207719-11800a00-e6be-11ea-8339-9d763526acb9.png)
![image](https://user-images.githubusercontent.com/63078162/91208632-548ead00-e6bf-11ea-80a9-564603e0e6fc.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
