### PR TITLE
Validate entity id at server side

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "@hapi/wreck": "17.0.0",
     "@hapi/cryptiles": "5.0.0",
-    "html-entities": "1.3.1"
+    "html-entities": "1.3.1",
+    "xregexp": "4.3.0",
+    "@types/xregexp": "4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@hapi/wreck": "17.0.0",
-    "@hapi/cryptiles": "5.0.0"
+    "@hapi/cryptiles": "5.0.0",
+    "html-entities": "1.3.1"
   }
 }

--- a/server/multitenancy/routes.ts
+++ b/server/multitenancy/routes.ts
@@ -18,6 +18,8 @@ import { IRouter, SessionStorageFactory } from '../../../../src/core/server';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityClient } from '../backend/opendistro_security_client';
 
+const TENANT_NAME_REGEX: RegExp = /^[0-9a-zA-Z_\-]+$/;
+
 export function setupMultitenantRoutes(
   router: IRouter,
   sessionStroageFactory: SessionStorageFactory<SecuritySessionCookie>,
@@ -25,6 +27,11 @@ export function setupMultitenantRoutes(
 ) {
   const PREFIX: string = '/api/v1';
 
+  function validateTenantName(tenantName: string) {
+    if (!TENANT_NAME_REGEX.test(tenantName)) {
+      return 'Invalid tenant name.';
+    }
+  }
   /**
    * Updates selected tenant.
    */
@@ -34,7 +41,9 @@ export function setupMultitenantRoutes(
       validate: {
         body: schema.object({
           username: schema.string(),
-          tenant: schema.string(),
+          tenant: schema.string({
+            validate: validateTenantName,
+          }),
         }),
       },
     },

--- a/server/multitenancy/routes.ts
+++ b/server/multitenancy/routes.ts
@@ -17,8 +17,7 @@ import { schema } from '@kbn/config-schema';
 import { IRouter, SessionStorageFactory } from '../../../../src/core/server';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityClient } from '../backend/opendistro_security_client';
-
-const TENANT_NAME_REGEX: RegExp = /^[0-9a-zA-Z_\-]+$/;
+import { AllHtmlEntities } from 'html-entities';
 
 export function setupMultitenantRoutes(
   router: IRouter,
@@ -27,11 +26,8 @@ export function setupMultitenantRoutes(
 ) {
   const PREFIX: string = '/api/v1';
 
-  function validateTenantName(tenantName: string) {
-    if (!TENANT_NAME_REGEX.test(tenantName)) {
-      return 'Invalid tenant name.';
-    }
-  }
+  const entities = new AllHtmlEntities();
+
   /**
    * Updates selected tenant.
    */
@@ -41,9 +37,7 @@ export function setupMultitenantRoutes(
       validate: {
         body: schema.object({
           username: schema.string(),
-          tenant: schema.string({
-            validate: validateTenantName,
-          }),
+          tenant: schema.string(),
         }),
       },
     },
@@ -61,7 +55,7 @@ export function setupMultitenantRoutes(
       cookie.tenant = tenant;
       sessionStroageFactory.asScoped(request).set(cookie);
       return response.ok({
-        body: tenant,
+        body: entities.encode(tenant),
       });
     }
   );
@@ -82,7 +76,7 @@ export function setupMultitenantRoutes(
         });
       }
       return response.ok({
-        body: cookie.tenant,
+        body: entities.encode(cookie.tenant),
       });
     }
   );

--- a/server/multitenancy/routes.ts
+++ b/server/multitenancy/routes.ts
@@ -14,10 +14,10 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { AllHtmlEntities } from 'html-entities';
 import { IRouter, SessionStorageFactory } from '../../../../src/core/server';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityClient } from '../backend/opendistro_security_client';
-import { AllHtmlEntities } from 'html-entities';
 
 export function setupMultitenantRoutes(
   router: IRouter,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,14 +14,9 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import {
-  IRouter,
-  ResponseError,
-  IKibanaResponse,
-  KibanaResponseFactory,
-} from 'kibana/server';
-import { API_PREFIX, CONFIGURATION_API_PREFIX } from '../../common';
+import { IRouter, ResponseError, IKibanaResponse, KibanaResponseFactory } from 'kibana/server';
 import XRegExp from 'xregexp';
+import { API_PREFIX, CONFIGURATION_API_PREFIX } from '../../common';
 
 // see: https://www.npmjs.com/package/xregexp & https://javascript.info/regexp-unicode
 const RESOURCE_ID_REGEX = XRegExp('^[\\p{L}\\p{N}\\p{P}-]+$', 'u');

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -19,10 +19,12 @@ import {
   ResponseError,
   IKibanaResponse,
   KibanaResponseFactory,
-} from '../../../../src/core/server';
+} from 'kibana/server';
 import { API_PREFIX, CONFIGURATION_API_PREFIX } from '../../common';
+import XRegExp from 'xregexp';
 
-const RESOURCE_ID_REGEX: RegExp = /^[0-9a-zA-Z_\-]+$/;
+// see: https://www.npmjs.com/package/xregexp & https://javascript.info/regexp-unicode
+const RESOURCE_ID_REGEX = XRegExp('^[\\p{L}\\p{N}\\p{P}-]+$', 'u');
 
 // TODO: consider to extract entity CRUD operations and put it into a client class
 export function defineRoutes(router: IRouter) {
@@ -85,7 +87,7 @@ export function defineRoutes(router: IRouter) {
   }
 
   function validateEntityId(resourceName: string) {
-    if (!RESOURCE_ID_REGEX.test(resourceName)) {
+    if (!XRegExp.test(resourceName, RESOURCE_ID_REGEX)) {
       return 'Invalid entity name or id.';
     }
   }
@@ -368,7 +370,7 @@ export function defineRoutes(router: IRouter) {
         params: schema.object({
           resourceName: schema.string(),
           id: schema.string({
-            validate: validateEntityId,
+            minLength: 1,
           }),
         }),
       },

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -22,6 +22,8 @@ import {
 } from '../../../../src/core/server';
 import { API_PREFIX, CONFIGURATION_API_PREFIX } from '../../common';
 
+const RESOURCE_ID_REGEX: RegExp = /^[0-9a-zA-Z_\-]+$/;
+
 // TODO: consider to extract entity CRUD operations and put it into a client class
 export function defineRoutes(router: IRouter) {
   const internalUserSchema = schema.object({
@@ -80,6 +82,12 @@ export function defineRoutes(router: IRouter) {
       throw new Error(`Unknown resource ${resourceName}`);
     }
     inputSchema.validate(requestBody); // throws error if validation fail
+  }
+
+  function validateEntityId(resourceName: string) {
+    if (!RESOURCE_ID_REGEX.test(resourceName)) {
+      return 'Invalid entity name or id.';
+    }
   }
 
   /**
@@ -359,7 +367,9 @@ export function defineRoutes(router: IRouter) {
       validate: {
         params: schema.object({
           resourceName: schema.string(),
-          id: schema.string(),
+          id: schema.string({
+            validate: validateEntityId,
+          }),
         }),
       },
     },
@@ -435,7 +445,9 @@ export function defineRoutes(router: IRouter) {
       validate: {
         params: schema.object({
           resourceName: schema.string(),
-          id: schema.string(),
+          id: schema.string({
+            validate: validateEntityId,
+          }),
         }),
         body: schema.any(),
       },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
limit entity name allowed characters to numbers, letters, hyphen and underscore

test:
when creating internal user `a.b.c`
```
% curl -H "Content-Type: application/json" -H 'kbn-xsrf: true' -XPOST --include localhost:5601/nfh/api/v1/configuration/internalusers/a.b.c --cookie 'security_authentication=Fe26.2**d5ca53bbe4d1b6b6f67aadccd5754edc32003f069f16e88831add7e3ca88fb1c*99gIgfLsVDdzUs8cFpskZQ*9Ppr6Zy0JXSFz8z9_z0cGWwBRLXetInGl92Lbhc5mcNIGnccBCZ11KEbejDOrF9bmMWAgLg_VTnJQ2fpSV0uXXo62rp6LACUIcO2D6xuUshHhaD-5Sb6IwuynygzWBpsNbsQA_VLYq1UhIEzn2KQ9bvxCs5hJRHLZ5Vio3bzYj4DldBH-GLrSrSCqFAElvVBWbVb92TZyAdcGIzexvW22ksAbReZjHH3aJCAW-LLJhw**58a4f4b56956e60c9560c3f3b73b2e00feb1c39efcb165707cb09dbc5a1f6d61*a65_bMg-rjNWVCbKjZm5jExFLKtOwt2ImbfCxBbIAzc' -d'{ "password": "aaa"}'
HTTP/1.1 400 Bad Request
kbn-name: f8ffc2227bb6.ant.amazon.com
content-type: application/json; charset=utf-8
vary: origin
cache-control: private, no-cache, no-store, must-revalidate
set-cookie: security_authentication=Fe26.2**18844739027dfc367115a13b889531655d45411450555b9b26edf3ddc2439fc3*gYnSu_jpZodkY6lAOHqSaQ*KYdpb1f8P4dHQ7oygu5oFyzZM8n74s4uKoP_vHfcoZrenfHfthHsvy0CQPRaMU23KLdz3TVKT0GnZzqRzKn_NgxMULNPHh2dPCF1XpKO9_eZqXyJxvlR6y_2n5ZvQTEWk1hxeGBjdJLfvXhFXFP_XoTZQvRq6d2K3QbKFm8pRV9jT6wcdjgTed5pQ90JqAJWlogA0-9gwGSLWFLVNrAuWfkvDax_Xu23TVFwfipPRQA**e0e0340f8a146bd2a39f2f2ce00bacb95e24eb1816f8ae125c8877a2090474ff*XLgwPOd3nYBT2IKSlaWoNgPHjSGi7mlxTtBDjPoe-T4; HttpOnly; Path=/nfh
content-length: 100
date: Tue, 15 Sep 2020 06:02:53 GMT
Connection: keep-alive

{"statusCode":400,"error":"Bad Request","message":"[request params.id]: Invalid entity name or id."}
```


when updating tenant
```
% curl -H "Content-Type: application/json" -H 'kbn-xsrf: true' -XPOST --include localhost:5601/nfh/api/v1/multitenancy/tenant --cookie 'security_authentication=Fe26.2**d5ca53bbe4d1b6b6f67aadccd5754edc32003f069f16e88831add7e3ca88fb1c*99gIgfLsVDdzUs8cFpskZQ*9Ppr6Zy0JXSFz8z9_z0cGWwBRLXetInGl92Lbhc5mcNIGnccBCZ11KEbejDOrF9bmMWAgLg_VTnJQ2fpSV0uXXo62rp6LACUIcO2D6xuUshHhaD-5Sb6IwuynygzWBpsNbsQA_VLYq1UhIEzn2KQ9bvxCs5hJRHLZ5Vio3bzYj4DldBH-GLrSrSCqFAElvVBWbVb92TZyAdcGIzexvW22ksAbReZjHH3aJCAW-LLJhw**58a4f4b56956e60c9560c3f3b73b2e00feb1c39efcb165707cb09dbc5a1f6d61*a65_bMg-rjNWVCbKjZm5jExFLKtOwt2ImbfCxBbIAzc' -d'{ "username": "admin", "tenant": "<abc>"}'
HTTP/1.1 200 OK
kbn-name: f8ffc2227bb6.ant.amazon.com
content-type: text/html; charset=utf-8
vary: origin
cache-control: private, no-cache, no-store, must-revalidate
set-cookie: security_authentication=Fe26.2**2020f01b148f37f26eb267fdee80c92bc2e632c01fe9eea0c570486d92172bd8*-g0WD2YOuuHinD8As5WkyQ*VEB793YXymyAhqiJ2BK1L0r1vLN2Yf_gVkrq_PvMGxFYG0B1fhpuHEpEoMlTlbL6Jb65niwY8ftWZbwjFvQ56QYlr6YanIsg_x4I94ev1Bq56JFwQjtJyoZRvFIC9fg55T5s89Nnjk4DH_20zJfc4trQ9jL1DyFofYQT2Tw73Vd7jHqKTZ3NN362LwwhIvImhjFBUBtqAMilyIBoy4itCAy-0moWJ3PCtms3q9bOSGc**45b9c1a3dd4cd1547b7aa67f195101a68bb8aac6aceebf861a4c3e29e9fe2152*1477Ig-CvaVeAcL1G19UTBHo_FSiApjOxSORZjCl9Bw; HttpOnly; Path=/nfh
content-length: 11
date: Tue, 15 Sep 2020 06:00:50 GMT
Connection: keep-alive

&lt;abc&gt;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
