### PR TITLE
Make view expression column center aligned

### DIFF
--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import React from 'react';
-import { EuiInMemoryTable } from '@elastic/eui';
+import { EuiInMemoryTable, CENTER_ALIGNMENT } from '@elastic/eui';
 import { keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { renderExpression } from '../../utils/display-utils';
@@ -50,6 +50,7 @@ const columns = [
     field: 'http_configuration',
     name: 'HTTP configuration',
     render: (config: object) => renderExpression('HTTP configuration', config),
+    align: CENTER_ALIGNMENT,
   },
   {
     field: 'backend_type',
@@ -59,6 +60,7 @@ const columns = [
     field: 'backend_configuration',
     name: 'Backend configuration',
     render: (config: object) => renderExpression('Backend configuration', config),
+    align: CENTER_ALIGNMENT,
   },
 ];
 

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import React from 'react';
-import { EuiInMemoryTable, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiInMemoryTable, EuiEmptyPrompt, CENTER_ALIGNMENT } from '@elastic/eui';
 import { keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { renderExpression, ExternalLinkButton } from '../../utils/display-utils';
@@ -41,6 +41,7 @@ const columns = [
     field: 'backend_configuration',
     name: 'Backend configuration',
     render: (config: object) => renderExpression('Backend configuration', config),
+    align: CENTER_ALIGNMENT,
   },
 ];
 

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -23,6 +23,7 @@ import {
   EuiFlexGroup,
   EuiEmptyPrompt,
   EuiButton,
+  CENTER_ALIGNMENT,
 } from '@elastic/eui';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import {
@@ -115,6 +116,7 @@ function getColumns(
 
         return renderExpression('Document-level security', JSON.parse(dls));
       },
+      align: CENTER_ALIGNMENT,
     },
     {
       field: 'fls',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make view expression column center aligned in authentication & authorization and role-view.

**Screenshot:**
![image](https://user-images.githubusercontent.com/63824432/91217328-29f72100-e6cc-11ea-8791-7baae9fbb54a.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
