### PR TITLE
Fix OIDC logout

### DIFF
--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -33,6 +33,7 @@ import { logout } from './utils';
 import { PasswordResetPanel } from './password-reset-panel';
 import { TenantSwitchPanel } from './tenant-switch-panel';
 import { ClientConfigType } from '../../types';
+import { LogoutButton } from './log-out-button';
 
 export function AccountNavButton(props: {
   coreStart: CoreStart;
@@ -113,9 +114,7 @@ export function AccountNavButton(props: {
           {horizontalRule}
         </>
       )}
-      <EuiButtonEmpty color="danger" size="xs" onClick={() => logout(props.coreStart.http)}>
-        Log out
-      </EuiButtonEmpty>
+      <LogoutButton authType={props.config.auth.type} http={props.coreStart.http} />
     </div>
   );
   return (

--- a/public/apps/account/log-out-button.tsx
+++ b/public/apps/account/log-out-button.tsx
@@ -1,0 +1,35 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiButtonEmpty } from '@elastic/eui';
+import { HttpStart } from 'kibana/public';
+import { logout } from './utils';
+
+export function LogoutButton(props: { authType: string; http: HttpStart }) {
+  if (props.authType === 'openid') {
+    return (
+      <EuiButtonEmpty color="danger" size="xs" href="/auth/logout">
+        Log out
+      </EuiButtonEmpty>
+    );
+  } else {
+    return (
+      <EuiButtonEmpty color="danger" size="xs" onClick={() => logout(props.http)}>
+        Log out
+      </EuiButtonEmpty>
+    );
+  }
+}

--- a/public/types.ts
+++ b/public/types.ts
@@ -50,4 +50,7 @@ export interface ClientConfigType {
       enable_global: boolean;
     };
   };
+  auth: {
+    type: string;
+  };
 }

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -26,12 +26,11 @@ import {
   AuthToolkit,
   IKibanaResponse,
 } from 'kibana/server';
-import { stringify } from 'querystring';
 import { SecurityPluginConfigType } from '../../..';
 import { SecuritySessionCookie } from '../../../session/security_cookie';
 import { OpenIdAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
-import { parseTokenResponse, callTokenEndpoint } from './helper';
+import { callTokenEndpoint } from './helper';
 import { composeNextUrlQeuryParam } from '../../../utils/next_url';
 
 export interface OpenIdAuthConfig {
@@ -182,7 +181,7 @@ export class OpenIdAuthentication extends AuthenticationType {
     toolkit: AuthToolkit
   ): IKibanaResponse {
     this.sessionStorageFactory.asScoped(request).clear();
-    if (request.url.pathname!.startsWith('/app/')) {
+    if (request.url.pathname!.startsWith('/app/') || request.url.pathname === '/') {
       // nextUrl is a key value pair
       const nextUrl = composeNextUrlQeuryParam(
         request,

--- a/server/index.ts
+++ b/server/index.ts
@@ -188,6 +188,7 @@ export type SecurityPluginConfigType = TypeOf<typeof configSchema>;
 export const config: PluginConfigDescriptor<SecurityPluginConfigType> = {
   exposeToBrowser: {
     enabled: true,
+    auth: true,
     ui: true,
     multitenancy: true,
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fix OIDC logout.
* The OIDC logout used to be a XHR `POST` request. It will redirect user to IDP logout endpoint, which will be blocked by browser CORS policy. change it to `GET`
* refactor logout parameters, do URL encoding


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
