### PR TITLE
Add unit test for role edit

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,1 +1,16 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
 module.exports = 'test-file-stub';

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,1 +1,16 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
 module.exports = {};

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.test.tsx
@@ -1,0 +1,42 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { EuiComboBox } from '@elastic/eui';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { ComboBoxOptions } from '../../types';
+import { ClusterPermissionPanel } from './cluster-permission-panel';
+
+describe('Role edit - cluster permission panel', () => {
+  it('render data', () => {
+    const samplePermission1 = 'permission1';
+    const samplePermission2 = 'permission2';
+    const state: ComboBoxOptions = [{ label: samplePermission1 }];
+    const optionUniverse: ComboBoxOptions = [
+      { label: samplePermission1 },
+      { label: samplePermission2 },
+    ];
+    const setState = jest.fn();
+
+    const component = shallow(
+      <ClusterPermissionPanel state={state} optionUniverse={optionUniverse} setState={setState} />
+    );
+
+    const comboBox = component.find(EuiComboBox).first();
+    expect(comboBox.prop('selectedOptions')).toBe(state);
+    expect(comboBox.prop('options')).toBe(optionUniverse);
+    expect(comboBox.prop('onChange')).toBe(setState);
+  });
+});

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -13,7 +13,6 @@
  *   permissions and limitations under the License.
  */
 
-import './_index.scss';
 import React, { Dispatch, SetStateAction } from 'react';
 import { EuiForm, EuiFlexGroup, EuiFlexItem, EuiComboBox } from '@elastic/eui';
 import { ComboBoxOptions, ResourceType, Action } from '../../types';

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -16,7 +16,7 @@
 import './_index.scss';
 import React, { Dispatch, SetStateAction } from 'react';
 import { EuiForm, EuiFlexGroup, EuiFlexItem, EuiComboBox } from '@elastic/eui';
-import { ComboBoxOptions, ResourceType, Action } from '../../types';
+import { ComboBoxOptions, ResourceType } from '../../types';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { FormRow } from '../../utils/form-row';
 import { LIMIT_WIDTH_INPUT_CLASS } from './constant';

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -13,6 +13,7 @@
  *   permissions and limitations under the License.
  */
 
+import './_index.scss';
 import React, { Dispatch, SetStateAction } from 'react';
 import { EuiForm, EuiFlexGroup, EuiFlexItem, EuiComboBox } from '@elastic/eui';
 import { ComboBoxOptions, ResourceType, Action } from '../../types';
@@ -53,7 +54,7 @@ export function ClusterPermissionPanel(props: {
             {/* TODO: 'Browse and select' button with a pop-up modal for selection */}
             <EuiFlexItem grow={false}>
               <ExternalLinkButton
-                href={buildHashUrl(ResourceType.permissions, Action.create)}
+                href={buildHashUrl(ResourceType.permissions)}
                 text="Create new permission group"
               />
             </EuiFlexItem>

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { shallow, CommonWrapper, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import { RoleIndexPermission, ComboBoxOptions, FieldLevelSecurityMethod } from '../../types';
 import { stringToComboBoxOption } from '../../utils/combo-box-utils';
@@ -28,7 +28,7 @@ import {
   AnonymizationRow,
 } from './index-permission-panel';
 import { RoleIndexPermissionStateClass } from './types';
-import { EuiComboBox, EuiSuperSelect, EuiButton, EuiTextArea, EuiAccordion } from '@elastic/eui';
+import { EuiComboBox, EuiSuperSelect, EuiButton, EuiTextArea } from '@elastic/eui';
 
 jest.mock('../../utils/array-state-utils');
 // eslint-disable-next-line

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.test.tsx
@@ -1,0 +1,239 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { shallow, CommonWrapper, ShallowWrapper } from 'enzyme';
+import React from 'react';
+import { RoleIndexPermission, ComboBoxOptions, FieldLevelSecurityMethod } from '../../types';
+import { stringToComboBoxOption } from '../../utils/combo-box-utils';
+import {
+  buildIndexPermissionState,
+  IndexPermissionPanel,
+  unbuildIndexPermissionState,
+  IndexPatternRow,
+  IndexPermissionRow,
+  DocLevelSecurityRow,
+  FieldLevelSecurityRow,
+  AnonymizationRow,
+} from './index-permission-panel';
+import { RoleIndexPermissionStateClass } from './types';
+import { EuiComboBox, EuiSuperSelect, EuiButton, EuiTextArea, EuiAccordion } from '@elastic/eui';
+
+jest.mock('../../utils/array-state-utils');
+// eslint-disable-next-line
+const arrayStateUtils = require('../../utils/array-state-utils');
+
+describe('Role edit - index permission panel', () => {
+  const indexPattern1 = 'index1';
+  const indexPattern2 = 'index*';
+  const allowedAction1 = 'readall';
+  const allowedAction2 = 'crud';
+  const field1 = 'field1';
+  const field2 = 'field2';
+  const dls = 'dummy';
+
+  const sampleIndexPatterns = [indexPattern1, indexPattern2];
+  const sampleIndexPatternsOptions = sampleIndexPatterns.map(stringToComboBoxOption);
+  const sampleActionGroup = [allowedAction1];
+  const sampleActionGroupOptions = sampleActionGroup.map(stringToComboBoxOption);
+  const sampleOptionUniverse = [allowedAction1, allowedAction2].map(stringToComboBoxOption);
+  const setState = jest.fn();
+
+  it('buildIndexPermissionState', () => {
+    const input: RoleIndexPermission[] = [
+      {
+        index_patterns: [indexPattern1, indexPattern2],
+        allowed_actions: sampleActionGroup,
+        dls,
+        fls: ['~' + field1, field2],
+        masked_fields: [field1, field2],
+      },
+    ];
+
+    const result = buildIndexPermissionState(input);
+
+    expect(result).toEqual([
+      {
+        indexPatterns: sampleIndexPatternsOptions,
+        allowedActions: sampleActionGroupOptions,
+        docLevelSecurity: dls,
+        fieldLevelSecurityMethod: 'exclude',
+        fieldLevelSecurityFields: [field1, field2].map(stringToComboBoxOption),
+        maskedFields: [field1, field2].map(stringToComboBoxOption),
+      },
+    ]);
+  });
+
+  it('unbuildIndexPermissionState', () => {
+    const input: RoleIndexPermissionStateClass[] = [
+      {
+        indexPatterns: sampleIndexPatternsOptions,
+        allowedActions: [allowedAction1].map(stringToComboBoxOption),
+        docLevelSecurity: dls,
+        fieldLevelSecurityMethod: 'exclude',
+        fieldLevelSecurityFields: [field1].map(stringToComboBoxOption),
+        maskedFields: [field1, field2].map(stringToComboBoxOption),
+      },
+      {
+        indexPatterns: sampleIndexPatternsOptions,
+        allowedActions: [allowedAction1].map(stringToComboBoxOption),
+        docLevelSecurity: dls,
+        fieldLevelSecurityMethod: 'include',
+        fieldLevelSecurityFields: [field2].map(stringToComboBoxOption),
+        maskedFields: [field1, field2].map(stringToComboBoxOption),
+      },
+    ];
+
+    const result = unbuildIndexPermissionState(input);
+
+    expect(result).toEqual([
+      {
+        index_patterns: sampleIndexPatterns,
+        allowed_actions: sampleActionGroup,
+        dls,
+        fls: ['~' + field1],
+        masked_fields: [field1, field2],
+      },
+      {
+        index_patterns: sampleIndexPatterns,
+        allowed_actions: sampleActionGroup,
+        dls,
+        fls: [field2],
+        masked_fields: [field1, field2],
+      },
+    ]);
+  });
+
+  it('IndexPatternRow', () => {
+    const value: ComboBoxOptions = sampleIndexPatternsOptions;
+    const onChangeHandler: (s: ComboBoxOptions) => void = jest.fn();
+    const onCreateHandler: (s: string) => void = jest.fn();
+
+    const component = shallow(<IndexPatternRow {...{ value, onChangeHandler, onCreateHandler }} />);
+
+    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(value);
+  });
+
+  it('IndexPermissionRow', () => {
+    const value: ComboBoxOptions = sampleActionGroupOptions;
+    const permisionOptionsSet = sampleOptionUniverse;
+    const onChangeHandler: (s: ComboBoxOptions) => void = jest.fn();
+
+    const component = shallow(
+      <IndexPermissionRow {...{ value, onChangeHandler, permisionOptionsSet }} />
+    );
+
+    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(value);
+  });
+
+  it('DocLevelSecurityRow', () => {
+    const value: string = 'dls';
+    const onChangeHandler: (e: React.ChangeEvent<HTMLTextAreaElement>) => void = jest.fn();
+
+    const component = shallow(<DocLevelSecurityRow {...{ value, onChangeHandler }} />);
+
+    expect(component.find(EuiTextArea).first().prop('value')).toBe(value);
+  });
+
+  it('FieldLevelSecurityRow', () => {
+    const method: FieldLevelSecurityMethod = 'exclude';
+    const fields: ComboBoxOptions = [field1, field2].map(stringToComboBoxOption);
+    const onMethodChangeHandler: (s: string) => void = jest.fn();
+    const onFieldChangeHandler: (s: ComboBoxOptions) => void = jest.fn();
+    const onFieldCreateHandler: (s: string) => void = jest.fn();
+
+    const component = shallow(
+      <FieldLevelSecurityRow
+        {...{ method, fields, onMethodChangeHandler, onFieldChangeHandler, onFieldCreateHandler }}
+      />
+    );
+
+    expect(component.find(EuiSuperSelect).first().prop('valueOfSelected')).toBe(method);
+    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(fields);
+  });
+
+  it('AnonymizationRow', () => {
+    const value: ComboBoxOptions = [field1, field2].map(stringToComboBoxOption);
+    const onChangeHandler: (s: ComboBoxOptions) => void = jest.fn();
+    const onCreateHandler: (s: string) => void = jest.fn();
+
+    const component = shallow(
+      <AnonymizationRow {...{ value, onChangeHandler, onCreateHandler }} />
+    );
+
+    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(value);
+  });
+
+  describe('IndexPermissionPanel', () => {
+    it('should add an empty row if empty data', () => {
+      const state: RoleIndexPermissionStateClass[] = [];
+      const optionUniverse: ComboBoxOptions = [];
+
+      shallow(<IndexPermissionPanel {...{ state, optionUniverse, setState }} />);
+
+      expect(setState).toHaveBeenCalledTimes(1);
+    });
+
+    it('render data', () => {
+      const state: RoleIndexPermissionStateClass[] = [
+        {
+          indexPatterns: sampleIndexPatternsOptions,
+          allowedActions: sampleActionGroupOptions,
+          docLevelSecurity: dls,
+          fieldLevelSecurityMethod: 'exclude',
+          fieldLevelSecurityFields: [field1, field2].map(stringToComboBoxOption),
+          maskedFields: [field1, field2].map(stringToComboBoxOption),
+        },
+        {
+          indexPatterns: sampleIndexPatternsOptions,
+          allowedActions: sampleActionGroupOptions,
+          docLevelSecurity: dls,
+          fieldLevelSecurityMethod: 'include',
+          fieldLevelSecurityFields: [field2, field1].map(stringToComboBoxOption),
+          maskedFields: [field2, field1].map(stringToComboBoxOption),
+        },
+      ];
+      const optionUniverse = sampleOptionUniverse;
+
+      const result = shallow(<IndexPermissionPanel {...{ state, optionUniverse, setState }} />);
+
+      expect(result.find(IndexPatternRow).length).toBe(2);
+      expect(result.find(IndexPermissionRow).length).toBe(2);
+      expect(result.find(DocLevelSecurityRow).length).toBe(2);
+      expect(result.find(FieldLevelSecurityRow).length).toBe(2);
+      expect(result.find(AnonymizationRow).length).toBe(2);
+    });
+
+    it('add row', () => {
+      const state: RoleIndexPermissionStateClass[] = [
+        {
+          indexPatterns: sampleIndexPatternsOptions,
+          allowedActions: sampleActionGroupOptions,
+          docLevelSecurity: dls,
+          fieldLevelSecurityMethod: 'exclude',
+          fieldLevelSecurityFields: [field1, field2].map(stringToComboBoxOption),
+          maskedFields: [field1, field2].map(stringToComboBoxOption),
+        },
+      ];
+      const optionUniverse = [allowedAction1, allowedAction2].map(stringToComboBoxOption);
+
+      const component = shallow(<IndexPermissionPanel {...{ state, optionUniverse, setState }} />);
+      component.find(EuiButton).last().simulate('click');
+
+      expect(arrayStateUtils.appendElementToArray).toHaveBeenCalledTimes(1);
+    });
+
+    // TODO: Add unit test for remove row. Need to investigate how to simulate a click on a Accordion's extraAction
+  });
+});

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -13,7 +13,6 @@
  *   permissions and limitations under the License.
  */
 
-import './_index.scss';
 import {
   EuiAccordion,
   EuiButton,
@@ -112,7 +111,7 @@ const FIELD_LEVEL_SECURITY_PLACEHOLDER = `{
     }
 }`;
 
-function IndexPatternRow(props: {
+export function IndexPatternRow(props: {
   value: ComboBoxOptions;
   onChangeHandler: (s: ComboBoxOptions) => void;
   onCreateHandler: (s: string) => void;
@@ -130,7 +129,7 @@ function IndexPatternRow(props: {
   );
 }
 
-function IndexPermissionRow(props: {
+export function IndexPermissionRow(props: {
   value: ComboBoxOptions;
   permisionOptionsSet: ComboBoxOptions;
   onChangeHandler: (s: ComboBoxOptions) => void;
@@ -163,7 +162,8 @@ function IndexPermissionRow(props: {
     </FormRow>
   );
 }
-function DocLevelSecurityRow(props: {
+
+export function DocLevelSecurityRow(props: {
   value: string;
   onChangeHandler: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }) {
@@ -182,7 +182,8 @@ function DocLevelSecurityRow(props: {
     </FormRow>
   );
 }
-function FieldLevelSecurityRow(props: {
+
+export function FieldLevelSecurityRow(props: {
   method: FieldLevelSecurityMethod;
   fields: ComboBoxOptions;
   onMethodChangeHandler: (s: string) => void;
@@ -219,7 +220,8 @@ function FieldLevelSecurityRow(props: {
     </FormRow>
   );
 }
-function AnonymizationRow(props: {
+
+export function AnonymizationRow(props: {
   value: ComboBoxOptions;
   onChangeHandler: (s: ComboBoxOptions) => void;
   onCreateHandler: (s: string) => void;
@@ -240,6 +242,7 @@ function AnonymizationRow(props: {
     </FormRow>
   );
 }
+
 export function generateIndexPermissionPanels(
   indexPermissions: RoleIndexPermissionStateClass[],
   permisionOptionsSet: ComboBoxOptions,

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -13,6 +13,7 @@
  *   permissions and limitations under the License.
  */
 
+import './_index.scss';
 import {
   EuiAccordion,
   EuiButton,
@@ -154,7 +155,7 @@ export function IndexPermissionRow(props: {
         {/* TODO: 'Browse and select' button with a pop-up modal for selection */}
         <EuiFlexItem grow={false}>
           <ExternalLinkButton
-            href={buildHashUrl(ResourceType.permissions, Action.create)}
+            href={buildHashUrl(ResourceType.permissions)}
             text="Create new permission group"
           />
         </EuiFlexItem>

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -26,7 +26,7 @@ import {
 } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction } from 'react';
 import { isEmpty } from 'lodash';
-import { RoleIndexPermission, ResourceType, Action } from '../../types';
+import { RoleIndexPermission, ResourceType } from '../../types';
 import {
   appendElementToArray,
   removeElementFromArray,

--- a/public/apps/configuration/panels/role-edit/role-edit.test.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.test.tsx
@@ -1,0 +1,180 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { EuiButton, EuiFieldText } from '@elastic/eui';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { updateRole } from '../../utils/role-detail-utils';
+import { setCrossPageToast } from '../../utils/storage-utils';
+import { fetchTenantNameList } from '../../utils/tenant-utils';
+import { ClusterPermissionPanel } from './cluster-permission-panel';
+import { IndexPermissionPanel } from './index-permission-panel';
+import { getSuccessToastMessage, RoleEdit } from './role-edit';
+import { TenantPanel } from './tenant-panel';
+
+jest.mock('../../utils/role-detail-utils', () => ({
+  getRoleDetail: jest.fn().mockReturnValue({
+    cluster_permissions: [],
+    index_permissions: [],
+    tenant_permissions: [],
+    reserved: false,
+  }),
+  updateRole: jest.fn(),
+}));
+jest.mock('../../utils/action-groups-utils', () => ({
+  fetchActionGroups: jest.fn().mockReturnValue({}),
+}));
+jest.mock('../../utils/tenant-utils');
+jest.mock('../../utils/storage-utils');
+
+describe('Role edit', () => {
+  const sampleSourceRole = 'role';
+  const mockCoreStart = {
+    http: 1,
+  };
+
+  const useEffect = jest.spyOn(React, 'useEffect');
+  const useState = jest.spyOn(React, 'useState');
+  // useEffect.mockImplementationOnce((f) => f());
+
+  it('basic rendering', () => {
+    const action = 'create';
+    const buildBreadcrumbs = jest.fn();
+
+    const component = shallow(
+      <RoleEdit
+        action={action}
+        sourceRoleName={sampleSourceRole}
+        buildBreadcrumbs={buildBreadcrumbs}
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+
+    expect(buildBreadcrumbs).toBeCalledTimes(1);
+    expect(component.find(ClusterPermissionPanel).length).toBe(1);
+    expect(component.find(IndexPermissionPanel).length).toBe(1);
+    expect(component.find(TenantPanel).length).toBe(1);
+  });
+
+  it('pull role data for editing', () => {
+    useEffect.mockImplementationOnce((f) => f());
+    useEffect.mockImplementationOnce((f) => f());
+    useEffect.mockImplementationOnce((f) => f());
+    useState.mockImplementation((initialValue) => [initialValue, jest.fn()]);
+    const action = 'edit';
+    const buildBreadcrumbs = jest.fn();
+
+    const component = shallow(
+      <RoleEdit
+        action={action}
+        sourceRoleName={sampleSourceRole}
+        buildBreadcrumbs={buildBreadcrumbs}
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+
+    expect(fetchTenantNameList).toBeCalledTimes(1);
+  });
+
+  describe('getSuccessToastMessage', () => {
+    it('message for creation', () => {
+      const result = getSuccessToastMessage('create', 'role1');
+
+      // No explicit assertion on result since it might migration to i18n in the future.
+      expect(result).toBeTruthy();
+    });
+
+    it('message for editing', () => {
+      const result = getSuccessToastMessage('edit', 'role1');
+
+      // No explicit assertion on result since it might migration to i18n in the future.
+      expect(result).toBeTruthy();
+    });
+    it('message for unexpected action', () => {
+      const result = getSuccessToastMessage('foo', 'role1');
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  it('submit update', (done) => {
+    useEffect.mockImplementationOnce((f) => f());
+    useEffect.mockImplementationOnce((f) => f());
+    useEffect.mockImplementationOnce((f) => f());
+    useState.mockImplementation((initialValue) => [initialValue, jest.fn()]);
+    const action = 'edit';
+    const buildBreadcrumbs = jest.fn();
+
+    const component = shallow(
+      <RoleEdit
+        action={action}
+        sourceRoleName={sampleSourceRole}
+        buildBreadcrumbs={buildBreadcrumbs}
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+    // click update
+    component.find(EuiButton).last().simulate('click');
+
+    expect(updateRole).toBeCalledWith(mockCoreStart.http, '', {
+      cluster_permissions: [],
+      index_permissions: [],
+      tenant_permissions: [],
+    });
+
+    process.nextTick(() => {
+      expect(setCrossPageToast).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('change role name', () => {
+    useEffect.mockImplementationOnce((f) => f());
+    useEffect.mockImplementationOnce((f) => f());
+    useEffect.mockImplementationOnce((f) => f());
+    const setState = jest.fn();
+    useState.mockImplementation((initialValue) => [initialValue, setState]);
+    const action = 'edit';
+    const buildBreadcrumbs = jest.fn();
+    const updatedRoleName = 'admin';
+
+    const component = shallow(
+      <RoleEdit
+        action={action}
+        sourceRoleName={sampleSourceRole}
+        buildBreadcrumbs={buildBreadcrumbs}
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+    component
+      .find(EuiFieldText)
+      .first()
+      .simulate('change', { target: { value: updatedRoleName } });
+
+    expect(setState).toBeCalledWith(updatedRoleName);
+  });
+});

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -67,7 +67,7 @@ const TITLE_TEXT_DICT = {
   duplicate: 'Duplicate Role',
 };
 
-function getSuccessToastMessage(action: string, roleName: string): string {
+export function getSuccessToastMessage(action: string, roleName: string): string {
   switch (action) {
     case 'create':
     case 'duplicate':
@@ -80,7 +80,7 @@ function getSuccessToastMessage(action: string, roleName: string): string {
 }
 
 export function RoleEdit(props: RoleEditDeps) {
-  const [roleName, setRoleName] = useState('');
+  const [roleName, setRoleName] = React.useState('');
   const [roleClusterPermission, setRoleClusterPermission] = useState<ComboBoxOptions>([]);
   const [roleIndexPermission, setRoleIndexPermission] = useState<RoleIndexPermissionStateClass[]>(
     []
@@ -91,7 +91,7 @@ export function RoleEdit(props: RoleEditDeps) {
 
   const [toasts, addToast, removeToast] = useToastState();
 
-  useEffect(() => {
+  React.useEffect(() => {
     const action = props.action;
     if (action === 'edit' || action === 'duplicate') {
       const fetchData = async () => {
@@ -117,7 +117,7 @@ export function RoleEdit(props: RoleEditDeps) {
   }, [addToast, props.action, props.coreStart.http, props.sourceRoleName]);
 
   const [actionGroups, setActionGroups] = useState<string[]>([]);
-  useEffect(() => {
+  React.useEffect(() => {
     const fetchActionGroupNames = async () => {
       try {
         const actionGroupsObject = await fetchActionGroups(props.coreStart.http);
@@ -131,8 +131,8 @@ export function RoleEdit(props: RoleEditDeps) {
     fetchActionGroupNames();
   }, [addToast, props.coreStart.http]);
 
-  const [tenantNames, setTenantNames] = useState<string[]>([]);
-  useEffect(() => {
+  const [tenantNames, setTenantNames] = React.useState<string[]>([]);
+  React.useEffect(() => {
     const fetchTenantNames = async () => {
       try {
         setTenantNames(await fetchTenantNameList(props.coreStart.http));

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -26,7 +26,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { isEmpty } from 'lodash';
 import { BreadcrumbsPageDependencies } from '../../../types';
 import { CLUSTER_PERMISSIONS, INDEX_PERMISSIONS } from '../../constants';

--- a/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
@@ -26,6 +26,7 @@ import React from 'react';
 import { EuiComboBox, EuiButton, EuiSuperSelect } from '@elastic/eui';
 
 jest.mock('../../utils/array-state-utils');
+const arrayStateUtils = require('../../utils/array-state-utils');
 
 describe('Role edit - tenant panel', () => {
   const tenantName1 = 'tenant1';
@@ -74,14 +75,14 @@ describe('Role edit - tenant panel', () => {
     const setState = jest.fn();
 
     it('render an empty row if data is empty', () => {
-      shallow(
-        <TenantPanel state={[]} optionUniverse={optionUniverse} setState={setState} />
-      );
+      shallow(<TenantPanel state={[]} optionUniverse={optionUniverse} setState={setState} />);
 
-      expect(setState).toHaveBeenCalledWith([{
-        tenantPatterns: [],
-        permissionType: TenantPermissionType.Full,
-      }]);
+      expect(setState).toHaveBeenCalledWith([
+        {
+          tenantPatterns: [],
+          permissionType: TenantPermissionType.Full,
+        },
+      ]);
     });
 
     it('render data', () => {
@@ -117,7 +118,24 @@ describe('Role edit - tenant panel', () => {
 
       const addRowButton = component.find(EuiButton).last();
       addRowButton.simulate('click');
-      expect(setState).toHaveBeenCalled();
+      expect(arrayStateUtils.appendElementToArray).toHaveBeenCalled();
+    });
+
+    it('remove row', () => {
+      const state: RoleTenantPermissionStateClass[] = [
+        {
+          tenantPatterns: [{ label: tenantName1 }],
+          permissionType: TenantPermissionType.Full,
+        },
+      ];
+      
+      const component = shallow(
+        <TenantPanel state={state} optionUniverse={optionUniverse} setState={setState} />
+      );
+
+      const removeRowButton = component.find(EuiButton).first();
+      removeRowButton.simulate('click');
+      expect(arrayStateUtils.removeElementFromArray).toHaveBeenCalled();
     });
   });
 });

--- a/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { RoleTenantPermission, TenantPermissionType, ComboBoxOptions } from '../../types';
+import { RoleTenantPermission, TenantPermissionType } from '../../types';
 import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../../constants';
 import { RoleTenantPermissionStateClass } from './types';
 import {
@@ -26,7 +26,6 @@ import React from 'react';
 import { EuiComboBox, EuiButton, EuiSuperSelect } from '@elastic/eui';
 
 jest.mock('../../utils/array-state-utils');
-const arrayStateUtils = require('../../utils/array-state-utils');
 
 describe('Role edit - tenant panel', () => {
   const tenantName1 = 'tenant1';
@@ -67,30 +66,6 @@ describe('Role edit - tenant panel', () => {
     ];
 
     expect(result).toEqual(expected);
-  });
-
-  describe('TenantPanel', () => {
-    const tenantName2 = 'tenant2';
-    const state: RoleTenantPermissionStateClass[] = [
-      {
-        tenantPatterns: [{ label: tenantName1 }],
-        permissionType: TenantPermissionType.Full,
-      },
-      {
-        tenantPatterns: [{ label: tenantName2 }],
-        permissionType: TenantPermissionType.Read,
-      },
-    ];
-    const optionUniverse = [{ label: tenantName1 }, { label: tenantName2 }];
-    const setState = jest.fn();
-
-    const component = shallow(
-      <TenantPanel state={state} optionUniverse={optionUniverse} setState={setState} />
-    );
-
-    const comboBoxArray = component.find(EuiComboBox);
-    expect(comboBoxArray.length).toEqual(2);
-    expect(comboBoxArray.at(0).prop('selectedOptions')).toBe(state[0].tenantPatterns);
   });
 
   describe('TenantPanel', () => {

--- a/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
@@ -1,0 +1,148 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { RoleTenantPermission, TenantPermissionType, ComboBoxOptions } from '../../types';
+import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../../constants';
+import { RoleTenantPermissionStateClass } from './types';
+import {
+  buildTenantPermissionState,
+  unbuildTenantPermissionState,
+  TenantPanel,
+} from './tenant-panel';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { EuiComboBox, EuiButton, EuiSuperSelect } from '@elastic/eui';
+
+jest.mock('../../utils/array-state-utils');
+const arrayStateUtils = require('../../utils/array-state-utils');
+
+describe('Role edit - tenant panel', () => {
+  const tenantName1 = 'tenant1';
+  it('buildTenantPermissionState', () => {
+    const input: RoleTenantPermission[] = [
+      {
+        tenant_patterns: [tenantName1],
+        allowed_actions: [TENANT_READ_PERMISSION],
+      },
+    ];
+
+    const result = buildTenantPermissionState(input);
+
+    const expected: RoleTenantPermissionStateClass[] = [
+      {
+        tenantPatterns: [{ label: tenantName1 }],
+        permissionType: TenantPermissionType.Read,
+      },
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it('unbuildTenantPermissionState', () => {
+    const permissions: RoleTenantPermissionStateClass[] = [
+      {
+        tenantPatterns: [{ label: tenantName1 }],
+        permissionType: TenantPermissionType.Full,
+      },
+    ];
+
+    const result = unbuildTenantPermissionState(permissions);
+
+    const expected: RoleTenantPermission[] = [
+      {
+        tenant_patterns: [tenantName1],
+        allowed_actions: [TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION],
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  describe('TenantPanel', () => {
+    const tenantName2 = 'tenant2';
+    const state: RoleTenantPermissionStateClass[] = [
+      {
+        tenantPatterns: [{ label: tenantName1 }],
+        permissionType: TenantPermissionType.Full,
+      },
+      {
+        tenantPatterns: [{ label: tenantName2 }],
+        permissionType: TenantPermissionType.Read,
+      },
+    ];
+    const optionUniverse = [{ label: tenantName1 }, { label: tenantName2 }];
+    const setState = jest.fn();
+
+    const component = shallow(
+      <TenantPanel state={state} optionUniverse={optionUniverse} setState={setState} />
+    );
+
+    const comboBoxArray = component.find(EuiComboBox);
+    expect(comboBoxArray.length).toEqual(2);
+    expect(comboBoxArray.at(0).prop('selectedOptions')).toBe(state[0].tenantPatterns);
+  });
+
+  describe('TenantPanel', () => {
+    const tenantName2 = 'tenant2';
+    const optionUniverse = [{ label: tenantName1 }, { label: tenantName2 }];
+    const setState = jest.fn();
+
+    it('render an empty row if data is empty', () => {
+      shallow(
+        <TenantPanel state={[]} optionUniverse={optionUniverse} setState={setState} />
+      );
+
+      expect(setState).toHaveBeenCalledWith([{
+        tenantPatterns: [],
+        permissionType: TenantPermissionType.Full,
+      }]);
+    });
+
+    it('render data', () => {
+      const state: RoleTenantPermissionStateClass[] = [
+        {
+          tenantPatterns: [{ label: tenantName1 }],
+          permissionType: TenantPermissionType.Full,
+        },
+        {
+          tenantPatterns: [{ label: tenantName2 }],
+          permissionType: TenantPermissionType.Read,
+        },
+      ];
+
+      const component = shallow(
+        <TenantPanel state={state} optionUniverse={optionUniverse} setState={setState} />
+      );
+
+      const comboBoxArray = component.find(EuiComboBox);
+      expect(comboBoxArray.length).toEqual(2);
+      expect(comboBoxArray.at(0).prop('selectedOptions')).toBe(state[0].tenantPatterns);
+      expect(comboBoxArray.at(1).prop('selectedOptions')).toBe(state[1].tenantPatterns);
+
+      const superSelectArray = component.find(EuiSuperSelect);
+      expect(superSelectArray.at(0).prop('valueOfSelected')).toBe(state[0].permissionType);
+      expect(superSelectArray.at(1).prop('valueOfSelected')).toBe(state[1].permissionType);
+    });
+
+    it('add row', () => {
+      const component = shallow(
+        <TenantPanel state={[]} optionUniverse={optionUniverse} setState={setState} />
+      );
+
+      const addRowButton = component.find(EuiButton).last();
+      addRowButton.simulate('click');
+      expect(setState).toHaveBeenCalled();
+    });
+  });
+});

--- a/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
@@ -119,7 +119,7 @@ describe('Role edit - tenant panel', () => {
 
       const addRowButton = component.find(EuiButton).last();
       addRowButton.simulate('click');
-      expect(arrayStateUtils.appendElementToArray).toHaveBeenCalled();
+      expect(arrayStateUtils.appendElementToArray).toHaveBeenCalledTimes(1);
     });
 
     it('remove row', () => {
@@ -136,7 +136,7 @@ describe('Role edit - tenant panel', () => {
 
       const removeRowButton = component.find(EuiButton).first();
       removeRowButton.simulate('click');
-      expect(arrayStateUtils.removeElementFromArray).toHaveBeenCalled();
+      expect(arrayStateUtils.removeElementFromArray).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.test.tsx
@@ -26,6 +26,7 @@ import React from 'react';
 import { EuiComboBox, EuiButton, EuiSuperSelect } from '@elastic/eui';
 
 jest.mock('../../utils/array-state-utils');
+// eslint-disable-next-line
 const arrayStateUtils = require('../../utils/array-state-utils');
 
 describe('Role edit - tenant panel', () => {
@@ -128,7 +129,7 @@ describe('Role edit - tenant panel', () => {
           permissionType: TenantPermissionType.Full,
         },
       ];
-      
+
       const component = shallow(
         <TenantPanel state={state} optionUniverse={optionUniverse} setState={setState} />
       );

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -45,22 +45,20 @@ export function buildTenantPermissionState(
   });
 }
 
+const TENANT_PERMISSION_TYPE_DICT: Record<string, string[]> = {
+  [TenantPermissionType.Full]: [TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION],
+  [TenantPermissionType.Read]: [TENANT_READ_PERMISSION],
+  [TenantPermissionType.Write]: [TENANT_WRITE_PERMISSION],
+  [TenantPermissionType.None]: [],
+} 
+
 export function unbuildTenantPermissionState(
   permissions: RoleTenantPermissionStateClass[]
 ): RoleTenantPermission[] {
   return permissions.map((permission) => {
-    const permissionType = permission.permissionType;
-    let allowedActions: string[] = [];
-    if (permissionType === TenantPermissionType.Full) {
-      allowedActions = [TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION];
-    } else if (permissionType === TenantPermissionType.Read) {
-      allowedActions = [TENANT_READ_PERMISSION];
-    } else if (permissionType === TenantPermissionType.Write) {
-      allowedActions = [TENANT_WRITE_PERMISSION];
-    }
     return {
       tenant_patterns: permission.tenantPatterns.map(comboBoxOptionToString),
-      allowed_actions: allowedActions,
+      allowed_actions: TENANT_PERMISSION_TYPE_DICT[permission.permissionType],
     };
   });
 }

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -50,7 +50,7 @@ const TENANT_PERMISSION_TYPE_DICT: Record<string, string[]> = {
   [TenantPermissionType.Read]: [TENANT_READ_PERMISSION],
   [TenantPermissionType.Write]: [TENANT_WRITE_PERMISSION],
   [TenantPermissionType.None]: [],
-} 
+};
 
 export function unbuildTenantPermissionState(
   permissions: RoleTenantPermissionStateClass[]

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -20,8 +20,8 @@ module.exports = {
   roots: ['<rootDir>'],
   coverageDirectory: './coverage',
   moduleNameMapper: {
-    "\\.(css|less|sass|scss)$": "<rootDir>/__mocks__/styleMock.js",
-    "\\.(gif|ttf|eot|svg)$": "<rootDir>/__mocks__/fileMock.js"
+    '\\.(css|less|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
+    '\\.(gif|ttf|eot|svg)$': '<rootDir>/__mocks__/fileMock.js',
   },
   modulePathIgnorePatterns: ['<rootDir>/target/'],
   coverageReporters: ['lcov', 'text', 'cobertura'],

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -20,8 +20,8 @@ module.exports = {
   roots: ['<rootDir>'],
   coverageDirectory: './coverage',
   moduleNameMapper: {
-    // "\\.(css|less|scss)$": "<rootDir>/test/mocks/styleMock.ts",
-    // "^ui/(.*)": "<rootDir>/../../src/legacy/ui/public/$1/",
+    "\\.(css|less|sass|scss)$": "<rootDir>/__mocks__/styleMock.js",
+    "\\.(gif|ttf|eot|svg)$": "<rootDir>/__mocks__/fileMock.js"
   },
   modulePathIgnorePatterns: ['<rootDir>/target/'],
   coverageReporters: ['lcov', 'text', 'cobertura'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add unit test for role edit - tenant panel.

Coverage:
**Before**
% yarn test:jest --coverage
yarn run v1.22.4
$ NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js --coverage

File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|------------------------
All files                                            |    6.25 |     7.77 |    5.19 |    6.04 |
 public/apps/configuration/panels/role-edit          |       0 |        0 |       0 |       0 |
  tenant-panel.tsx                                   |       0 |        0 |       0 |       0 | 39-147

Test Suites: 3 failed, 5 passed, 8 total
Tests:       41 passed, 41 total
Snapshots:   0 total
Time:        27.877s

**After**
% yarn test:jest --coverage
yarn run v1.22.4
$ NODE_PATH=../../node_modules ../../node_modules/.bin/jest --config ./test/jest.config.js --coverage

File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|---------------------------------------------
All files                                            |    11.6 |    10.36 |    13.4 |   11.32 |
 public/apps/configuration/panels/role-edit          |   87.61 |       80 |   89.58 |   87.27 |
  cluster-permission-panel.tsx                       |     100 |      100 |     100 |     100 |
  constant.tsx                                       |     100 |      100 |     100 |     100 |
  index-permission-panel.tsx                         |   93.75 |    83.33 |   90.91 |    93.1 | 270-288
  role-edit.tsx                                      |   79.31 |       75 |   76.92 |   79.31 | 107-111,126-127,140-141,152,155,172-173,252
  tenant-panel.tsx                                   |     100 |      100 |     100 |     100 |
  types.tsx                                          |       0 |        0 |       0 |       0 |


Test Suites: 3 failed, 9 passed, 12 total
Tests:       65 passed, 65 total
Snapshots:   0 total
Time:        36.629s

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
