### PR TITLE
Add object name (e.g. role name, user name etc.) to success toast

### DIFF
--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -53,11 +53,17 @@ const TITLE_TEXT_DICT = {
   duplicate: 'Duplicate internal user',
 };
 
-const UPDATE_TEXT_DICT = {
-  create: 'User successfully created',
-  edit: 'User successfully updated',
-  duplicate: 'User successfully duplicated',
-};
+function getSuccessToastMessage(action: string, userName: string): string {
+  switch (action) {
+    case 'create':
+    case 'duplicate':
+      return `User "${userName}" successfully created`;
+    case 'edit':
+      return `User "${userName}" successfully updated`;
+    default:
+      return '';
+  }
+}
 
 export function InternalUserEdit(props: InternalUserEditDeps) {
   const [userName, setUserName] = useState<string>('');
@@ -111,7 +117,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
       setCrossPageToast(buildUrl(ResourceType.users), {
         id: 'updateUserSucceeded',
         color: 'success',
-        title: UPDATE_TEXT_DICT[props.action],
+        title: getSuccessToastMessage(props.action, userName),
       });
       // Redirect to user listing
       window.location.href = buildHashUrl(ResourceType.users);

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -165,6 +165,18 @@ const SEARCH_OPTIONS: EuiSearchBarProps = {
   ],
 };
 
+function getSuccessToastMessage(action: string, groupName: string): string {
+  switch (action) {
+    case 'create':
+    case 'duplicate':
+      return `Action group "${groupName}" successfully created`;
+    case 'edit':
+      return `Action group "${groupName}" successfully updated`;
+    default:
+      return '';
+  }
+}
+
 export function PermissionList(props: AppDependencies) {
   const [permissionList, setPermissionList] = useState<PermissionListingItem[]>([]);
   const [actionGroupDict, setActionGroupDict] = useState<DataObject<ActionGroupItem>>({});
@@ -265,7 +277,7 @@ export function PermissionList(props: AppDependencies) {
             fetchData();
             addToast({
               id: 'saveSucceeded',
-              title: `${groupName} saved.`,
+              title: getSuccessToastMessage(action, groupName),
               color: 'success',
             });
           } catch (e) {

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -67,11 +67,17 @@ const TITLE_TEXT_DICT = {
   duplicate: 'Duplicate Role',
 };
 
-const UPDATE_TEXT_DICT = {
-  create: 'Role successfully created',
-  edit: 'Role successfully updated',
-  duplicate: 'Role successfully duplicated',
-};
+function getSuccessToastMessage(action: string, roleName: string): string {
+  switch (action) {
+    case 'create':
+    case 'duplicate':
+      return `Role "${roleName}" successfully created`;
+    case 'edit':
+      return `Role "${roleName}" successfully updated`;
+    default:
+      return '';
+  }
+}
 
 export function RoleEdit(props: RoleEditDeps) {
   const [roleName, setRoleName] = useState('');
@@ -158,7 +164,7 @@ export function RoleEdit(props: RoleEditDeps) {
       setCrossPageToast(buildUrl(ResourceType.roles, Action.view, roleName), {
         id: 'updateRoleSucceeded',
         color: 'success',
-        title: UPDATE_TEXT_DICT[props.action],
+        title: getSuccessToastMessage(props.action, roleName),
       });
       // Redirect to role view
       window.location.href = buildHashUrl(ResourceType.roles, Action.view, roleName);

--- a/public/apps/configuration/panels/role-mapping/RoleEditMappedUser.tsx
+++ b/public/apps/configuration/panels/role-mapping/RoleEditMappedUser.tsx
@@ -112,7 +112,7 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
         {
           id: 'updateRoleMappingSucceeded',
           color: 'success',
-          title: props.roleName + ' saved.',
+          title: 'Role "' + props.roleName + '" successfully updated.',
         }
       );
       window.location.href = buildHashUrl(

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -53,6 +53,18 @@ import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
 import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
 import { useContextMenuState } from '../../utils/context-menu';
 
+function getSuccessToastMessage(action: string, tenantName: string): string {
+  switch (action) {
+    case 'create':
+    case 'duplicate':
+      return `Tenant "${tenantName}" successfully created`;
+    case 'edit':
+      return `Tenant "${tenantName}" successfully updated`;
+    default:
+      return '';
+  }
+}
+
 export function TenantList(props: AppDependencies) {
   const [tenantData, setTenantData] = useState<Tenant[]>([]);
   const [errorFlag, setErrorFlag] = useState(false);
@@ -286,7 +298,7 @@ export function TenantList(props: AppDependencies) {
             fetchData();
             addToast({
               id: 'saveSucceeded',
-              title: `${tenantName} saved.`,
+              title: getSuccessToastMessage(action, tenantName),
               color: 'success',
             });
           } catch (e) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add object name (e.g. role name, user name etc.) to success toast.

**Some Screenshots:**
![image](https://user-images.githubusercontent.com/63824432/91488637-6fe6ed00-e864-11ea-828e-1889a259e8bb.png)

![image](https://user-images.githubusercontent.com/63824432/91488725-96a52380-e864-11ea-9739-a6ef749aab03.png)

![image](https://user-images.githubusercontent.com/63824432/91488906-d79d3800-e864-11ea-8263-6f6e94e80711.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
