### PR TITLE
Add unit test for tenant utils

### DIFF
--- a/public/apps/configuration/utils/tenant-utils.test.tsx
+++ b/public/apps/configuration/utils/tenant-utils.test.tsx
@@ -83,18 +83,12 @@ describe('Tenant list utils', () => {
     it('transform global tenant', () => {
       const result = transformTenantData({ global_tenant: globalTenant }, false);
       expect(result.length).toBe(1);
-      expect(result[0].tenant).toBe(GLOBAL_USER_DICT.Label);
-      expect(result[0].tenantValue).toBe(GLOBAL_USER_DICT.Value);
-      expect(result[0].description).toBe(GLOBAL_USER_DICT.Description);
       expect(result[0]).toEqual(expectedGlobalTenantListing);
     });
 
     it('transform private tenant', () => {
       const result = transformTenantData({}, true);
       expect(result.length).toBe(1);
-      expect(result[0].tenant).toBe(PRIVATE_USER_DICT.Label);
-      expect(result[0].tenantValue).toBe(PRIVATE_USER_DICT.Value);
-      expect(result[0].description).toBe(PRIVATE_USER_DICT.Description);
       expect(result[0]).toEqual(expectedPrivateTenantListing);
     });
 
@@ -105,8 +99,6 @@ describe('Tenant list utils', () => {
       );
       expect(result.length).toBe(2);
       expect(result[0]).toEqual(expectedGlobalTenantListing);
-      expect(result[1].tenant).toBe('dummy');
-      expect(result[1].tenantValue).toBe('dummy');
       expect(result[1]).toMatchObject(expectedTenantListing);
     });
 
@@ -118,8 +110,6 @@ describe('Tenant list utils', () => {
       expect(result.length).toBe(3);
       expect(result[0]).toEqual(expectedGlobalTenantListing);
       expect(result[1]).toEqual(expectedPrivateTenantListing);
-      expect(result[2].tenant).toBe('dummy');
-      expect(result[2].tenantValue).toBe('dummy');
       expect(result[2]).toMatchObject(expectedTenantListing);
     });
   });

--- a/public/apps/configuration/utils/tenant-utils.test.tsx
+++ b/public/apps/configuration/utils/tenant-utils.test.tsx
@@ -1,0 +1,316 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  GLOBAL_USER_DICT,
+  PRIVATE_USER_DICT,
+  transformTenantData,
+  resolveTenantName,
+  RESOLVED_GLOBAL_TENANT,
+  RESOLVED_PRIVATE_TENANT,
+  globalTenantName,
+  formatTenantName,
+  transformRoleTenantPermissionData,
+  getTenantPermissionType,
+  transformRoleTenantPermissions,
+} from './tenant-utils';
+import {
+  RoleViewTenantInvalidText,
+  TENANT_READ_PERMISSION,
+  TENANT_WRITE_PERMISSION,
+} from '../constants';
+import { TenantPermissionType } from '../types';
+
+describe('Tenant list utils', () => {
+  const expectedGlobalTenantListing = {
+    tenant: GLOBAL_USER_DICT.Label,
+    reserved: true,
+    description: GLOBAL_USER_DICT.Description,
+    tenantValue: GLOBAL_USER_DICT.Value,
+  };
+
+  const expectedPrivateTenantListing = {
+    tenant: PRIVATE_USER_DICT.Label,
+    reserved: true,
+    description: PRIVATE_USER_DICT.Description,
+    tenantValue: PRIVATE_USER_DICT.Value,
+  };
+
+  const expectedTenantListing = {
+    tenant: 'dummy',
+    reserved: false,
+    description: 'dummy',
+    tenantValue: 'dummy',
+  };
+
+  const tenantList = [
+    expectedGlobalTenantListing,
+    expectedPrivateTenantListing,
+    expectedTenantListing,
+  ];
+
+  describe('transform to listing data', () => {
+    const globalTenant = {
+      description: 'Global tenant',
+      reserved: true,
+      hidden: false,
+      static: false,
+      tenant: '',
+      tenantValue: '',
+    };
+
+    const sampleTenant1 = {
+      description: 'dummy',
+      reserved: false,
+      hidden: false,
+      static: false,
+      tenant: '',
+      tenantValue: '',
+    };
+
+    it('transform global tenant', () => {
+      const result = transformTenantData({ global_tenant: globalTenant }, false);
+      expect(result.length).toBe(1);
+      expect(result[0].tenant).toBe(GLOBAL_USER_DICT.Label);
+      expect(result[0].tenantValue).toBe(GLOBAL_USER_DICT.Value);
+      expect(result[0].description).toBe(GLOBAL_USER_DICT.Description);
+      expect(result[0]).toEqual(expectedGlobalTenantListing);
+    });
+
+    it('transform private tenant', () => {
+      const result = transformTenantData({}, true);
+      expect(result.length).toBe(1);
+      expect(result[0].tenant).toBe(PRIVATE_USER_DICT.Label);
+      expect(result[0].tenantValue).toBe(PRIVATE_USER_DICT.Value);
+      expect(result[0].description).toBe(PRIVATE_USER_DICT.Description);
+      expect(result[0]).toEqual(expectedPrivateTenantListing);
+    });
+
+    it('transform global and custom tenant', () => {
+      const result = transformTenantData(
+        { global_tenant: globalTenant, dummy: sampleTenant1 },
+        false
+      );
+      expect(result.length).toBe(2);
+      expect(result[0]).toEqual(expectedGlobalTenantListing);
+      expect(result[1].tenant).toBe('dummy');
+      expect(result[1].tenantValue).toBe('dummy');
+      expect(result[1]).toMatchObject(expectedTenantListing);
+    });
+
+    it('transform global, private and custom tenant', () => {
+      const result = transformTenantData(
+        { global_tenant: globalTenant, dummy: sampleTenant1 },
+        true
+      );
+      expect(result.length).toBe(3);
+      expect(result[0]).toEqual(expectedGlobalTenantListing);
+      expect(result[1]).toEqual(expectedPrivateTenantListing);
+      expect(result[2].tenant).toBe('dummy');
+      expect(result[2].tenantValue).toBe('dummy');
+      expect(result[2]).toMatchObject(expectedTenantListing);
+    });
+  });
+
+  describe('Resolve tenant name', () => {
+    const tenantNames = ['', 'undefined', 'user1', '__user__', ' dummy'];
+    const userName = 'user1';
+
+    it('resolve to global tenant when tenant name is empty', () => {
+      const result = resolveTenantName(tenantNames[0], userName);
+      expect(result).toBe(RESOLVED_GLOBAL_TENANT);
+    });
+
+    it('resolve to global tenant when tenant name is undefined', () => {
+      const result = resolveTenantName(tenantNames[1], userName);
+      expect(result).toBe(RESOLVED_GLOBAL_TENANT);
+    });
+
+    it('resolve to private tenant when tenant name is user name', () => {
+      const result = resolveTenantName(tenantNames[2], userName);
+      expect(result).toBe(RESOLVED_PRIVATE_TENANT);
+    });
+
+    it('resolve to private tenant when tenant name is __user__', () => {
+      const result = resolveTenantName(tenantNames[3], userName);
+      expect(result).toBe(RESOLVED_PRIVATE_TENANT);
+    });
+
+    it('resolve to actual tenant name when tenant name is custom', () => {
+      const result = resolveTenantName(tenantNames[4], userName);
+      expect(result).toBe(tenantNames[4]);
+    });
+  });
+
+  describe('Format tenant name', () => {
+    it('format global tenant', () => {
+      const result = formatTenantName(globalTenantName);
+      expect(result).toBe(GLOBAL_USER_DICT.Label);
+    });
+
+    it('format non-global tenant', () => {
+      const result = formatTenantName('dummy');
+      expect(result).toBe('dummy');
+    });
+  });
+
+  const sampleTenantPattern1 = ['dummy'];
+  const sampleTenantPattern2 = ['dummy', 'dummy'];
+  const sampleTenantPattern3 = ['dummy*'];
+
+  describe('transform role tenant permission data', () => {
+    const permissionType = 'dummy';
+
+    const expectedRoleTenantPermissionData1 = {
+      tenant_patterns: sampleTenantPattern1,
+      permissionType,
+      tenant: tenantList[2].tenant,
+      reserved: tenantList[2].reserved,
+      description: tenantList[2].description,
+      tenantValue: tenantList[2].tenantValue,
+    };
+
+    const expectedRoleTenantPermissionData2 = {
+      tenant_patterns: sampleTenantPattern2,
+      permissionType,
+      tenant: RoleViewTenantInvalidText,
+      reserved: false,
+      description: RoleViewTenantInvalidText,
+      tenantValue: RoleViewTenantInvalidText,
+    };
+
+    const expectedRoleTenantPermissionData3 = {
+      tenant_patterns: sampleTenantPattern3,
+      permissionType,
+      tenant: RoleViewTenantInvalidText,
+      reserved: false,
+      description: RoleViewTenantInvalidText,
+      tenantValue: RoleViewTenantInvalidText,
+    };
+
+    it('transform single tenant permission', () => {
+      const result = transformRoleTenantPermissionData(
+        [
+          {
+            tenant_patterns: sampleTenantPattern1,
+            permissionType,
+          },
+        ],
+        tenantList
+      );
+      expect(result[0]).toEqual(expectedRoleTenantPermissionData1);
+    });
+
+    it('transform multiple tenant permission', () => {
+      const result = transformRoleTenantPermissionData(
+        [
+          {
+            tenant_patterns: sampleTenantPattern2,
+            permissionType,
+          },
+        ],
+        tenantList
+      );
+      expect(result[0]).toEqual(expectedRoleTenantPermissionData2);
+    });
+
+    it('transform tenant pattern', () => {
+      const result = transformRoleTenantPermissionData(
+        [
+          {
+            tenant_patterns: sampleTenantPattern3,
+            permissionType,
+          },
+        ],
+        tenantList
+      );
+      expect(result[0]).toEqual(expectedRoleTenantPermissionData3);
+    });
+  });
+
+  const emptyTenantPermissions: string[] = [];
+  const readTenantPermissions: string[] = [TENANT_READ_PERMISSION];
+  const writeTenantPermissions: string[] = [TENANT_WRITE_PERMISSION];
+  const readWriteTenantPermissions: string[] = [TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION];
+
+  describe('Tenant permission type', () => {
+    it('empty permission', () => {
+      const result = getTenantPermissionType(emptyTenantPermissions);
+      expect(result).toBe(TenantPermissionType.None);
+    });
+
+    it('read permission', () => {
+      const result = getTenantPermissionType(readTenantPermissions);
+      expect(result).toBe(TenantPermissionType.Read);
+    });
+
+    it('write permission', () => {
+      const result = getTenantPermissionType(writeTenantPermissions);
+      expect(result).toBe(TenantPermissionType.Write);
+    });
+
+    it('read and write permission', () => {
+      const result = getTenantPermissionType(readWriteTenantPermissions);
+      expect(result).toBe(TenantPermissionType.Full);
+    });
+  });
+
+  describe('transform role tenant permissions', () => {
+    it('transform tenant patterns with just read permission', () => {
+      const expectedRoleTenantPermissionView = {
+        tenant_patterns: ['dummy'],
+        permissionType: TenantPermissionType.Read,
+      };
+
+      const result = transformRoleTenantPermissions([
+        {
+          tenant_patterns: sampleTenantPattern1,
+          allowed_actions: readTenantPermissions,
+        },
+      ]);
+      expect(result[0]).toMatchObject(expectedRoleTenantPermissionView);
+    });
+
+    it('transform tenant patterns with just write permission', () => {
+      const expectedRoleTenantPermissionView = {
+        tenant_patterns: ['dummy'],
+        permissionType: TenantPermissionType.Write,
+      };
+
+      const result = transformRoleTenantPermissions([
+        {
+          tenant_patterns: sampleTenantPattern1,
+          allowed_actions: writeTenantPermissions,
+        },
+      ]);
+      expect(result[0]).toMatchObject(expectedRoleTenantPermissionView);
+    });
+
+    it('transform tenant patterns with read and write permission', () => {
+      const expectedRoleTenantPermissionView = {
+        tenant_patterns: ['dummy'],
+        permissionType: TenantPermissionType.Full,
+      };
+
+      const result = transformRoleTenantPermissions([
+        {
+          tenant_patterns: sampleTenantPattern1,
+          allowed_actions: readWriteTenantPermissions,
+        },
+      ]);
+      expect(result[0]).toMatchObject(expectedRoleTenantPermissionView);
+    });
+  });
+});

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -33,14 +33,14 @@ import {
 } from '../types';
 import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../constants';
 
-const globalTenantName = 'global_tenant';
-const GLOBAL_USER_DICT: { [key: string]: string } = {
+export const globalTenantName = 'global_tenant';
+export const GLOBAL_USER_DICT: { [key: string]: string } = {
   Label: 'Global',
   Value: '',
   Description: 'Everyone can see it',
 };
 
-const PRIVATE_USER_DICT: { [key: string]: string } = {
+export const PRIVATE_USER_DICT: { [key: string]: string } = {
   Label: 'Private',
   Value: '__user__',
   Description: 'Only visible to the current logged in user',
@@ -113,7 +113,7 @@ export function resolveTenantName(tenant: string, userName: string) {
   }
 }
 
-function formatTenantName(tenantName: string): string {
+export function formatTenantName(tenantName: string): string {
   if (tenantName === globalTenantName) return GLOBAL_USER_DICT.Label;
   return tenantName;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add unit test for tenant utils

*UT result:*
```
% yarn test:jest public/apps/configuration/utils/tenant-utils.test.tsx
yarn run v1.22.4
$ NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js public/apps/configuration/utils/tenant-utils.test.tsx
 PASS  public/apps/configuration/utils/tenant-utils.test.tsx
  Tenant list utils
    transform to listing data
      ✓ transform global tenant (3ms)
      ✓ transform private tenant (1ms)
      ✓ transform global and custom tenant (1ms)
      ✓ transform global, private and custom tenant (1ms)
    Resolve tenant name
      ✓ resolve to global tenant when tenant name is empty
      ✓ resolve to global tenant when tenant name is undefined
      ✓ resolve to private tenant when tenant name is user name
      ✓ resolve to private tenant when tenant name is __user__
      ✓ resolve to actual tenant name when tenant name is custom
    Format tenant name
      ✓ format global tenant
      ✓ format non-global tenant (1ms)
    transform role tenant permission data
      ✓ transform single tenant permission
      ✓ transform multiple tenant permission
      ✓ transform tenant pattern
    Tenant permission type
      ✓ empty permission
      ✓ read permission (1ms)
      ✓ write permission
      ✓ read and write permission
    transform role tenant permissions
      ✓ transform tenant patterns with just read permission
      ✓ transform tenant patterns with just write permission
      ✓ transform tenant patterns with read and write permission

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        4.141s, estimated 5s
Ran all test suites matching /public\/apps\/configuration\/utils\/tenant-utils.test.tsx/i.
✨  Done in 5.35s.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
