### PR TITLE
set radio ID when custom tenant is selected

### DIFF
--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -95,6 +95,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   const [selectedCustomTenantOption, setSelectedCustomTenantOption] = useState<string>('');
   const onCustomTenantChange = (selectedOption: string) => {
     setSelectedCustomTenantOption(selectedOption);
+    setTenantSwitchRadioIdSelected(CUSTOM_TENANT_RADIO_ID);
     setErrorCallOut('');
   };
   const customTenantOptions = tenants.filter((tenant) => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is to address one UX feedback on tenant switch. Originally we tested the case that user clicks the radio icon first and then select. However, user can also go directly to the dropdown to select. So, this fix is to select the radio ID if the dropdown is changed.

*Test*
With the change, the workflow looks like this.

<img width="1189" alt="Screen Shot 2020-09-03 at 4 53 26 PM" src="https://user-images.githubusercontent.com/60111637/92184738-d93ba280-ee06-11ea-9676-a8767c84df75.png">

<img width="1198" alt="Screen Shot 2020-09-03 at 4 53 48 PM" src="https://user-images.githubusercontent.com/60111637/92184762-df318380-ee06-11ea-83b7-86aa93164775.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
