### PR TITLE
[AuditLogging] remove extra whitespace and follow up code improvement

### DIFF
--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -237,9 +237,5 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
     content = renderComplianceSetting();
   }
 
-  return (
-    <>
-      <div className="panel-restrict-width">{content}</div>
-    </>
-  );
+  return <div className="panel-restrict-width">{content}</div>;
 }

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -55,7 +55,7 @@ function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: bool
       <EuiTitle>
         <h3>Audit logging</h3>
       </EuiTitle>
-      <EuiHorizontalRule margin={'m'} />
+      <EuiHorizontalRule margin="m" />
       <EuiForm>
         <EuiDescribedFormGroup title={<h3>Storage location</h3>} className="described-form-group">
           <EuiFormRow className="form-row">
@@ -190,7 +190,7 @@ export function AuditLogging(props: AuditLoggingProps) {
               </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiHorizontalRule margin={'m'} />
+          <EuiHorizontalRule margin="m" />
           {renderGeneralSettings(configuration)}
         </EuiPanel>
 
@@ -215,16 +215,12 @@ export function AuditLogging(props: AuditLoggingProps) {
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          <EuiHorizontalRule margin={'m'} />
+          <EuiHorizontalRule margin="m" />
           {renderComplianceSettings(configuration)}
         </EuiPanel>
       </>
     );
   }
 
-  return (
-    <>
-      <div className="panel-restrict-width">{content}</div>
-    </>
-  );
+  return <div className="panel-restrict-width">{content}</div>;
 }

--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -188,7 +188,7 @@ const READ_WATCHED_FIELDS: SettingContent = {
   path: 'compliance.read_watched_fields',
   description:
     'List the indices and fields to watch during read events. Adding watched fields will generate one log per document' +
-    'access and could result in significant overhead. Sample data content:',
+    ' access and could result in significant overhead. Sample data content:',
   type: 'map',
   code: `{
   "index-name-pattern": ["field-name-pattern"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is to address a UX feedback to add a whitespace between two words.
Also address two comments from a previous PR
https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/pull/426

*Test*
whitespace fix

Before
<img width="2547" alt="Screen Shot 2020-08-31 at 5 07 42 PM" src="https://user-images.githubusercontent.com/60111637/91780570-bdd55b00-ebac-11ea-8a98-ae30c15e609d.png"> 

after
<img width="2515" alt="Screen Shot 2020-08-31 at 5 06 52 PM" src="https://user-images.githubusercontent.com/60111637/91780561-b9a93d80-ebac-11ea-9a4c-b6a635fdcb52.png">

Verified the max width and horizontal margin are still working.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
