### PR TITLE
[AuditLogging] add max width and fix margin of horizontal rule and em…

### DIFF
--- a/public/apps/configuration/_index.scss
+++ b/public/apps/configuration/_index.scss
@@ -26,6 +26,6 @@
     text-align: 'center'
 }
 
-.landing-page-maxwidth {
+.panel-restrict-width {
     max-width: 75%;
 }

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -229,9 +229,17 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
     );
   };
 
+  let content;
+
   if (props.setting === 'general') {
-    return renderGeneralSettings();
+    content = renderGeneralSettings();
+  } else {
+    content = renderComplianceSetting();
   }
 
-  return renderComplianceSetting();
+  return (
+    <>
+      <div className="panel-restrict-width">{content}</div>
+    </>
+  );
 }

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -55,7 +55,7 @@ function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: bool
       <EuiTitle>
         <h3>Audit logging</h3>
       </EuiTitle>
-      <EuiHorizontalRule />
+      <EuiHorizontalRule margin={'m'} />
       <EuiForm>
         <EuiDescribedFormGroup title={<h3>Storage location</h3>} className="described-form-group">
           <EuiFormRow className="form-row">
@@ -162,62 +162,69 @@ export function AuditLogging(props: AuditLoggingProps) {
 
   const statusPanel = renderStatusPanel(onSwitchChange, configuration.enabled || false);
 
+  let content;
+
   if (!configuration.enabled) {
-    return statusPanel;
+    content = statusPanel;
+  } else {
+    content = (
+      <>
+        {statusPanel}
+        <EuiSpacer />
+
+        <EuiPanel>
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiTitle>
+                <h3>General settings</h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                onClick={() => {
+                  window.location.href =
+                    buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT;
+                }}
+              >
+                Configure
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiHorizontalRule margin={'m'} />
+          {renderGeneralSettings(configuration)}
+        </EuiPanel>
+
+        <EuiSpacer />
+
+        <EuiPanel>
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiTitle>
+                <h3>Compliance settings</h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                onClick={() => {
+                  window.location.href =
+                    buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT;
+                }}
+              >
+                Configure
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+
+          <EuiHorizontalRule margin={'m'} />
+          {renderComplianceSettings(configuration)}
+        </EuiPanel>
+      </>
+    );
   }
 
   return (
     <>
-      {statusPanel}
-
-      <EuiSpacer />
-
-      <EuiPanel>
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiTitle>
-              <h3>General settings</h3>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              onClick={() => {
-                window.location.href =
-                  buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT;
-              }}
-            >
-              Configure
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiHorizontalRule />
-        {renderGeneralSettings(configuration)}
-      </EuiPanel>
-
-      <EuiSpacer />
-
-      <EuiPanel>
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiTitle>
-              <h3>Compliance settings</h3>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              onClick={() => {
-                window.location.href =
-                  buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT;
-              }}
-            >
-              Configure
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiHorizontalRule />
-        {renderComplianceSettings(configuration)}
-      </EuiPanel>
+      <div className="panel-restrict-width">{content}</div>
     </>
   );
 }

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -23,7 +23,7 @@ import {
   EuiSwitch,
   EuiTitle,
 } from '@elastic/eui';
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { displayBoolean, displayObject } from '../../utils/display-utils';
 import { comboBoxOptionToString, stringToComboBoxOption } from '../../utils/combo-box-utils';
 import { AuditLoggingSettings } from './types';
@@ -110,9 +110,18 @@ export function EditSettingGroup(props: {
         handleInvalid(setting.path, error);
       };
 
+      const codeMap = get(config, setting.path);
+      let codeString;
+
+      if (isEmpty(codeMap)) {
+        codeString = '{}';
+      } else {
+        codeString = displayObject(codeMap);
+      }
+
       return (
         <JsonCodeEditor
-          initialValue={displayObject(get(config, setting.path))}
+          initialValue={codeString}
           errorMessage={setting.error}
           handleCodeChange={handleCodeChange}
           handleCodeInvalid={handleCodeInvalid}

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -160,7 +160,7 @@ const setOfSteps = [
 export function GetStarted(props: AppDependencies) {
   return (
     <>
-      <div className="landing-page-maxwidth">
+      <div className="panel-restrict-width">
         <EuiPageHeader>
           <EuiTitle size="l">
             <h1>Get started</h1>


### PR DESCRIPTION
…pty code display

*Issue #, if available:*

*Description of changes:*
Address UX feedback for audit logging.
1. added the max width restriction.
2. add medium margin for the horizontal rule
3. fix an issue where code editor should receive string instead of object.

*Test*
The get started page is not impacted.
<img width="2539" alt="Screen Shot 2020-08-27 at 6 09 39 PM" src="https://user-images.githubusercontent.com/60111637/91509984-928efb00-e890-11ea-90ef-ece7947b893b.png">

The read view
<img width="2549" alt="Screen Shot 2020-08-27 at 6 09 47 PM" src="https://user-images.githubusercontent.com/60111637/91509997-9b7fcc80-e890-11ea-85cc-2bafb8bef2c7.png">

The edit view
<img width="2550" alt="Screen Shot 2020-08-27 at 6 09 58 PM" src="https://user-images.githubusercontent.com/60111637/91510007-a5093480-e890-11ea-937b-51e98dc6c6d6.png">

<img width="2543" alt="Screen Shot 2020-08-27 at 6 10 08 PM" src="https://user-images.githubusercontent.com/60111637/91510016-aa667f00-e890-11ea-898a-09836a624d25.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
