### PR TITLE
Add readonly mode

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -102,7 +102,6 @@ export class OpendistroSecurityPlugin
 
     core.application.registerAppUpdater(
       new BehaviorSubject<AppUpdater>((app) => {
-        console.log(app);
         if (!apiPermission && isReadonly && app.id !== 'dashboards' && app.id !== 'home') {
           return {
             status: AppStatus.inaccessible,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -19,6 +19,8 @@ import {
   CoreStart,
   Plugin,
   PluginInitializerContext,
+  AppUpdater,
+  AppStatus,
 } from '../../../src/core/public';
 import {
   OpendistroSecurityPluginSetup,
@@ -29,6 +31,8 @@ import {
 import { LOGIN_PAGE_URI, PLUGIN_NAME, SELECT_TENANT_PAGE_URI } from '../common';
 import { API_ENDPOINT_PERMISSIONS_INFO } from './apps/configuration/constants';
 import { setupTopNavButton } from './apps/account/account-app';
+import { BehaviorSubject } from 'rxjs';
+import { fetchAccountInfoSafe } from './apps/account/utils';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -41,6 +45,8 @@ async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   }
 }
 
+const DEFAULT_READONLY_ROLES = ['kibana_read_only'];
+
 export class OpendistroSecurityPlugin
   implements Plugin<OpendistroSecurityPluginSetup, OpendistroSecurityPluginStart> {
   // @ts-ignore : initializerContext not used
@@ -50,6 +56,11 @@ export class OpendistroSecurityPlugin
     const apiPermission = await hasApiPermission(core);
 
     const config = this.initializerContext.config.get<ClientConfigType>();
+
+    const accountInfo = (await fetchAccountInfoSafe(core.http))?.data;
+    const isReadonly = accountInfo?.roles.some((role) =>
+      (config.readonly_mode?.roles || DEFAULT_READONLY_ROLES).includes(role)
+    );
 
     if (apiPermission) {
       core.application.register({
@@ -88,6 +99,17 @@ export class OpendistroSecurityPlugin
         return renderPage(coreStart, params, config, apiPermission);
       },
     });
+
+    core.application.registerAppUpdater(
+      new BehaviorSubject<AppUpdater>((app) => {
+        console.log(app);
+        if (!apiPermission && isReadonly && app.id !== 'dashboards' && app.id !== 'home') {
+          return {
+            status: AppStatus.inaccessible,
+          };
+        }
+      })
+    );
 
     // Return methods that should be available to other plugins
     return {};

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -13,6 +13,7 @@
  *   permissions and limitations under the License.
  */
 
+import { BehaviorSubject } from 'rxjs';
 import {
   AppMountParameters,
   CoreSetup,
@@ -31,7 +32,6 @@ import {
 import { LOGIN_PAGE_URI, PLUGIN_NAME, SELECT_TENANT_PAGE_URI } from '../common';
 import { API_ENDPOINT_PERMISSIONS_INFO } from './apps/configuration/constants';
 import { setupTopNavButton } from './apps/account/account-app';
-import { BehaviorSubject } from 'rxjs';
 import { fetchAccountInfoSafe } from './apps/account/utils';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {

--- a/public/types.ts
+++ b/public/types.ts
@@ -32,6 +32,9 @@ export interface AuthInfo {
 }
 
 export interface ClientConfigType {
+  readonly_mode: {
+    roles: string[];
+  }
   ui: {
     basicauth: {
       login: {

--- a/public/types.ts
+++ b/public/types.ts
@@ -34,7 +34,7 @@ export interface AuthInfo {
 export interface ClientConfigType {
   readonly_mode: {
     roles: string[];
-  }
+  };
   ui: {
     basicauth: {
       login: {

--- a/server/index.ts
+++ b/server/index.ts
@@ -190,6 +190,7 @@ export const config: PluginConfigDescriptor<SecurityPluginConfigType> = {
     enabled: true,
     ui: true,
     multitenancy: true,
+    readonly_mode: true,
   },
   schema: configSchema,
   deprecations: ({ rename, unused }) => [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add readonly mode that can only see dashboards (configured by `readonly_modes.roles`, default to "kibana_read_only").

Known defects:
This PR didn't disable home app, on home app there are a number of links (e.g. dashboards, visualizations), click thru them will see an "Application not found error". But we didn't find a way to change default app to dashboards, means if we disable home app, after login user will be redirect to home app and see "Application not found error".

Screenshots:
![image](https://user-images.githubusercontent.com/63078162/92545345-ca892d00-f204-11ea-8e2b-ef6f584f95b3.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
