### PR TITLE
UI fixes in all listing, map user page and tenant edit modal

### DIFF
--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -66,7 +66,7 @@ export function renderFieldLevelSecurity() {
       return (
         <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
           <EuiText key={'-'} size="xs">
-            -
+            &mdash;
           </EuiText>
         </EuiFlexGroup>
       );
@@ -110,7 +110,7 @@ function getColumns(
       ),
       render: (dls: string) => {
         if (!dls) {
-          return '-';
+          return <span>&mdash;</span>;
         }
 
         return renderExpression('Document-level security', JSON.parse(dls));

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -40,6 +40,7 @@ import { renderExpression, displayHeaderWithTooltip } from '../../utils/display-
 import { ToolTipContent } from '../../constants';
 import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
 import { buildHashUrl } from '../../utils/url-builder';
+import { EMPTY_FIELD_VALUE } from '../../ui-constants';
 
 function toggleRowDetails(
   item: RoleIndexPermissionView,
@@ -66,7 +67,7 @@ export function renderFieldLevelSecurity() {
       return (
         <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
           <EuiText key={'-'} size="xs">
-            &mdash;
+            {EMPTY_FIELD_VALUE}
           </EuiText>
         </EuiFlexGroup>
       );
@@ -110,7 +111,7 @@ function getColumns(
       ),
       render: (dls: string) => {
         if (!dls) {
-          return <span>&mdash;</span>;
+          return EMPTY_FIELD_VALUE;
         }
 
         return renderExpression('Document-level security', JSON.parse(dls));

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -176,14 +176,14 @@ export function RoleView(props: RoleViewProps) {
         </EuiText>
       }
       actions={
-        <EuiFlexGroup gutterSize="s">
-          <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem>
             <ExternalLinkButton
               text="Create internal user"
               href={buildHashUrl(ResourceType.users, Action.create)}
             />
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
+          <EuiFlexItem>
             <EuiButton
               fill
               onClick={() => {
@@ -280,10 +280,10 @@ export function RoleView(props: RoleViewProps) {
                   </h3>
                 </EuiTitle>
                 <EuiText size="xs" color="subdued" className="panel-header-subtext">
-                  You can map two types of users: 1. Internal users within the Security plugin. An
+                  You can map two types of users: internal users and external identities. An
                   internal user can have its own backend role and host for an external
-                  authentication and authorization. 2. External identity, which directly maps to
-                  roles through an external authentication system.{' '}
+                  authentication and authorization. An external identity directly maps to roles
+                  through an external authentication system.{' '}
                   <EuiLink external={true} href={DocLinks.MapUsersToRolesDoc} target="_blank">
                     Learn More
                   </EuiLink>

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -72,6 +72,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               helpText="The tenant name must contain from m to n characters. Valid characters are lowercase a-z, 0-9, and -(hyphen)."
             >
               <EuiFieldText
+                fullWidth
                 disabled={props.action === 'edit'}
                 value={tenantName}
                 onChange={handleTenantNameChange}
@@ -83,6 +84,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               optional
             >
               <EuiTextArea
+                fullWidth
                 placeholder="Describe the tenant"
                 value={tenantDescription}
                 onChange={handleTenantDescriptionChange}

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -44,11 +44,12 @@ import { API_ENDPOINT_INTERNALUSERS } from '../constants';
 import { showTableStatusMessage } from '../utils/loading-spinner-utils';
 import { useDeleteConfirmState } from '../utils/delete-confirm-modal-utils';
 import { useContextMenuState } from '../utils/context-menu';
+import { EMPTY_FIELD_VALUE } from '../ui-constants';
 
 function dictView() {
   return (items: Dictionary<string>) => {
     if (isEmpty(items)) {
-      return <span>&mdash;</span>;
+      return EMPTY_FIELD_VALUE;
     }
     return (
       <EuiFlexGroup direction="column" style={{ margin: '1px' }}>

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -48,7 +48,7 @@ import { useContextMenuState } from '../utils/context-menu';
 function dictView() {
   return (items: Dictionary<string>) => {
     if (isEmpty(items)) {
-      return '-';
+      return <span>&mdash;</span>;
     }
     return (
       <EuiFlexGroup direction="column" style={{ margin: '1px' }}>

--- a/public/apps/configuration/ui-constants.tsx
+++ b/public/apps/configuration/ui-constants.tsx
@@ -1,0 +1,18 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+
+export const EMPTY_FIELD_VALUE = <span>&mdash;</span>;

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -28,6 +28,7 @@ import { isEmpty } from 'lodash';
 
 import React from 'react';
 import { ExpressionModal } from '../panels/expression-modal';
+import { EMPTY_FIELD_VALUE } from '../ui-constants';
 
 export function renderTextFlexItem(header: string, value: string) {
   return (
@@ -45,11 +46,11 @@ export function displayBoolean(bool: boolean | undefined) {
 }
 
 export function displayArray(array: string[] | undefined) {
-  return array?.join(', ') || <span>&mdash;</span>;
+  return array?.join(', ') || EMPTY_FIELD_VALUE;
 }
 
 export function displayObject(object: object | undefined) {
-  return !isEmpty(object) ? JSON.stringify(object, null, 2) : <span>&mdash;</span>;
+  return !isEmpty(object) ? JSON.stringify(object, null, 2) : EMPTY_FIELD_VALUE;
 }
 
 export function renderCustomization(reserved: boolean) {
@@ -72,7 +73,7 @@ export function truncatedListView(limit = 3) {
       return (
         <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
           <EuiText key={'-'} size="xs">
-            &mdash;
+            {EMPTY_FIELD_VALUE}
           </EuiText>
         </EuiFlexGroup>
       );
@@ -98,7 +99,7 @@ export function truncatedListView(limit = 3) {
 
 export function renderExpression(title: string, expression: object) {
   if (isEmpty(expression)) {
-    return <span>&mdash;</span>;
+    return EMPTY_FIELD_VALUE;
   }
 
   return <ExpressionModal title={title} expression={expression} />;

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -45,11 +45,11 @@ export function displayBoolean(bool: boolean | undefined) {
 }
 
 export function displayArray(array: string[] | undefined) {
-  return array?.join(', ') || '--';
+  return array?.join(', ') || <span>&mdash;</span>;
 }
 
 export function displayObject(object: object | undefined) {
-  return !isEmpty(object) ? JSON.stringify(object, null, 2) : '--';
+  return !isEmpty(object) ? JSON.stringify(object, null, 2) : <span>&mdash;</span>;
 }
 
 export function renderCustomization(reserved: boolean) {
@@ -72,7 +72,7 @@ export function truncatedListView(limit = 3) {
       return (
         <EuiFlexGroup direction="column" style={{ margin: '1px' }}>
           <EuiText key={'-'} size="xs">
-            -
+            &mdash;
           </EuiText>
         </EuiFlexGroup>
       );
@@ -98,7 +98,7 @@ export function truncatedListView(limit = 3) {
 
 export function renderExpression(title: string, expression: object) {
   if (isEmpty(expression)) {
-    return '-';
+    return <span>&mdash;</span>;
   }
 
   return <ExpressionModal title={title} expression={expression} />;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- change all dashes/hyphens into em-dash


![image](https://user-images.githubusercontent.com/63824432/91373023-2cd83b80-e7ca-11ea-92a5-00da354de695.png)

- Make map user buttons center aligned and update subtext

![image](https://user-images.githubusercontent.com/63824432/91373160-83457a00-e7ca-11ea-8604-ae7aceebae32.png)

- stretch text fields in tenant edit modal to full width

![image](https://user-images.githubusercontent.com/63824432/91373216-a839ed00-e7ca-11ea-9e89-9ca2b92f795a.png)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
