### PR TITLE
UI fixes for create role page

### DIFF
--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -44,7 +44,12 @@ export function ClusterPermissionPanel(props: {
         >
           <EuiFlexGroup>
             <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
-              <EuiComboBox options={optionUniverse} selectedOptions={state} onChange={setState} />
+              <EuiComboBox
+                placeholder="Search for action group name or permission name"
+                options={optionUniverse}
+                selectedOptions={state}
+                onChange={setState}
+              />
             </EuiFlexItem>
             {/* TODO: 'Browse and select' button with a pop-up modal for selection */}
             <EuiFlexItem grow={false}>

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -256,6 +256,7 @@ export function generateIndexPermissionPanels(
       <Fragment key={`index-permission-${arrayIndex}`}>
         <EuiAccordion
           id={`index-permission-${arrayIndex}`}
+          initialIsOpen={arrayIndex === 0}
           buttonContent={
             permission.indexPatterns.map(comboBoxOptionToString).join(', ') ||
             'Add index permission'

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -175,7 +175,7 @@ export function RoleEdit(props: RoleEditDeps) {
     <>
       {props.buildBreadcrumbs(TITLE_TEXT_DICT[props.action])}
       <EuiPageHeader>
-        <EuiText size="xs" color="subdued">
+        <EuiText size="xs" color="subdued" className="panel-header-subtext">
           <EuiTitle size="m">
             <h1>{TITLE_TEXT_DICT[props.action]}</h1>
           </EuiTitle>

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -89,7 +89,7 @@ function generateTenantPermissionPanels(
         <EuiFlexGroup>
           <EuiFlexItem style={{ maxWidth: '400px' }}>
             <EuiComboBox
-              placeholder="Search tenant name"
+              placeholder="Search tenant name or add a tenant pattern"
               selectedOptions={tenantPermission.tenantPatterns}
               onChange={onValueChangeHandler('tenantPatterns')}
               onCreateOption={onCreateOptionHandler('tenantPatterns')}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Made the page description 75% width of the container. 

- Added hint text to cluster permission combobox.

- Open the first accordion of index permission by default so that user can scan what expected to be filled.

- modified hint text of tenant permission to 'Search tenant name or add a tenant pattern'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
