### PR TITLE
Add unit test for permission listing page

### DIFF
--- a/public/apps/configuration/panels/permission-list/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.test.tsx
@@ -31,7 +31,7 @@ describe('Permission edit modal', () => {
         handleSave={handleSave}
       />
     );
-    component.find("#submit").simulate('click');
+    component.find('#submit').simulate('click');
 
     expect(handleSave).toBeCalled();
   });

--- a/public/apps/configuration/panels/permission-list/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.test.tsx
@@ -1,0 +1,38 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { PermissionEditModal } from './edit-modal';
+import { Action } from '../../types';
+
+describe('Permission edit modal', () => {
+  it('Submit change', () => {
+    const handleSave = jest.fn();
+    const component = shallow(
+      <PermissionEditModal
+        groupName={'group1'}
+        action={Action.create}
+        allowedActions={[]}
+        optionUniverse={[]}
+        handleClose={jest.fn()}
+        handleSave={handleSave}
+      />
+    );
+    component.find("#submit").simulate('click');
+
+    expect(handleSave).toBeCalled();
+  });
+});

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -54,6 +54,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
 
   const handleGroupNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
+    // TODO: Have a shared component to manage entity name form row.
     if (newValue.length <= 50) {
       setGroupName(newValue);
     }
@@ -93,6 +94,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
           <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
 
           <EuiButton
+            id="submit"
             onClick={async () => {
               await props.handleSave(groupName, allowedActions.map(comboBoxOptionToString));
             }}

--- a/public/apps/configuration/panels/permission-list/permission-list.test.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.test.tsx
@@ -15,20 +15,197 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
-import { PermissionList } from './permission-list';
-import { EuiInMemoryTable } from '@elastic/eui';
+import { PermissionList, renderBooleanToCheckMark, toggleRowDetails, renderRowExpanstionArrow } from './permission-list';
+import { EuiInMemoryTable, EuiButtonIcon } from '@elastic/eui';
+import {
+  requestDeleteActionGroups,
+  fetchActionGroups,
+  updateActionGroup,
+  PermissionListingItem,
+} from '../../utils/action-groups-utils';
+import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
+import { PermissionEditModal } from './edit-modal';
 
-describe('Permission list', () => {
-  it('render empty', () => {
-    const component = shallow(
-      <PermissionList
-        coreStart={{} as any}
-        navigation={{} as any}
-        params={{} as any}
-        config={{} as any}
-      />
-    );
+jest.mock('../../utils/action-groups-utils', () => ({
+  requestDeleteActionGroups: jest.fn(),
+  fetchActionGroups: jest.fn(),
+  mergeAllPermissions: jest.fn().mockReturnValue([]),
+  updateActionGroup: jest.fn(),
+}));
+jest.mock('../../utils/delete-confirm-modal-utils', () => ({
+  useDeleteConfirmState: jest.fn().mockReturnValue([jest.fn(), '']),
+}));
+jest.mock('../../utils/context-menu', () => ({
+  useContextMenuState: jest
+    .fn()
+    .mockImplementation((buttonText, buttonProps, children) => [children, jest.fn()]),
+}));
+jest.mock('../../utils/toast-utils', () => ({
+  useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()])
+}));
 
-    expect(component.find(EuiInMemoryTable).prop('items').length).toBe(0);
+describe('Permission list page ', () => {
+  const sampleActionGroup: PermissionListingItem = {
+    name: 'group',
+    type: 'Action group',
+    reserved: false,
+    allowedActions: [],
+    hasClusterPermission: true,
+    hasIndexPermission: false,
+  };
+
+  it('renderBooleanToCheckMark', () => {
+    expect(renderBooleanToCheckMark(false)).toBeFalsy();
+    expect(renderBooleanToCheckMark(true)).toBeTruthy();
+  });
+
+  it('toggleRowDetails', () => {
+    const setMap = jest.fn()
+    toggleRowDetails(sampleActionGroup, {}, setMap);
+    const updateMapFunc = setMap.mock.calls[0][0];
+    updateMapFunc({'group': ''})
+  });
+
+  describe('renderRowExpanstionArrow', () => {
+    it('should render down arrow when collapsed', () => {
+      const renderFunc = renderRowExpanstionArrow({}, {}, jest.fn());
+      const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>     
+      const component = shallow(<Wrapper />);
+
+      expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowDown');
+    });
+
+    it('should render up arrow when expanded', () => {
+      const renderFunc = renderRowExpanstionArrow({[sampleActionGroup.name]: sampleActionGroup}, {}, jest.fn());
+      const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>     
+      const component = shallow(<Wrapper />);
+
+      expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowUp');
+    });    
+  });
+
+  describe('PermissionList', () => {
+    it('render empty', () => {
+      const component = shallow(
+        <PermissionList
+          coreStart={{} as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+
+      expect(component.find(EuiInMemoryTable).prop('items').length).toBe(0);
+    });
+
+    it('fetch data', () => {
+      jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+      shallow(
+        <PermissionList
+          coreStart={{} as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+
+      expect(fetchActionGroups).toBeCalled();
+    });
+
+    it('fetch data error', () => {
+      const consoleLog = jest.spyOn(console, 'log');
+      consoleLog.mockImplementation(() => {});
+      jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+      const error = new Error();
+      fetchActionGroups.mockImplementationOnce(() => {
+        throw error;
+      });
+      // Hide the error message
+      jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+      shallow(
+        <PermissionList
+          coreStart={{} as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+
+      // Expect error log
+      expect(consoleLog).toBeCalledWith(error);
+    });
+
+    it('submit change', () => {
+      const component = shallow(
+        <PermissionList
+          coreStart={{} as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+      component.find('#create-from-selection').simulate('click');
+      const submitFunc = component.find(PermissionEditModal).prop('handleSave');
+      submitFunc('group1', []);
+
+      expect(updateActionGroup).toBeCalled();
+    });
+
+    it('submit change error', () => {
+      const consoleLog = jest.spyOn(console, 'log');
+      consoleLog.mockImplementation(() => {});
+      const error = new Error();
+      updateActionGroup.mockImplementationOnce(() => {
+        throw error;
+      });
+      const component = shallow(
+        <PermissionList
+          coreStart={{} as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+      component.find('#create-from-selection').simulate('click');
+      const submitFunc = component.find(PermissionEditModal).prop('handleSave');
+      submitFunc('group1', []);
+
+      // Expect error log
+      expect(consoleLog).toBeCalledWith(error);
+    });
+
+    it('delete action group', (done) => {
+      shallow(
+        <PermissionList
+          coreStart={{} as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+      const deleteFunc = useDeleteConfirmState.mock.calls[0][0];
+
+      deleteFunc();
+
+      process.nextTick(() => {
+        expect(requestDeleteActionGroups).toBeCalled();
+        done();
+      });
+    });    
+    
+    it('edit and duplicate button should be enabled when there is 1 custom action group selected', () => {
+      jest.spyOn(React, 'useState').mockImplementation(() => [[sampleActionGroup], jest.fn()]);
+      const component = shallow(
+        <PermissionList
+          coreStart={{} as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+
+      expect(component.find('#edit').prop('disabled')).toBe(false);
+      expect(component.find('#duplicate').prop('disabled')).toBe(false);
+    });
   });
 });

--- a/public/apps/configuration/panels/permission-list/permission-list.test.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.test.tsx
@@ -15,7 +15,12 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
-import { PermissionList, renderBooleanToCheckMark, toggleRowDetails, renderRowExpanstionArrow } from './permission-list';
+import {
+  PermissionList,
+  renderBooleanToCheckMark,
+  toggleRowDetails,
+  renderRowExpanstionArrow,
+} from './permission-list';
 import { EuiInMemoryTable, EuiButtonIcon } from '@elastic/eui';
 import {
   requestDeleteActionGroups,
@@ -41,7 +46,7 @@ jest.mock('../../utils/context-menu', () => ({
     .mockImplementation((buttonText, buttonProps, children) => [children, jest.fn()]),
 }));
 jest.mock('../../utils/toast-utils', () => ({
-  useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()])
+  useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
 }));
 
 describe('Permission list page ', () => {
@@ -60,28 +65,32 @@ describe('Permission list page ', () => {
   });
 
   it('toggleRowDetails', () => {
-    const setMap = jest.fn()
+    const setMap = jest.fn();
     toggleRowDetails(sampleActionGroup, {}, setMap);
     const updateMapFunc = setMap.mock.calls[0][0];
-    updateMapFunc({'group': ''})
+    updateMapFunc({ group: '' });
   });
 
   describe('renderRowExpanstionArrow', () => {
     it('should render down arrow when collapsed', () => {
       const renderFunc = renderRowExpanstionArrow({}, {}, jest.fn());
-      const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>     
+      const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>;
       const component = shallow(<Wrapper />);
 
       expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowDown');
     });
 
     it('should render up arrow when expanded', () => {
-      const renderFunc = renderRowExpanstionArrow({[sampleActionGroup.name]: sampleActionGroup}, {}, jest.fn());
-      const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>     
+      const renderFunc = renderRowExpanstionArrow(
+        { [sampleActionGroup.name]: sampleActionGroup },
+        {},
+        jest.fn()
+      );
+      const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>;
       const component = shallow(<Wrapper />);
 
       expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowUp');
-    });    
+    });
   });
 
   describe('PermissionList', () => {
@@ -191,8 +200,8 @@ describe('Permission list page ', () => {
         expect(requestDeleteActionGroups).toBeCalled();
         done();
       });
-    });    
-    
+    });
+
     it('edit and duplicate button should be enabled when there is 1 custom action group selected', () => {
       jest.spyOn(React, 'useState').mockImplementation(() => [[sampleActionGroup], jest.fn()]);
       const component = shallow(

--- a/public/apps/configuration/panels/permission-list/permission-list.test.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.test.tsx
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { PermissionList } from './permission-list';
+import { EuiInMemoryTable } from '@elastic/eui';
+
+describe('Permission list', () => {
+  it('render empty', () => {
+    const component = shallow(
+      <PermissionList
+        coreStart={{} as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+
+    expect(component.find(EuiInMemoryTable).prop('items').length).toBe(0);
+  });
+});

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -38,7 +38,6 @@ import React, {
   ReactNode,
   SetStateAction,
   useCallback,
-  useEffect,
   useState,
 } from 'react';
 import { AppDependencies } from '../../../types';

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -33,13 +33,7 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { difference } from 'lodash';
-import React, {
-  Dispatch,
-  ReactNode,
-  SetStateAction,
-  useCallback,
-  useState,
-} from 'react';
+import React, { Dispatch, ReactNode, SetStateAction, useCallback, useState } from 'react';
 import { AppDependencies } from '../../../types';
 import { Action, DataObject, ActionGroupItem, ExpandedRowMapInterface } from '../../types';
 import {

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -52,7 +52,7 @@ import {
 } from '../../utils/action-groups-utils';
 import { stringToComboBoxOption } from '../../utils/combo-box-utils';
 import { ExternalLink, renderCustomization } from '../../utils/display-utils';
-import { useToastState } from '../../utils/toast-utils';
+import { useToastState, getSuccessToastMessage } from '../../utils/toast-utils';
 import { PermissionEditModal } from './edit-modal';
 import { PermissionTree } from '../permission-tree';
 import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
@@ -165,17 +165,6 @@ const SEARCH_OPTIONS: EuiSearchBarProps = {
   ],
 };
 
-function getSuccessToastMessage(action: string, groupName: string): string {
-  switch (action) {
-    case 'create':
-    case 'duplicate':
-      return `Action group "${groupName}" successfully created`;
-    case 'edit':
-      return `Action group "${groupName}" successfully updated`;
-    default:
-      return '';
-  }
-}
 
 export function PermissionList(props: AppDependencies) {
   const [permissionList, setPermissionList] = useState<PermissionListingItem[]>([]);
@@ -281,7 +270,7 @@ export function PermissionList(props: AppDependencies) {
             fetchData();
             addToast({
               id: 'saveSucceeded',
-              title: getSuccessToastMessage(action, groupName),
+              title: getSuccessToastMessage('Action group', action, groupName),
               color: 'success',
             });
           } catch (e) {
@@ -317,7 +306,7 @@ export function PermissionList(props: AppDependencies) {
     </EuiButtonEmpty>,
   ];
 
-  const [createActionGroupMenu, closeCreateActionGroupMenu] = useContextMenuState(
+  const [createActionGroupMenu, ] = useContextMenuState(
     'Create action group',
     { fill: true },
     createActionGroupMenuItems

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -87,15 +87,14 @@ export function renderRowExpanstionArrow(
   actionGroupDict: DataObject<ActionGroupItem>,
   setItemIdToExpandedRowMap: Dispatch<SetStateAction<ExpandedRowMapInterface>>
 ) {
-  return (item: PermissionListingItem) => (
+  return (item: PermissionListingItem) =>
     item.type === 'Action group' && (
       <EuiButtonIcon
         onClick={() => toggleRowDetails(item, actionGroupDict, setItemIdToExpandedRowMap)}
         aria-label={itemIdToExpandedRowMap[item.name] ? 'Collapse' : 'Expand'}
         iconType={itemIdToExpandedRowMap[item.name] ? 'arrowUp' : 'arrowDown'}
       />
-    )
-  );
+    );
 }
 
 function getColumns(
@@ -137,7 +136,7 @@ function getColumns(
         itemIdToExpandedRowMap,
         actionGroupDict,
         setItemIdToExpandedRowMap
-      )
+      ),
     },
   ];
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add unit test for permission listing page.

Coverage:
Folder-level:

File                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------------|---------|----------|---------|---------|-----------------------------------
All files            |   80.82 |    66.67 |      60 |   81.94 |
 edit-modal.tsx      |   66.67 |       25 |   66.67 |   66.67 | 56-59
 permission-list.tsx |   82.81 |       75 |   59.09 |   84.13 | 75,93,220,234-256,274-275,303,313

All: 
Before:

File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|--------------------------------------------
All files                                            |    21.5 |    18.81 |   21.76 |   21.33 |

After:

File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|--------------------------------------------
All files                                            |   24.43 |    21.97 |   24.58 |   24.32 |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
