### PR TITLE
Add unit test for role list component

### DIFF
--- a/public/apps/configuration/panels/role-list.test.tsx
+++ b/public/apps/configuration/panels/role-list.test.tsx
@@ -66,7 +66,7 @@ describe('Role list', () => {
     // Hide the error message
     jest.spyOn(console, 'log').mockImplementationOnce(() => {});
     mockRoleListUtils.fetchRole.mockImplementationOnce(() => {
-      throw 'error';
+      throw Error();
     });
 
     shallow(

--- a/public/apps/configuration/panels/role-list.test.tsx
+++ b/public/apps/configuration/panels/role-list.test.tsx
@@ -1,0 +1,123 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { RoleList } from './role-list';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { EuiInMemoryTable } from '@elastic/eui';
+
+jest.mock('../utils/role-list-utils');
+jest.mock('../utils/url-builder');
+jest.mock('../utils/display-utils');
+// eslint-disable-next-line
+const mockRoleListUtils = require('../utils/role-list-utils');
+
+describe('Role list', () => {
+  const setState = jest.fn();
+  const mockCoreStart = {
+    http: 1,
+  };
+
+  beforeEach(() => {
+    jest.spyOn(React, 'useState').mockImplementation((initialValue) => [initialValue, setState]);
+  });
+
+  it('Render empty', () => {
+    const mockRoleListingData = [
+      {
+        roleName: 'role_1',
+        reserved: true,
+        clusterPermission: ['readonly'],
+        indexPermission: ['data1'],
+        tenantPermission: ['tenant1'],
+        internaluser: [],
+        backendRoles: [],
+      },
+    ];
+
+    mockRoleListUtils.transformRoleData = jest.fn().mockReturnValue(mockRoleListingData);
+
+    const component = shallow(
+      <RoleList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+
+    expect(component.find(EuiInMemoryTable).prop('items').length).toBe(0);
+  });
+
+  it('Render error', (done) => {
+    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+    // Hide the error message
+    jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+    mockRoleListUtils.fetchRole.mockImplementationOnce(() => {
+      throw 'error';
+    });
+
+    shallow(
+      <RoleList
+        coreStart={{} as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+
+    process.nextTick(() => {
+      // Expect setting error to true
+      expect(setState).toHaveBeenCalledWith(true);
+      done();
+    });
+  });
+
+  it('Render data', (done) => {
+    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+
+    const mockRoleListingData = [
+      {
+        roleName: 'role_1',
+        reserved: true,
+        clusterPermission: ['readonly'],
+        indexPermission: ['data1'],
+        tenantPermission: ['tenant1'],
+        internaluser: [],
+        backendRoles: [],
+      },
+    ];
+
+    mockRoleListUtils.transformRoleData = jest.fn().mockReturnValue(mockRoleListingData);
+
+    shallow(
+      <RoleList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+
+    process.nextTick(() => {});
+    process.nextTick(() => {
+      expect(mockRoleListUtils.fetchRole).toHaveBeenCalledTimes(1);
+      expect(mockRoleListUtils.fetchRoleMapping).toHaveBeenCalledTimes(1);
+      expect(mockRoleListUtils.transformRoleData).toHaveBeenCalledTimes(1);
+      expect(setState).toHaveBeenCalledWith(mockRoleListingData);
+      done();
+    });
+  });
+});

--- a/public/apps/configuration/panels/role-list.test.tsx
+++ b/public/apps/configuration/panels/role-list.test.tsx
@@ -111,7 +111,6 @@ describe('Role list', () => {
       />
     );
 
-    process.nextTick(() => {});
     process.nextTick(() => {
       expect(mockRoleListUtils.fetchRole).toHaveBeenCalledTimes(1);
       expect(mockRoleListUtils.fetchRoleMapping).toHaveBeenCalledTimes(1);

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -34,11 +34,12 @@ import { difference } from 'lodash';
 import { AppDependencies } from '../../types';
 import {
   transformRoleData,
-  buildSearchFilterOptions,
   requestDeleteRoles,
   RoleListing,
+  fetchRole,
+  fetchRoleMapping,
+  buildSearchFilterOptions,
 } from '../utils/role-list-utils';
-import { API_ENDPOINT_ROLES, API_ENDPOINT_ROLESMAPPING } from '../constants';
 import { ResourceType, Action } from '../types';
 import { buildHashUrl } from '../utils/url-builder';
 import { renderCustomization, truncatedListView } from '../utils/display-utils';
@@ -90,17 +91,17 @@ const columns: Array<EuiBasicTableColumn<RoleListing>> = [
 ];
 
 export function RoleList(props: AppDependencies) {
-  const [roleData, setRoleData] = useState<RoleListing[]>([]);
-  const [errorFlag, setErrorFlag] = useState(false);
+  const [roleData, setRoleData] = React.useState<RoleListing[]>([]);
+  const [errorFlag, setErrorFlag] = React.useState(false);
   const [selection, setSelection] = useState<RoleListing[]>([]);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
+  React.useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const rawRoleData = await props.coreStart.http.get(API_ENDPOINT_ROLES);
-        const rawRoleMappingData = await props.coreStart.http.get(API_ENDPOINT_ROLESMAPPING);
+        const rawRoleData = await fetchRole(props.coreStart.http);
+        const rawRoleMappingData = await fetchRoleMapping(props.coreStart.http);
         const processedData = transformRoleData(rawRoleData, rawRoleMappingData);
         setRoleData(processedData);
       } catch (e) {

--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -91,10 +91,13 @@ export async function requestDeleteRoles(http: HttpStart, roles: string[]) {
     await http.delete(`${API_ENDPOINT_ROLES}/${role}`);
   }
 }
+
+// TODO: have a type definition for it
 export function fetchRole(http: HttpStart): Promise<any> {
   return http.get(API_ENDPOINT_ROLES);
 }
 
+// TODO: have a type definition for it
 export function fetchRoleMapping(http: HttpStart): Promise<any> {
   return http.get(API_ENDPOINT_ROLESMAPPING);
 }

--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -15,7 +15,7 @@
 
 import { map, chain } from 'lodash';
 import { HttpStart } from '../../../../../../src/core/public';
-import { API_ENDPOINT_ROLES } from '../constants';
+import { API_ENDPOINT_ROLES, API_ENDPOINT_ROLESMAPPING } from '../constants';
 
 export interface RoleListing {
   roleName: string;
@@ -90,4 +90,11 @@ export async function requestDeleteRoles(http: HttpStart, roles: string[]) {
   for (const role of roles) {
     await http.delete(`${API_ENDPOINT_ROLES}/${role}`);
   }
+}
+export function fetchRole(http: HttpStart): Promise<any> {
+  return http.get(API_ENDPOINT_ROLES);
+}
+
+export function fetchRoleMapping(http: HttpStart): Promise<any> {
+  return http.get(API_ENDPOINT_ROLESMAPPING);
 }

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -14,3 +14,8 @@
  */
 
 require('babel-polyfill');
+
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add unit test for role list component.

*Coverage:* (the failure are integration test that should be excluded)
**Before**:
% yarn test:jest --coverage
yarn run v1.22.4
$ NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js --coverage
 PASS  server/auth/auth_handler_factory.test.ts (7.199s)
 PASS  public/apps/configuration/utils/tenant-utils.test.tsx (7.224s)
 PASS  public/apps/configuration/utils/role-list-utils.test.tsx (7.279s)
 FAIL  test/jest_integration/multi_tenancy.test.ts

-----------------------------------------------------|---------|----------|---------|---------|-------------------
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                            |    3.82 |     6.46 |    2.85 |    3.66 |
 build_tools                                         |       0 |        0 |       0 |       0 |
  build_plugin.js                                    |       0 |        0 |       0 |       0 | 16-153
 common                                              |     100 |      100 |     100 |     100 |
  index.ts                                           |     100 |      100 |     100 |     100 |
 public                                              |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |      100 |       0 |       0 | 24
  plugin.ts                                          |       0 |        0 |       0 |       0 | 34-101
  types.ts                                           |       0 |        0 |       0 |       0 |
 public/apps                                         |       0 |      100 |     100 |       0 |
  apps-constants.tsx                                 |       0 |      100 |     100 |       0 | 18-21
  types.ts                                           |       0 |        0 |       0 |       0 |
 public/apps/account                                 |       0 |        0 |       0 |       0 |
  account-app.tsx                                    |       0 |        0 |       0 |       0 | 24-40
  account-nav-button.tsx                             |       0 |        0 |       0 |       0 | 44-132
  constants.tsx                                      |       0 |      100 |     100 |       0 | 19
  password-reset-panel.tsx                           |       0 |      100 |       0 |       0 | 41-138
  role-info-panel.tsx                                |       0 |        0 |       0 |       0 | 29-73
  tenant-selection-page.tsx                          |       0 |        0 |       0 |       0 | 24-51
  tenant-switch-panel.tsx                            |       0 |        0 |       0 |       0 | 49-248
  types.ts                                           |       0 |        0 |       0 |       0 |
  utils.tsx                                          |       0 |        0 |       0 |       0 | 22-39
 public/apps/configuration                           |   24.24 |        0 |       0 |      25 |
  app-router.tsx                                     |       0 |        0 |       0 |       0 | 42-235
  configuration-app.tsx                              |       0 |      100 |       0 |       0 | 30-32
  constants.tsx                                      |     100 |      100 |     100 |     100 |
  cross-page-toast.tsx                               |       0 |        0 |       0 |       0 | 24-34
  types.ts                                           |       0 |        0 |       0 |       0 |
  ui-constants.tsx                                   |       0 |      100 |     100 |       0 | 18
 public/apps/configuration/panels                    |       0 |        0 |       0 |       0 |
  expression-modal.tsx                               |       0 |        0 |       0 |       0 | 28-54
  get-started.tsx                                    |       0 |      100 |       0 |       0 | 38-210
  nav-panel.tsx                                      |       0 |      100 |       0 |       0 | 21-36
  role-list.tsx                                      |       0 |        0 |       0 |       0 | 50-229
  user-list.tsx                                      |       0 |        0 |       0 |       0 | 50-227
 public/apps/configuration/panels/audit-logging      |       0 |        0 |       0 |       0 |
  audit-logging-edit-settings.tsx                    |       0 |        0 |       0 |       0 | 45-240
  audit-logging.tsx                                  |       0 |        0 |       0 |       0 | 53-225
  code-editor.tsx                                    |       0 |        0 |       0 |       0 | 27-45
  constants.tsx                                      |       0 |      100 |     100 |       0 | 16-339
  edit-setting-group.tsx                             |       0 |        0 |       0 |       0 | 34-152
  types.tsx                                          |       0 |        0 |       0 |       0 |
  view-setting-group.tsx                             |       0 |        0 |       0 |       0 | 32-62
 public/apps/configuration/panels/auth-view          |       0 |        0 |       0 |       0 |
  auth-view.tsx                                      |       0 |        0 |       0 |       0 | 25-82
  authentication-sequence-panel.tsx                  |       0 |        0 |       0 |       0 | 23-98
  authorization-panel.tsx                            |       0 |        0 |       0 |       0 | 23-81
 public/apps/configuration/panels/internal-user-edit |       0 |        0 |       0 |       0 |
  attribute-panel.tsx                                |       0 |        0 |       0 |       0 | 37-125
  internal-user-edit.tsx                             |       0 |        0 |       0 |       0 | 50-182
  types.tsx                                          |       0 |        0 |       0 |       0 |
 public/apps/configuration/panels/permission-list    |       0 |        0 |       0 |       0 |
  edit-modal.tsx                                     |       0 |        0 |       0 |       0 | 43-97
  permission-list.tsx                                |       0 |        0 |       0 |       0 | 64-322
 public/apps/configuration/panels/permission-tree    |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 |
  permission-tree.tsx                                |       0 |        0 |       0 |       0 | 23-52
 public/apps/configuration/panels/role-edit          |       0 |        0 |       0 |       0 |
  cluster-permission-panel.tsx                       |       0 |      100 |       0 |       0 | 31-32
  constant.tsx                                       |       0 |      100 |     100 |       0 | 16
  index-permission-panel.tsx                         |       0 |        0 |       0 |       0 | 50-326
  role-edit.tsx                                      |       0 |        0 |       0 |       0 | 64-252
  tenant-panel.tsx                                   |       0 |        0 |       0 |       0 | 39-147
  types.tsx                                          |       0 |        0 |       0 |       0 |
 public/apps/configuration/panels/role-mapping       |       0 |        0 |       0 |       0 |
  RoleEditMappedUser.tsx                             |       0 |        0 |       0 |       0 | 51-165
  external-identities-panel.tsx                      |       0 |        0 |       0 |       0 | 38-106
  internal-users-panel.tsx                           |       0 |      100 |       0 |       0 | 30-31
  types.tsx                                          |       0 |        0 |       0 |       0 |
 public/apps/configuration/panels/role-view          |       0 |        0 |       0 |       0 |
  cluster-permission-panel.tsx                       |       0 |        0 |       0 |       0 | 34-52
  index-permission-panel.tsx                         |       0 |        0 |       0 |       0 | 50-176
  role-view.tsx                                      |       0 |        0 |       0 |       0 | 79-381
  tenants-panel.tsx                                  |       0 |        0 |       0 |       0 | 59-186
 public/apps/configuration/panels/tenant-list        |       0 |        0 |       0 |       0 |
  edit-modal.tsx                                     |       0 |        0 |       0 |       0 | 42-101
  tenant-list.tsx                                    |       0 |        0 |       0 |       0 | 57-345
 public/apps/configuration/utils                     |   20.39 |    41.18 |   14.29 |   19.79 |
  action-groups-utils.tsx                            |       0 |        0 |       0 |       0 | 31-98
  array-state-utils.tsx                              |       0 |        0 |       0 |       0 | 20-120
  audit-logging-utils.tsx                            |       0 |      100 |       0 |       0 | 21
  combo-box-utils.tsx                                |       0 |      100 |       0 |       0 | 23-64
  context-menu.tsx                                   |       0 |      100 |       0 |       0 | 32-68
  delete-confirm-modal-utils.tsx                     |       0 |        0 |       0 |       0 | 30-60
  display-utils.tsx                                  |       0 |        0 |       0 |       0 | 34-121
  form-row.tsx                                       |       0 |        0 |       0 |       0 | 31
  index-permission-utils.tsx                         |       0 |        0 |       0 |       0 | 29-35
  internal-user-detail-utils.tsx                     |       0 |      100 |       0 |       0 | 21-29
  internal-user-list-utils.tsx                       |       0 |        0 |       0 |       0 | 26-49
  loading-spinner-utils.tsx                          |       0 |        0 |       0 |       0 | 19-28
  panel-with-header.tsx                              |       0 |        0 |       0 |       0 | 29
  password-edit-panel.tsx                            |       0 |      100 |       0 |       0 | 25-44
  role-detail-utils.tsx                              |       0 |      100 |       0 |       0 | 21-25
  role-list-utils.tsx                                |      50 |      100 |   57.14 |   42.86 | 90-102
  role-mapping-utils.tsx                             |       0 |        0 |       0 |       0 | 32-59
  storage-utils.tsx                                  |       0 |        0 |       0 |       0 | 24-44
  tenant-utils.tsx                                   |   84.44 |      100 |   64.71 |   82.93 | 50-54,77-97
  toast-utils.tsx                                    |       0 |      100 |       0 |       0 | 20-44
  url-builder.tsx                                    |       0 |        0 |       0 |       0 | 36-53
 public/apps/login                                   |       0 |        0 |       0 |       0 |
  login-app.tsx                                      |       0 |      100 |       0 |       0 | 29-30
  login-page.tsx                                     |       0 |        0 |       0 |       0 | 41-125
 public/services                                     |       0 |        0 |       0 |       0 |
  chrome_wrapper.ts                                  |       0 |        0 |       0 |       0 | 19-21
 public/utils                                        |       0 |      100 |       0 |       0 |
  auth-info-utils.tsx                                |       0 |      100 |       0 |       0 | 21
 server                                              |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 | 20-208
  plugin.ts                                          |       0 |        0 |       0 |       0 | 76-160
  types.ts                                           |       0 |        0 |       0 |       0 |
 server/auth                                         |     100 |      100 |     100 |     100 |
  auth_handler_factory.ts                            |     100 |      100 |     100 |     100 |
  user.ts                                            |       0 |        0 |       0 |       0 |
 server/auth/types                                   |       0 |        0 |       0 |       0 |
  authentication_type.ts                             |       0 |        0 |       0 |       0 | 54-208
  index.ts                                           |       0 |        0 |       0 |       0 |
 server/auth/types/basic                             |       0 |        0 |       0 |       0 |
  basic_auth.ts                                      |       0 |        0 |       0 |       0 | 35-134
  routes.ts                                          |       0 |        0 |       0 |       0 | 42-205
 server/auth/types/jwt                               |       0 |        0 |       0 |       0 |
  jwt_auth.ts                                        |       0 |        0 |       0 |       0 | 33-129
 server/auth/types/openid                            |       0 |        0 |       0 |       0 |
  helper.ts                                          |       0 |        0 |       0 |       0 | 22-65
  openid_auth.ts                                     |       0 |        0 |       0 |       0 | 49-209
  routes.ts                                          |       0 |        0 |       0 |       0 | 33-203
 server/auth/types/proxy                             |       0 |        0 |       0 |       0 |
  proxy_auth.ts                                      |       0 |        0 |       0 |       0 | 35-151
  routes.ts                                          |       0 |        0 |       0 |       0 | 33-77
 server/auth/types/saml                              |       0 |        0 |       0 |       0 |
  routes.ts                                          |       0 |        0 |       0 |       0 | 34-205
  saml_auth.ts                                       |       0 |        0 |       0 |       0 | 35-113
 server/backend                                      |       0 |        0 |       0 |       0 |
  opendistro_security_client.ts                      |       0 |        0 |       0 |       0 | 23-201
  opendistro_security_configuration_plugin.ts        |       0 |        0 |       0 |       0 | 18-216
  opendistro_security_plugin.ts                      |       0 |        0 |       0 |       0 | 18-66
 server/errors                                       |       0 |      100 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 |
  no_available_tenant_error.ts                       |       0 |      100 |       0 |       0 | 18
  unauthenticated_error.ts                           |       0 |      100 |       0 |       0 | 18
 server/multitenancy                                 |       0 |        0 |       0 |       0 |
  routes.ts                                          |       0 |        0 |       0 |       0 | 26-129
  tenant_index.ts                                    |       0 |      100 |       0 |       0 | 40-126
  tenant_resolver.ts                                 |       0 |        0 |       0 |       0 | 21-163
 server/routes                                       |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 | 27-828
 server/session                                      |       0 |        0 |       0 |       0 |
  security_cookie.ts                                 |       0 |        0 |       0 |       0 | 45-69
 server/utils                                        |       0 |      100 |       0 |       0 |
  next_url.ts                                        |       0 |      100 |       0 |       0 | 22-25
-----------------------------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 3 failed, 3 passed, 6 total
Tests:       33 passed, 33 total
Snapshots:   0 total
Time:        25.286s
Ran all test suites.

**After**:
% yarn test:jest --coverage
yarn run v1.22.4
$ NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js --coverage
 PASS  public/apps/configuration/utils/role-list-utils.test.tsx (6.371s)
 PASS  public/apps/configuration/utils/tenant-utils.test.tsx (6.617s)
 PASS  server/auth/auth_handler_factory.test.ts
 PASS  public/apps/configuration/panels/role-list.test.tsx (11.474s)
 FAIL  test/jest_integration/basic_auth.test.ts

-----------------------------------------------------|---------|----------|---------|---------|------------------------
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|------------------------
All files                                            |    5.78 |     7.77 |    4.02 |    5.66 |
 build_tools                                         |       0 |        0 |       0 |       0 |
  build_plugin.js                                    |       0 |        0 |       0 |       0 | 16-153
 common                                              |     100 |      100 |     100 |     100 |
  index.ts                                           |     100 |      100 |     100 |     100 |
 public                                              |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |      100 |       0 |       0 | 24
  plugin.ts                                          |       0 |        0 |       0 |       0 | 34-101
  types.ts                                           |       0 |        0 |       0 |       0 |
 public/apps                                         |       0 |      100 |     100 |       0 |
  apps-constants.tsx                                 |       0 |      100 |     100 |       0 | 18-21
  types.ts                                           |       0 |        0 |       0 |       0 |
 public/apps/account                                 |       0 |        0 |       0 |       0 |
  account-app.tsx                                    |       0 |        0 |       0 |       0 | 24-40
  account-nav-button.tsx                             |       0 |        0 |       0 |       0 | 44-132
  constants.tsx                                      |       0 |      100 |     100 |       0 | 19
  password-reset-panel.tsx                           |       0 |      100 |       0 |       0 | 41-138
  role-info-panel.tsx                                |       0 |        0 |       0 |       0 | 29-73
  tenant-selection-page.tsx                          |       0 |        0 |       0 |       0 | 24-51
  tenant-switch-panel.tsx                            |       0 |        0 |       0 |       0 | 49-248
  types.ts                                           |       0 |        0 |       0 |       0 |
  utils.tsx                                          |       0 |        0 |       0 |       0 | 22-39
 public/apps/configuration                           |   25.76 |        0 |       0 |   26.56 |
  app-router.tsx                                     |       0 |        0 |       0 |       0 | 42-235
  configuration-app.tsx                              |       0 |      100 |       0 |       0 | 30-32
  constants.tsx                                      |     100 |      100 |     100 |     100 |
  cross-page-toast.tsx                               |       0 |        0 |       0 |       0 | 24-34
  types.ts                                           |       0 |        0 |       0 |       0 |
  ui-constants.tsx                                   |     100 |      100 |     100 |     100 |
 public/apps/configuration/panels                    |   24.74 |    18.18 |    7.89 |   25.81 |
  expression-modal.tsx                               |       0 |        0 |       0 |       0 | 28-54
  get-started.tsx                                    |       0 |      100 |       0 |       0 | 38-210
  nav-panel.tsx                                      |       0 |      100 |       0 |       0 | 21-36
  role-list.tsx                                      |   64.86 |       50 |      30 |   66.67 | 55,119-130,143-167,177
  user-list.tsx                                      |       0 |        0 |       0 |       0 | 50-227
 public/apps/configuration/panels/audit-logging      |       0 |        0 |       0 |       0 |
  audit-logging-edit-settings.tsx                    |       0 |        0 |       0 |       0 | 45-240
  audit-logging.tsx                                  |       0 |        0 |       0 |       0 | 53-225
  code-editor.tsx                                    |       0 |        0 |       0 |       0 | 27-45
  constants.tsx                                      |       0 |      100 |     100 |       0 | 16-339
  edit-setting-group.tsx                             |       0 |        0 |       0 |       0 | 34-152
  types.tsx                                          |       0 |        0 |       0 |       0 |
  view-setting-group.tsx                             |       0 |        0 |       0 |       0 | 32-62
 public/apps/configuration/panels/auth-view          |       0 |        0 |       0 |       0 |
  auth-view.tsx                                      |       0 |        0 |       0 |       0 | 25-82
  authentication-sequence-panel.tsx                  |       0 |        0 |       0 |       0 | 23-98
  authorization-panel.tsx                            |       0 |        0 |       0 |       0 | 23-81
 public/apps/configuration/panels/internal-user-edit |       0 |        0 |       0 |       0 |
  attribute-panel.tsx                                |       0 |        0 |       0 |       0 | 37-125
  internal-user-edit.tsx                             |       0 |        0 |       0 |       0 | 50-182
  types.tsx                                          |       0 |        0 |       0 |       0 |
 public/apps/configuration/panels/permission-list    |       0 |        0 |       0 |       0 |
  edit-modal.tsx                                     |       0 |        0 |       0 |       0 | 43-97
  permission-list.tsx                                |       0 |        0 |       0 |       0 | 64-322
 public/apps/configuration/panels/permission-tree    |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 |
  permission-tree.tsx                                |       0 |        0 |       0 |       0 | 23-52
 public/apps/configuration/panels/role-edit          |       0 |        0 |       0 |       0 |
  cluster-permission-panel.tsx                       |       0 |      100 |       0 |       0 | 31-32
  constant.tsx                                       |       0 |      100 |     100 |       0 | 16
  index-permission-panel.tsx                         |       0 |        0 |       0 |       0 | 50-326
  role-edit.tsx                                      |       0 |        0 |       0 |       0 | 64-252
  tenant-panel.tsx                                   |       0 |        0 |       0 |       0 | 39-147
  types.tsx                                          |       0 |        0 |       0 |       0 |
 public/apps/configuration/panels/role-mapping       |       0 |        0 |       0 |       0 |
  RoleEditMappedUser.tsx                             |       0 |        0 |       0 |       0 | 51-165
  external-identities-panel.tsx                      |       0 |        0 |       0 |       0 | 38-106
  internal-users-panel.tsx                           |       0 |      100 |       0 |       0 | 30-31
  types.tsx                                          |       0 |        0 |       0 |       0 |
 public/apps/configuration/panels/role-view          |       0 |        0 |       0 |       0 |
  cluster-permission-panel.tsx                       |       0 |        0 |       0 |       0 | 34-52
  index-permission-panel.tsx                         |       0 |        0 |       0 |       0 | 50-176
  role-view.tsx                                      |       0 |        0 |       0 |       0 | 79-381
  tenants-panel.tsx                                  |       0 |        0 |       0 |       0 | 59-186
 public/apps/configuration/panels/tenant-list        |       0 |        0 |       0 |       0 |
  edit-modal.tsx                                     |       0 |        0 |       0 |       0 | 42-101
  tenant-list.tsx                                    |       0 |        0 |       0 |       0 | 57-345
 public/apps/configuration/utils                     |   28.64 |    47.06 |    18.1 |   28.88 |
  action-groups-utils.tsx                            |       0 |        0 |       0 |       0 | 31-98
  array-state-utils.tsx                              |       0 |        0 |       0 |       0 | 20-120
  audit-logging-utils.tsx                            |       0 |      100 |       0 |       0 | 21
  combo-box-utils.tsx                                |       0 |      100 |       0 |       0 | 23-64
  context-menu.tsx                                   |   77.78 |      100 |      50 |    87.5 | 40
  delete-confirm-modal-utils.tsx                     |   54.55 |       25 |      25 |   66.67 | 35-36,41
  display-utils.tsx                                  |    5.88 |        0 |       0 |    5.88 | 34-105,109-121
  form-row.tsx                                       |       0 |        0 |       0 |       0 | 31
  index-permission-utils.tsx                         |       0 |        0 |       0 |       0 | 29-35
  internal-user-detail-utils.tsx                     |       0 |      100 |       0 |       0 | 21-29
  internal-user-list-utils.tsx                       |       0 |        0 |       0 |       0 | 26-49
  loading-spinner-utils.tsx                          |     100 |      100 |     100 |     100 |
  panel-with-header.tsx                              |       0 |        0 |       0 |       0 | 29
  password-edit-panel.tsx                            |       0 |      100 |       0 |       0 | 25-44
  role-detail-utils.tsx                              |       0 |      100 |       0 |       0 | 21-25
  role-list-utils.tsx                                |      50 |      100 |   57.14 |   42.86 | 90-102
  role-mapping-utils.tsx                             |       0 |        0 |       0 |       0 | 32-59
  storage-utils.tsx                                  |       0 |        0 |       0 |       0 | 24-44
  tenant-utils.tsx                                   |   84.44 |      100 |   64.71 |   82.93 | 50-54,77-97
  toast-utils.tsx                                    |       0 |      100 |       0 |       0 | 20-44
  url-builder.tsx                                    |       0 |        0 |       0 |       0 | 36-53
 public/apps/login                                   |       0 |        0 |       0 |       0 |
  login-app.tsx                                      |       0 |      100 |       0 |       0 | 29-30
  login-page.tsx                                     |       0 |        0 |       0 |       0 | 41-125
 public/services                                     |       0 |        0 |       0 |       0 |
  chrome_wrapper.ts                                  |       0 |        0 |       0 |       0 | 19-21
 public/utils                                        |       0 |      100 |       0 |       0 |
  auth-info-utils.tsx                                |       0 |      100 |       0 |       0 | 21
 server                                              |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 | 20-208
  plugin.ts                                          |       0 |        0 |       0 |       0 | 76-160
  types.ts                                           |       0 |        0 |       0 |       0 |
 server/auth                                         |     100 |      100 |     100 |     100 |
  auth_handler_factory.ts                            |     100 |      100 |     100 |     100 |
  user.ts                                            |       0 |        0 |       0 |       0 |
 server/auth/types                                   |       0 |        0 |       0 |       0 |
  authentication_type.ts                             |       0 |        0 |       0 |       0 | 54-208
  index.ts                                           |       0 |        0 |       0 |       0 |
 server/auth/types/basic                             |       0 |        0 |       0 |       0 |
  basic_auth.ts                                      |       0 |        0 |       0 |       0 | 35-134
  routes.ts                                          |       0 |        0 |       0 |       0 | 42-205
 server/auth/types/jwt                               |       0 |        0 |       0 |       0 |
  jwt_auth.ts                                        |       0 |        0 |       0 |       0 | 33-129
 server/auth/types/openid                            |       0 |        0 |       0 |       0 |
  helper.ts                                          |       0 |        0 |       0 |       0 | 22-65
  openid_auth.ts                                     |       0 |        0 |       0 |       0 | 49-209
  routes.ts                                          |       0 |        0 |       0 |       0 | 33-203
 server/auth/types/proxy                             |       0 |        0 |       0 |       0 |
  proxy_auth.ts                                      |       0 |        0 |       0 |       0 | 35-151
  routes.ts                                          |       0 |        0 |       0 |       0 | 33-77
 server/auth/types/saml                              |       0 |        0 |       0 |       0 |
  routes.ts                                          |       0 |        0 |       0 |       0 | 34-205
  saml_auth.ts                                       |       0 |        0 |       0 |       0 | 35-113
 server/backend                                      |       0 |        0 |       0 |       0 |
  opendistro_security_client.ts                      |       0 |        0 |       0 |       0 | 23-201
  opendistro_security_configuration_plugin.ts        |       0 |        0 |       0 |       0 | 18-216
  opendistro_security_plugin.ts                      |       0 |        0 |       0 |       0 | 18-66
 server/errors                                       |       0 |      100 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 |
  no_available_tenant_error.ts                       |       0 |      100 |       0 |       0 | 18
  unauthenticated_error.ts                           |       0 |      100 |       0 |       0 | 18
 server/multitenancy                                 |       0 |        0 |       0 |       0 |
  routes.ts                                          |       0 |        0 |       0 |       0 | 26-129
  tenant_index.ts                                    |       0 |      100 |       0 |       0 | 40-126
  tenant_resolver.ts                                 |       0 |        0 |       0 |       0 | 21-163
 server/routes                                       |       0 |        0 |       0 |       0 |
  index.ts                                           |       0 |        0 |       0 |       0 | 27-828
 server/session                                      |       0 |        0 |       0 |       0 |
  security_cookie.ts                                 |       0 |        0 |       0 |       0 | 45-69
 server/utils                                        |       0 |      100 |       0 |       0 |
  next_url.ts                                        |       0 |      100 |       0 |       0 | 22-25
-----------------------------------------------------|---------|----------|---------|---------|------------------------

Test Suites: 3 failed, 4 passed, 7 total
Tests:       36 passed, 36 total
Snapshots:   0 total
Time:        26.811s
Ran all test suites.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
