### PR TITLE
Fix SAML authtoken call

### DIFF
--- a/server/backend/opendistro_security_client.ts
+++ b/server/backend/opendistro_security_client.ts
@@ -193,7 +193,7 @@ export class SecurityClient {
       acsEndpoint,
     };
     try {
-      return await this.esClient.callAsInternalUser('opendistro_security.authtoken', {
+      return await this.esClient.asScoped().callAsCurrentUser('opendistro_security.authtoken', {
         body,
       });
     } catch (error) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* the old version Security plugin somehow allows auth token call from kibanaserver user, while the new version doesn't. Using scoped client to fix this


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
