### PR TITLE
Add unit test for tenant list page

### DIFF
--- a/public/apps/configuration/panels/tenant-list/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.test.tsx
@@ -13,14 +13,25 @@
  *   permissions and limitations under the License.
  */
 
-import { HttpStart } from 'kibana/public';
-import { API_ENDPOINT_AUTHINFO } from '../../common';
-import { AuthInfo } from '../types';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { TenantEditModal } from './edit-modal';
+import { Action } from '../../types';
 
-export async function getAuthInfo(http: HttpStart) {
-  return (await http.get(`${API_ENDPOINT_AUTHINFO}`)) as AuthInfo;
-}
+describe('Permission edit modal', () => {
+  it('Submit change', () => {
+    const handleSave = jest.fn();
+    const component = shallow(
+      <TenantEditModal
+        tenantName={'tenant1'}
+        tenantDescription={'description1'}
+        action={Action.create}
+        handleClose={jest.fn()}
+        handleSave={handleSave}
+      />
+    );
+    component.find('#submit').simulate('click');
 
-export async function getCurrentUser(http: HttpStart) {
-  return (await getAuthInfo(http)).user_name;
-}
+    expect(handleSave).toBeCalled();
+  });
+});

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -97,6 +97,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
           <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
 
           <EuiButton
+            id="submit"
             onClick={async () => {
               await props.handleSave(tenantName, tenantDescription);
             }}

--- a/public/apps/configuration/panels/tenant-list/tenant-list.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.test.tsx
@@ -222,23 +222,28 @@ describe('Tenant list', () => {
     expect(consoleLog).toBeCalledWith(error);
   });
 
-  describe('Action menu enable-diable check', () => {
-    const sampleTenantList: Tenant[] = [
-      {
-        tenant: 'tenant_1',
-        description: '',
-        reserved: true,
-        tenantValue: 'tenant_1',
-      },
-      {
-        tenant: 'tenant_2',
-        description: '',
-        reserved: false,
-        tenantValue: 'tenant_2',
-      },
-    ];
-    it('edit and delete should be disabled when there is at least 1 reserved tenant selected', () => {
-      jest.spyOn(React, 'useState').mockImplementation(() => [[sampleTenantList], jest.fn()]);
+  describe('Action menu enable-disable check', () => {
+    const sampleReservedTenant: Tenant = {
+      tenant: 'tenant_1',
+      description: '',
+      reserved: true,
+      tenantValue: 'tenant_1',
+    };
+    const sampleCustomTenant1: Tenant = {
+      tenant: 'tenant_2',
+      description: '',
+      reserved: false,
+      tenantValue: 'tenant_2',
+    };
+    const sampleCustomTenant2: Tenant = {
+      tenant: 'tenant_3',
+      description: '',
+      reserved: false,
+      tenantValue: 'tenant_3',
+    };
+
+    it('edit and delete should be disabled when selected tenant is reserved', () => {
+      jest.spyOn(React, 'useState').mockImplementation(() => [[sampleReservedTenant], jest.fn()]);
       const component = shallow(
         <TenantList
           coreStart={mockCoreStart as any}
@@ -251,8 +256,10 @@ describe('Tenant list', () => {
       expect(component.find('#delete').prop('disabled')).toBe(true);
     });
 
-    it('All menues should be disabled when there is multiple tenant selected including multiple tenant', () => {
-      jest.spyOn(React, 'useState').mockImplementation(() => [[sampleTenantList], jest.fn()]);
+    it('All menues should be disabled when there is multiple tenant selected including reserved tenant', () => {
+      jest
+        .spyOn(React, 'useState')
+        .mockImplementation(() => [[sampleReservedTenant, sampleCustomTenant1], jest.fn()]);
       const component = shallow(
         <TenantList
           coreStart={mockCoreStart as any}
@@ -267,6 +274,27 @@ describe('Tenant list', () => {
       expect(component.find('#createDashboard').prop('disabled')).toBe(true);
       expect(component.find('#createVisualizations').prop('disabled')).toBe(true);
       expect(component.find('#delete').prop('disabled')).toBe(true);
+    });
+
+    it('All menues should be disabled except delete when there is multiple custom tenant selected', () => {
+      jest
+        .spyOn(React, 'useState')
+        .mockImplementation(() => [[sampleCustomTenant1, sampleCustomTenant2], jest.fn()]);
+      const component = shallow(
+        <TenantList
+          coreStart={mockCoreStart as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={config as any}
+        />
+      );
+      expect(component.find('#switchTenant').prop('disabled')).toBe(true);
+      expect(component.find('#edit').prop('disabled')).toBe(true);
+      expect(component.find('#duplicate').prop('disabled')).toBe(true);
+      expect(component.find('#createDashboard').prop('disabled')).toBe(true);
+      expect(component.find('#createVisualizations').prop('disabled')).toBe(true);
+
+      expect(component.find('#delete').prop('disabled')).toBe(false);
     });
   });
 });

--- a/public/apps/configuration/panels/tenant-list/tenant-list.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.test.tsx
@@ -1,0 +1,272 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { TenantList } from './tenant-list';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { EuiInMemoryTable } from '@elastic/eui';
+import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
+import { Tenant } from '../../types';
+import { TenantEditModal } from './edit-modal';
+
+jest.mock('../../utils/tenant-utils');
+jest.mock('../../../../utils/auth-info-utils');
+jest.mock('../../utils/delete-confirm-modal-utils', () => ({
+  useDeleteConfirmState: jest.fn().mockReturnValue([jest.fn(), '']),
+}));
+jest.mock('../../utils/context-menu', () => ({
+  useContextMenuState: jest
+    .fn()
+    .mockImplementation((buttonText, buttonProps, children) => [children, jest.fn()]),
+}));
+jest.mock('../../utils/toast-utils', () => ({
+  useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
+  getSuccessToastMessage: jest.fn(),
+  createUnknownErrorToast: jest.fn(),
+}));
+// eslint-disable-next-line
+const mockTenantUtils = require('../../utils/tenant-utils');
+// eslint-disable-next-line
+const mockAuthInfoUtils = require('../../../../utils/auth-info-utils');
+
+describe('Tenant list', () => {
+  const setState = jest.fn();
+  const mockCoreStart = {
+    http: 1,
+  };
+  const config = {
+    multitenancy: {
+      tenants: {
+        enable_private: 'true',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.spyOn(React, 'useState').mockImplementation((initialValue) => [initialValue, setState]);
+  });
+
+  it('Render empty', () => {
+    const mockTenantListingData = [
+      {
+        tenant: 'tenant_1',
+        description: '',
+        reserved: true,
+        tenantValue: 'tenant_1',
+      },
+    ];
+
+    mockTenantUtils.transformTenantData = jest.fn().mockReturnValue(mockTenantListingData);
+
+    const component = shallow(
+      <TenantList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={config as any}
+      />
+    );
+
+    expect(component.find(EuiInMemoryTable).prop('items').length).toBe(0);
+  });
+
+  it('fetch data error', (done) => {
+    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+    // Hide the error message
+    jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+    mockTenantUtils.fetchTenants.mockImplementationOnce(() => {
+      throw Error();
+    });
+
+    shallow(
+      <TenantList
+        coreStart={{} as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={config as any}
+      />
+    );
+
+    process.nextTick(() => {
+      // Expect setting error to true
+      expect(setState).toHaveBeenCalledWith(true);
+      done();
+    });
+  });
+
+  it('fetch data', (done) => {
+    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+
+    const mockTenantListingData = [
+      {
+        tenant: 'tenant_1',
+        description: '',
+        reserved: true,
+        tenantValue: 'tenant_1',
+      },
+    ];
+
+    mockTenantUtils.transformRoleData = jest.fn().mockReturnValue(mockTenantListingData);
+
+    shallow(
+      <TenantList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={config as any}
+      />
+    );
+
+    process.nextTick(() => {
+      expect(mockTenantUtils.fetchTenants).toHaveBeenCalledTimes(1);
+      expect(mockTenantUtils.transformTenantData).toHaveBeenCalledTimes(1);
+      expect(mockTenantUtils.fetchCurrentTenant).toHaveBeenCalledTimes(1);
+      expect(mockAuthInfoUtils.getCurrentUser).toHaveBeenCalledTimes(1);
+      expect(setState).toHaveBeenCalledWith(mockTenantListingData);
+      done();
+    });
+  });
+
+  it('delete tenant', (done) => {
+    shallow(
+      <TenantList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={config as any}
+      />
+    );
+    const deleteFunc = useDeleteConfirmState.mock.calls[0][0];
+
+    deleteFunc();
+
+    process.nextTick(() => {
+      expect(mockTenantUtils.requestDeleteTenant).toBeCalled();
+      done();
+    });
+  });
+
+  it('delete tenant error', (done) => {
+    mockTenantUtils.requestDeleteTenant.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    // Hide the error message
+    const loggingFunc = jest.fn();
+    jest.spyOn(console, 'log').mockImplementationOnce(loggingFunc);
+    shallow(
+      <TenantList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={config as any}
+      />
+    );
+    const deleteFunc = useDeleteConfirmState.mock.calls[0][0];
+
+    deleteFunc();
+
+    process.nextTick(() => {
+      expect(loggingFunc).toBeCalled();
+      done();
+    });
+  });
+
+  it('submit tenant', () => {
+    const component = shallow(
+      <TenantList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={config as any}
+      />
+    );
+    component.find('#createTenant').simulate('click');
+    const submitFunc = component.find(TenantEditModal).prop('handleSave');
+    submitFunc('tenant_1', '');
+
+    expect(mockTenantUtils.updateTenant).toBeCalled();
+  });
+
+  it('submit tenant error', () => {
+    const consoleLog = jest.spyOn(console, 'log');
+    consoleLog.mockImplementation(() => {});
+    const error = new Error();
+    mockTenantUtils.updateTenant.mockImplementationOnce(() => {
+      throw error;
+    });
+    const component = shallow(
+      <TenantList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={config as any}
+      />
+    );
+    component.find('#createTenant').simulate('click');
+    const submitFunc = component.find(TenantEditModal).prop('handleSave');
+    submitFunc('tenant_1', '');
+
+    // Expect error log
+    expect(consoleLog).toBeCalledWith(error);
+  });
+
+  describe('Action menu enable-diable check', () => {
+    const sampleTenantList: Tenant[] = [
+      {
+        tenant: 'tenant_1',
+        description: '',
+        reserved: true,
+        tenantValue: 'tenant_1',
+      },
+      {
+        tenant: 'tenant_2',
+        description: '',
+        reserved: false,
+        tenantValue: 'tenant_2',
+      },
+    ];
+    it('edit and delete should be disabled when there is at least 1 reserved tenant selected', () => {
+      jest.spyOn(React, 'useState').mockImplementation(() => [[sampleTenantList], jest.fn()]);
+      const component = shallow(
+        <TenantList
+          coreStart={mockCoreStart as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={config as any}
+        />
+      );
+      expect(component.find('#edit').prop('disabled')).toBe(true);
+      expect(component.find('#delete').prop('disabled')).toBe(true);
+    });
+
+    it('All menues should be disabled when there is multiple tenant selected including multiple tenant', () => {
+      jest.spyOn(React, 'useState').mockImplementation(() => [[sampleTenantList], jest.fn()]);
+      const component = shallow(
+        <TenantList
+          coreStart={mockCoreStart as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={config as any}
+        />
+      );
+      expect(component.find('#switchTenant').prop('disabled')).toBe(true);
+      expect(component.find('#edit').prop('disabled')).toBe(true);
+      expect(component.find('#duplicate').prop('disabled')).toBe(true);
+      expect(component.find('#createDashboard').prop('disabled')).toBe(true);
+      expect(component.find('#createVisualizations').prop('disabled')).toBe(true);
+      expect(component.find('#delete').prop('disabled')).toBe(true);
+    });
+  });
+});

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -32,7 +32,7 @@ import {
 } from '@elastic/eui';
 import React, { ReactNode, useEffect, useState, useCallback } from 'react';
 import { difference } from 'lodash';
-import { getAuthInfo } from '../../../../utils/auth-info-utils';
+import { getCurrentUser } from '../../../../utils/auth-info-utils';
 import { AppDependencies } from '../../../types';
 import { Action, Tenant } from '../../types';
 import { ExternalLink, renderCustomization } from '../../utils/display-utils';
@@ -47,28 +47,20 @@ import {
 } from '../../utils/tenant-utils';
 import { getNavLinkById } from '../../../../services/chrome_wrapper';
 import { TenantEditModal } from './edit-modal';
-import { useToastState, createUnknownErrorToast } from '../../utils/toast-utils';
+import {
+  useToastState,
+  createUnknownErrorToast,
+  getSuccessToastMessage,
+} from '../../utils/toast-utils';
 import { PageId } from '../../types';
 import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
 import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
 import { useContextMenuState } from '../../utils/context-menu';
 import { generateResourceName } from '../../utils/resource-utils';
 
-function getSuccessToastMessage(action: string, tenantName: string): string {
-  switch (action) {
-    case 'create':
-    case 'duplicate':
-      return `Tenant "${tenantName}" successfully created`;
-    case 'edit':
-      return `Tenant "${tenantName}" successfully updated`;
-    default:
-      return '';
-  }
-}
-
 export function TenantList(props: AppDependencies) {
-  const [tenantData, setTenantData] = useState<Tenant[]>([]);
-  const [errorFlag, setErrorFlag] = useState(false);
+  const [tenantData, setTenantData] = React.useState<Tenant[]>([]);
+  const [errorFlag, setErrorFlag] = React.useState(false);
   const [selection, setSelection] = useState<Tenant[]>([]);
   const [currentTenant, setCurrentTenant] = useState('');
   const [currentUsername, setCurrentUsername] = useState('');
@@ -86,7 +78,7 @@ export function TenantList(props: AppDependencies) {
       const rawTenantData = await fetchTenants(props.coreStart.http);
       const processedTenantData = transformTenantData(rawTenantData, isPrivateEnabled);
       const activeTenant = await fetchCurrentTenant(props.coreStart.http);
-      const currentUser = (await getAuthInfo(props.coreStart.http)).user_name;
+      const currentUser = await getCurrentUser(props.coreStart.http);
       setCurrentUsername(currentUser);
       setCurrentTenant(resolveTenantName(activeTenant, currentUser));
       setTenantData(processedTenantData);
@@ -98,7 +90,7 @@ export function TenantList(props: AppDependencies) {
     }
   }, [isPrivateEnabled, props.coreStart.http]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     fetchData();
   }, [props.coreStart.http, fetchData]);
 
@@ -231,6 +223,7 @@ export function TenantList(props: AppDependencies) {
 
   const actionsMenuItems = [
     <EuiButtonEmpty
+      id="switchTenant"
       key="switchTenant"
       disabled={selection.length !== 1}
       onClick={() => switchToSelectedTenant(selection[0].tenantValue, selection[0].tenant)}
@@ -238,6 +231,7 @@ export function TenantList(props: AppDependencies) {
       Switch to selected tenant
     </EuiButtonEmpty>,
     <EuiButtonEmpty
+      id="edit"
       key="edit"
       disabled={selection.length !== 1 || selection[0].reserved}
       onClick={() => showEditModal(selection[0].tenant, Action.edit, selection[0].description)}
@@ -245,6 +239,7 @@ export function TenantList(props: AppDependencies) {
       Edit
     </EuiButtonEmpty>,
     <EuiButtonEmpty
+      id="duplicate"
       key="duplicate"
       disabled={selection.length !== 1}
       onClick={() =>
@@ -258,6 +253,7 @@ export function TenantList(props: AppDependencies) {
       Duplicate
     </EuiButtonEmpty>,
     <EuiButtonEmpty
+      id="createDashboard"
       key="createDashboard"
       disabled={selection.length !== 1}
       onClick={() => viewOrCreateDashboard(selection[0].tenantValue, Action.create)}
@@ -265,6 +261,7 @@ export function TenantList(props: AppDependencies) {
       Create dashboard
     </EuiButtonEmpty>,
     <EuiButtonEmpty
+      id="createVisualizations"
       key="createVisualizations"
       disabled={selection.length !== 1}
       onClick={() => viewOrCreateVisualization(selection[0].tenantValue, Action.create)}
@@ -272,6 +269,7 @@ export function TenantList(props: AppDependencies) {
       Create visualizations
     </EuiButtonEmpty>,
     <EuiButtonEmpty
+      id="delete"
       key="delete"
       color="danger"
       onClick={showDeleteConfirmModal}
@@ -303,7 +301,7 @@ export function TenantList(props: AppDependencies) {
             fetchData();
             addToast({
               id: 'saveSucceeded',
-              title: getSuccessToastMessage(action, tenantName),
+              title: getSuccessToastMessage('Tenant', action, tenantName),
               color: 'success',
             });
           } catch (e) {
@@ -344,7 +342,11 @@ export function TenantList(props: AppDependencies) {
             <EuiFlexGroup>
               <EuiFlexItem>{actionsMenu}</EuiFlexItem>
               <EuiFlexItem>
-                <EuiButton fill onClick={() => showEditModal('', Action.create, '')}>
+                <EuiButton
+                  id="createTenant"
+                  fill
+                  onClick={() => showEditModal('', Action.create, '')}
+                >
                   Create tenant
                 </EuiButton>
               </EuiFlexItem>

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -61,7 +61,7 @@ import { generateResourceName } from '../../utils/resource-utils';
 export function TenantList(props: AppDependencies) {
   const [tenantData, setTenantData] = React.useState<Tenant[]>([]);
   const [errorFlag, setErrorFlag] = React.useState(false);
-  const [selection, setSelection] = useState<Tenant[]>([]);
+  const [selection, setSelection] = React.useState<Tenant[]>([]);
   const [currentTenant, setCurrentTenant] = useState('');
   const [currentUsername, setCurrentUsername] = useState('');
   // Modal state

--- a/public/apps/configuration/utils/delete-confirm-modal-utils.test.tsx
+++ b/public/apps/configuration/utils/delete-confirm-modal-utils.test.tsx
@@ -1,0 +1,44 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useDeleteConfirmState } from './delete-confirm-modal-utils';
+
+describe('Delete confirm modal utils', () => {
+  describe('useDeleteConfirmState', () => {
+    const handleDelete = jest.fn();
+    const entity = 'dummy_entity';
+
+    it('confirm modal should be empty initially', () => {
+      const { result } = renderHook(() => useDeleteConfirmState(handleDelete, entity));
+      const deleteConfirmModal = result.current[1];
+      expect(deleteConfirmModal).toBe(undefined);
+    });
+
+    it('deleteConfirmModal should not be undefined after calling showDeleteConfirmModal', () => {
+      const { result } = renderHook(() => useDeleteConfirmState(handleDelete, entity));
+
+      const showDeleteConfirmModal = result.current[0];
+      act(() => {
+        showDeleteConfirmModal();
+      });
+
+      expect(typeof showDeleteConfirmModal).toBe('function');
+
+      const deleteConfirmModal = result.current[1];
+      expect(typeof deleteConfirmModal).not.toBe(undefined);
+    });
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add unit test for tenant list page

Coverage:
Folder-level:

File                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------------|---------|----------|---------|---------|-----------------------------------
All files            |   63.16 |    66.67 |      33.33 |   64.52 |
 edit-modal.tsx |   77.78 |       50 |      50 |   77.78 | 53,57  
 tenant-list.tsx |   61.63 |       70 |   30.77 |    63.1 | 115-119,123,127-139,144-149,159-164,178-211,229-267,294  

All: 
Before:

File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|--------------------------------------------
All files                                            |   24.43 |    21.97 |   24.58 |   24.32 |

All:
After:

File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|----------|---------|---------|--------------------------------------------
All files                                            |   29.31 |    24.9 |   27.69 |   29.26 |                                 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
