### PR TITLE
Remove hover state for permission tree leaf node

### DIFF
--- a/public/apps/configuration/panels/permission-tree/_index.scss
+++ b/public/apps/configuration/panels/permission-tree/_index.scss
@@ -18,3 +18,8 @@
   overflow-Y: scroll;
   width: 100%;
 }
+
+.tree-leaf-node:hover {
+  background-color: inherit;
+  cursor: auto;
+}

--- a/public/apps/configuration/panels/permission-tree/permission-tree.tsx
+++ b/public/apps/configuration/panels/permission-tree/permission-tree.tsx
@@ -16,6 +16,7 @@
 import { EuiTreeView, EuiText } from '@elastic/eui';
 import { Node } from '@elastic/eui/src/components/tree_view/tree_view';
 import React from 'react';
+import { isEmpty } from 'lodash';
 import { ActionGroupItem, DataObject } from '../../types';
 
 import './_index.scss';
@@ -35,6 +36,7 @@ function buildTreeItem(
     id: name,
     icon: <EuiText size="xs">•</EuiText>,
     children: children?.map((child) => buildTreeItem(child, depth + 1, actionGroups)),
+    className: isEmpty(children) ? 'tree-leaf-node' : '',
   };
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove hover state for permission tree leaf node by adding a cssClass for leaf node to override it.

Screenshots (not able to include the cursor)
Before:
![image](https://user-images.githubusercontent.com/63078162/93404085-20ca2180-f83e-11ea-8599-d83ad2e382fe.png)

After:
![image](https://user-images.githubusercontent.com/63078162/93404013-f2e4dd00-f83d-11ea-8a0f-5b3202d85b70.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
