### PR TITLE
Fix a UI bug that form row label is grey

### DIFF
--- a/public/apps/configuration/utils/form-row.tsx
+++ b/public/apps/configuration/utils/form-row.tsx
@@ -32,21 +32,23 @@ export function FormRow(props: FormRowDeps) {
     <EuiFormRow
       fullWidth
       label={
-        <EuiText size="xs" color="subdued">
-          <p>
+        <>
+          <EuiText size="xs">
             <b>{props.headerText}</b>
             <i>{props.optional && ' - optional'}</i>
-          </p>
-          {props.headerSubText}
-          {props.helpLink && (
-            <>
-              {' '}
-              <EuiLink href="{props.helpLink}" external>
-                Learn more
-              </EuiLink>
-            </>
-          )}
-        </EuiText>
+          </EuiText>
+          <EuiText color="subdued" size="xs">
+            {props.headerSubText}
+            {props.helpLink && (
+              <>
+                {' '}
+                <EuiLink href="{props.helpLink}" external>
+                  Learn more
+                </EuiLink>
+              </>
+            )}
+          </EuiText>
+        </>
       }
       helpText={props.helpText}
       isInvalid={props.isInvalid}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update form row title to primary (black) from subdued (grey)

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/63078162/91483717-fe577080-e85c-11ea-8f85-1fe9a2b26aa1.png)|![image](https://user-images.githubusercontent.com/63078162/91483663-e384fc00-e85c-11ea-9672-94a262378042.png)|


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
