### PR TITLE
adjust sytle for instruction text in authentication view

### DIFF
--- a/public/apps/configuration/panels/auth-view/_index.scss
+++ b/public/apps/configuration/panels/auth-view/_index.scss
@@ -1,0 +1,4 @@
+.instruction-text {
+  max-width: 800px;
+  margin: auto;
+}

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -20,6 +20,7 @@ import { AuthorizationPanel } from './authorization-panel';
 import { API_ENDPOINT_SECURITYCONFIG } from '../../constants';
 import { AppDependencies } from '../../../types';
 import { ExternalLinkButton } from '../../utils/display-utils';
+import './_index.scss';
 
 function renderInstructionView() {
   return (
@@ -34,12 +35,7 @@ function renderInstructionView() {
         <h2>You have not set up authentication and authorization</h2>
       </EuiText>
 
-      <EuiText
-        textAlign="center"
-        size="xs"
-        color="subdued"
-        style={{ marginLeft: 500, marginRight: 500 }}
-      >
+      <EuiText textAlign="center" size="xs" color="subdued" className="instruction-text">
         In order to use Security plugin, you must decide on authentication <EuiCode>authc</EuiCode>{' '}
         and authorization backends <EuiCode>authz</EuiCode>. Use{' '}
         <EuiCode>plugins/opendistro_security/securityconfig/config.yml</EuiCode> to define how to

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -20,7 +20,6 @@ import { AuthorizationPanel } from './authorization-panel';
 import { API_ENDPOINT_SECURITYCONFIG } from '../../constants';
 import { AppDependencies } from '../../../types';
 import { ExternalLinkButton } from '../../utils/display-utils';
-import './_index.scss';
 
 function renderInstructionView() {
   return (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the style for instruction text.

*Test*
The new look when browser window is small.
<img width="797" alt="Screen Shot 2020-08-27 at 11 25 54 AM" src="https://user-images.githubusercontent.com/60111637/91481623-94899780-e859-11ea-8f73-69396436ff4b.png">

The new look when browser window is max.
<img width="2557" alt="Screen Shot 2020-08-27 at 11 26 02 AM" src="https://user-images.githubusercontent.com/60111637/91481669-a10df000-e859-11ea-8024-fd5fe98660b3.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
