### PR TITLE
ui fix for customization column icon

### DIFF
--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -54,10 +54,14 @@ export function displayObject(object: object | undefined) {
 
 export function renderCustomization(reserved: boolean) {
   return (
-    <EuiText size="xs">
-      <EuiIcon type={reserved ? 'lock' : 'pencil'} />
-      {reserved ? 'Reserved' : 'Custom'}
-    </EuiText>
+    <EuiFlexGroup alignItems="center" gutterSize="xs">
+      <EuiFlexItem grow={false}>
+        <EuiIcon type={reserved ? 'lock' : 'pencil'} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">{reserved ? 'Reserved' : 'Custom'}</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make customization column icon vertically align and add spacing between icon and text.

**Screenshots:**

> Role-list:

![image](https://user-images.githubusercontent.com/63824432/91365896-12489700-e7b7-11ea-8426-c0c93d76ec97.png)

> Permissions:

![image](https://user-images.githubusercontent.com/63824432/91365921-22f90d00-e7b7-11ea-9476-dedd762acd76.png)

> Tenants:
![image](https://user-images.githubusercontent.com/63824432/91365972-4fad2480-e7b7-11ea-8f15-9147fa5a0e8c.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
