### PR TITLE
Fix a security issue that nextUrl could be an external website

### DIFF
--- a/public/apps/account/tenant-selection-page.tsx
+++ b/public/apps/account/tenant-selection-page.tsx
@@ -23,7 +23,7 @@ function handleModalClose(serverBasePath: string) {
   // navigate to nextUrl
   const urlParams = new URLSearchParams(window.location.search);
   let nextUrl = urlParams.get('nextUrl');
-  if (!nextUrl || nextUrl.toLowerCase().startsWith('http')) {
+  if (!nextUrl || nextUrl.toLowerCase().includes('//')) {
     nextUrl = serverBasePath;
   }
   window.location.href = nextUrl;

--- a/public/apps/account/tenant-selection-page.tsx
+++ b/public/apps/account/tenant-selection-page.tsx
@@ -22,7 +22,10 @@ import { TenantSwitchPanel } from './tenant-switch-panel';
 function handleModalClose(serverBasePath: string) {
   // navigate to nextUrl
   const urlParams = new URLSearchParams(window.location.search);
-  const nextUrl = urlParams.get('nextUrl') || serverBasePath;
+  let nextUrl = urlParams.get('nextUrl');
+  if (!nextUrl || nextUrl.toLowerCase().startsWith('http')) {
+    nextUrl = serverBasePath;
+  }
   window.location.href = nextUrl;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a security issue that nextUrl could be an external website. If detected the lowercase nextUrl starts with http, redirect to root. It is for the case that a user put an external phishing website in the nextUrl para and send the link to another user.

Following cases are verified to be handled after this change:
http://localhost:5601/gyq/app/login?nextUrl=http://opendistro.github.io
http://localhost:5601/gyq/app/login?nextUrl=HTTP://opendistro.github.io
http://localhost:5601/gyq/app/login?nextUrl=//opendistro.github.io
http://localhost:5601/gyq/app/login?nextUrl=%2F%2Fopendistro.github.io

Following cases are redirecting to invalid url so no need to be handled:
http://localhost:5601/gyq/app/login?nextUrl=/opendistro.github.io -> http://localhost:5601/opendistro.github.io
http://localhost:5601/gyq/app/login?nextUrl=/opendistro.github.io -> http://localhost:5601/gyq/app/opendistro.github.io

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
