### PR TITLE
Improve layout on permission tree

### DIFF
--- a/public/apps/configuration/panels/permission-tree.tsx
+++ b/public/apps/configuration/panels/permission-tree.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiTreeView, EuiIcon } from '@elastic/eui';
+import { EuiTreeView, EuiText } from '@elastic/eui';
 import { Node } from '@elastic/eui/src/components/tree_view/tree_view';
 import React from 'react';
 import { ActionGroupItem, DataObject } from '../types';
@@ -31,7 +31,7 @@ function buildTreeItem(
   return {
     label: name,
     id: name,
-    icon: <EuiIcon type="dot" />,
+    icon: <EuiText size="xs">•</EuiText>,
     children: children?.map((child) => buildTreeItem(child, depth + 1, actionGroups)),
   };
 }

--- a/public/apps/configuration/panels/permission-tree/_index.scss
+++ b/public/apps/configuration/panels/permission-tree/_index.scss
@@ -1,0 +1,20 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+ .permission-tree-container {
+  max-height: 200px;
+  overflow-Y: scroll;
+  width: 100%;
+ }

--- a/public/apps/configuration/panels/permission-tree/_index.scss
+++ b/public/apps/configuration/panels/permission-tree/_index.scss
@@ -13,9 +13,8 @@
  *   permissions and limitations under the License.
  */
 
- .permission-tree-container {
+.permission-tree-container {
   max-height: 200px;
   overflow-Y: scroll;
   width: 100%;
- }
- 
+}

--- a/public/apps/configuration/panels/permission-tree/_index.scss
+++ b/public/apps/configuration/panels/permission-tree/_index.scss
@@ -18,3 +18,4 @@
   overflow-Y: scroll;
   width: 100%;
  }
+ 

--- a/public/apps/configuration/panels/permission-tree/index.ts
+++ b/public/apps/configuration/panels/permission-tree/index.ts
@@ -1,0 +1,16 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export { PermissionTree } from './permission-tree';

--- a/public/apps/configuration/panels/permission-tree/permission-tree.tsx
+++ b/public/apps/configuration/panels/permission-tree/permission-tree.tsx
@@ -16,7 +16,9 @@
 import { EuiTreeView, EuiText } from '@elastic/eui';
 import { Node } from '@elastic/eui/src/components/tree_view/tree_view';
 import React from 'react';
-import { ActionGroupItem, DataObject } from '../types';
+import { ActionGroupItem, DataObject } from '../../types';
+
+import './_index.scss';
 
 const MAX_DEPTH = 5;
 
@@ -41,13 +43,15 @@ export function PermissionTree(props: {
   actionGroups: DataObject<ActionGroupItem>;
 }) {
   return (
-    <EuiTreeView
-      display="compressed"
-      aria-label="Permission tree"
-      showExpansionArrows
-      items={props.permissions.map((permission) =>
-        buildTreeItem(permission, 0, props.actionGroups)
-      )}
-    />
+    <div className="permission-tree-container">
+      <EuiTreeView
+        display="compressed"
+        aria-label="Permission tree"
+        showExpansionArrows
+        items={props.permissions.map((permission) =>
+          buildTreeItem(permission, 0, props.actionGroups)
+        )}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Use smaller dot on permission tree.
2. Limit max-height to 200px and add scroll bar.

Screenshot:
|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/63078162/91475918-204af600-e851-11ea-80c9-e4024512210d.png)|![image](https://user-images.githubusercontent.com/63078162/91474823-99e1e480-e84f-11ea-89a5-1032dab56813.png)|

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
