### PR TITLE
Validate resource name

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -157,6 +157,5 @@ export enum ToolTipContent {
   FieldLevelSecurity = 'Field-level security lets you control which document fields a user can see.',
 }
 
-// Name constraint: m is lower limit  and n is upper limit
-export const m = 2;
-export const n = 50;
+export const MIN_NUMBER_OF_CHARS_IN_RESOURCE_NAME = 2;
+export const MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME = 50;

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -156,3 +156,7 @@ export enum ToolTipContent {
   DocumentLevelSecurity = 'Document-level security lets you restrict a role to a subset of documents in an index.',
   FieldLevelSecurity = 'Field-level security lets you control which document fields a user can see.',
 }
+
+// Name constraint: m is lower limit  and n is upper limit
+export const m = 2;
+export const n = 50;

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -15,7 +15,6 @@
 
 import {
   EuiButton,
-  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -28,7 +27,6 @@ import {
 import React, { useState } from 'react';
 import { BreadcrumbsPageDependencies } from '../../../types';
 import { InternalUserUpdate, ResourceType } from '../../types';
-import { FormRow } from '../../utils/form-row';
 import { getUserDetail, updateUser } from '../../utils/internal-user-detail-utils';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { PasswordEditPanel } from '../../utils/password-edit-panel';
@@ -44,7 +42,7 @@ import { UserAttributeStateClass } from './types';
 import { setCrossPageToast } from '../../utils/storage-utils';
 import { ExternalLink } from '../../utils/display-utils';
 import { generateResourceName } from '../../utils/resource-utils';
-import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
+import { NameRow } from '../../utils/name-row';
 
 interface InternalUserEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -69,7 +67,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
 
   const [toasts, addToast, removeToast] = useToastState();
 
-  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
+  const [isFormValid, setIsFormValid] = useState<boolean>(true);
 
   React.useEffect(() => {
     const action = props.action;
@@ -145,25 +143,16 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         </EuiFlexGroup>
       </EuiPageHeader>
       <PanelWithHeader headerText="Credentials">
-        <EuiForm isInvalid={showErrors} error={errors}>
-          <FormRow
+        <EuiForm>
+          <NameRow
             headerText="Username"
             headerSubText="Specify a descriptive and unique user name. You cannot edit the name once the user is created."
-            helpText={resourceNameHelpText('user')}
-            isInvalid={showErrors}
-          >
-            <EuiFieldText
-              value={userName}
-              onChange={(e) => {
-                setUserName(e.target.value);
-              }}
-              onBlur={() => {
-                checkForResourceNameErrors('user', userName);
-              }}
-              disabled={props.action === 'edit'}
-              isInvalid={showErrors}
-            />
-          </FormRow>
+            resourceName={userName}
+            resourceType={'user'}
+            action={props.action}
+            setNameState={setUserName}
+            setIsFormValid={setIsFormValid}
+          />
           <PasswordEditPanel updatePassword={setPassword} updateIsInvalid={setIsPasswordInvalid} />
         </EuiForm>
       </PanelWithHeader>
@@ -181,7 +170,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton id="submit" fill onClick={updateUserHandler} disabled={showErrors}>
+          <EuiButton id="submit" fill onClick={updateUserHandler} disabled={!isFormValid}>
             {props.action === 'edit' ? 'Save changes' : 'Create'}
           </EuiButton>
         </EuiFlexItem>

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -44,6 +44,7 @@ import { UserAttributeStateClass } from './types';
 import { setCrossPageToast } from '../../utils/storage-utils';
 import { ExternalLink } from '../../utils/display-utils';
 import { generateResourceName } from '../../utils/resource-utils';
+import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
 
 interface InternalUserEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -67,6 +68,8 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
   const [backendRoles, setBackendRoles] = useState<string[]>([]);
 
   const [toasts, addToast, removeToast] = useToastState();
+
+  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
 
   React.useEffect(() => {
     const action = props.action;
@@ -142,19 +145,23 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         </EuiFlexGroup>
       </EuiPageHeader>
       <PanelWithHeader headerText="Credentials">
-        <EuiForm>
+        <EuiForm isInvalid={showErrors} error={errors}>
           <FormRow
             headerText="Username"
             headerSubText="Specify a descriptive and unique user name. You cannot edit the name once the user is created."
-            helpText="The username must contain from m to n characters. Valid characters are
-             lowercase a-z, 0-9 and (-) hyphen."
+            helpText={resourceNameHelpText('user')}
+            isInvalid={showErrors}
           >
             <EuiFieldText
               value={userName}
               onChange={(e) => {
                 setUserName(e.target.value);
               }}
+              onBlur={() => {
+                checkForResourceNameErrors('user', userName);
+              }}
               disabled={props.action === 'edit'}
+              isInvalid={showErrors}
             />
           </FormRow>
           <PasswordEditPanel updatePassword={setPassword} updateIsInvalid={setIsPasswordInvalid} />
@@ -174,7 +181,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton id="submit" fill onClick={updateUserHandler}>
+          <EuiButton id="submit" fill onClick={updateUserHandler} disabled={showErrors}>
             {props.action === 'edit' ? 'Save changes' : 'Create'}
           </EuiButton>
         </EuiFlexItem>

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -148,7 +148,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
             headerText="Username"
             headerSubText="Specify a descriptive and unique user name. You cannot edit the name once the user is created."
             resourceName={userName}
-            resourceType={'user'}
+            resourceType="user"
             action={props.action}
             setNameState={setUserName}
             setIsFormValid={setIsFormValid}

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -66,7 +66,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
               headerText="Name"
               headerSubText="Enter a unique name to describe the purpose of this group. You cannot change the name after creation."
               resourceName={groupName}
-              resourceType={''}
+              resourceType=""
               action={props.action}
               setNameState={setGroupName}
               setIsFormValid={setIsFormValid}

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -23,14 +23,13 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiForm,
-  EuiFieldText,
   EuiComboBox,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { ComboBoxOptions, Action } from '../../types';
 import { stringToComboBoxOption, comboBoxOptionToString } from '../../utils/combo-box-utils';
 import { FormRow } from '../../utils/form-row';
-import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
+import { NameRow } from '../../utils/name-row';
 
 interface PermissionEditModalDeps {
   groupName: string;
@@ -52,15 +51,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
   const [allowedActions, setAllowedActions] = useState<ComboBoxOptions>(
     props.allowedActions.map(stringToComboBoxOption)
   );
-  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
-
-  const handleGroupNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    // TODO: Have a shared component to manage entity name form row.
-    if (newValue.length <= 50) {
-      setGroupName(newValue);
-    }
-  };
+  const [isFormValid, setIsFormValid] = useState<boolean>(true);
 
   return (
     <EuiOverlayMask>
@@ -70,23 +61,16 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiForm isInvalid={showErrors} error={errors}>
-            <FormRow
+          <EuiForm>
+            <NameRow
               headerText="Name"
               headerSubText="Enter a unique name to describe the purpose of this group. You cannot change the name after creation."
-              helpText={resourceNameHelpText('')}
-              isInvalid={showErrors}
-            >
-              <EuiFieldText
-                disabled={props.action === 'edit'}
-                value={groupName}
-                onChange={handleGroupNameChange}
-                onBlur={() => {
-                  checkForResourceNameErrors('', groupName);
-                }}
-                isInvalid={showErrors}
-              />
-            </FormRow>
+              resourceName={groupName}
+              resourceType={''}
+              action={props.action}
+              setNameState={setGroupName}
+              setIsFormValid={setIsFormValid}
+            />
             <FormRow headerText="Permissions">
               <EuiComboBox
                 options={props.optionUniverse}
@@ -106,7 +90,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
               await props.handleSave(groupName, allowedActions.map(comboBoxOptionToString));
             }}
             fill
-            disabled={showErrors}
+            disabled={!isFormValid}
           >
             {props.action === Action.create ? 'Create' : 'Save'}
           </EuiButton>

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -30,6 +30,7 @@ import React, { useState } from 'react';
 import { ComboBoxOptions, Action } from '../../types';
 import { stringToComboBoxOption, comboBoxOptionToString } from '../../utils/combo-box-utils';
 import { FormRow } from '../../utils/form-row';
+import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
 
 interface PermissionEditModalDeps {
   groupName: string;
@@ -51,6 +52,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
   const [allowedActions, setAllowedActions] = useState<ComboBoxOptions>(
     props.allowedActions.map(stringToComboBoxOption)
   );
+  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
 
   const handleGroupNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
@@ -68,16 +70,21 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiForm>
+          <EuiForm isInvalid={showErrors} error={errors}>
             <FormRow
               headerText="Name"
               headerSubText="Enter a unique name to describe the purpose of this group. You cannot change the name after creation."
-              helpText="The name must be less than 50 characters."
+              helpText={resourceNameHelpText('')}
+              isInvalid={showErrors}
             >
               <EuiFieldText
                 disabled={props.action === 'edit'}
                 value={groupName}
                 onChange={handleGroupNameChange}
+                onBlur={() => {
+                  checkForResourceNameErrors('', groupName);
+                }}
+                isInvalid={showErrors}
               />
             </FormRow>
             <FormRow headerText="Permissions">
@@ -99,6 +106,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
               await props.handleSave(groupName, allowedActions.map(comboBoxOptionToString));
             }}
             fill
+            disabled={showErrors}
           >
             {props.action === Action.create ? 'Create' : 'Save'}
           </EuiButton>

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -201,7 +201,7 @@ export function RoleEdit(props: RoleEditDeps) {
             headerText="Name"
             headerSubText="Specify a descriptive and unique role name. You cannot edit the name once the role is created."
             resourceName={roleName}
-            resourceType={'role'}
+            resourceType="role"
             action={props.action}
             setNameState={setRoleName}
             setIsFormValid={setIsFormValid}

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -57,6 +57,7 @@ import {
 import { setCrossPageToast } from '../../utils/storage-utils';
 import { ExternalLink } from '../../utils/display-utils';
 import { generateResourceName } from '../../utils/resource-utils';
+import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
 
 interface RoleEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -83,6 +84,8 @@ export function RoleEdit(props: RoleEditDeps) {
   >([]);
 
   const [toasts, addToast, removeToast] = useToastState();
+
+  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
 
   React.useEffect(() => {
     const action = props.action;
@@ -195,19 +198,23 @@ export function RoleEdit(props: RoleEditDeps) {
         </EuiText>
       </EuiPageHeader>
       <PanelWithHeader headerText="Name">
-        <EuiForm>
+        <EuiForm isInvalid={showErrors} error={errors}>
           <FormRow
             headerText="Name"
             headerSubText="Specify a descriptive and unique role name. You cannot edit the name once the role is created."
-            helpText="The Role name must contain from m to n characters. Valid characters are
-            lowercase a-z, 0-9 and (-) hyphen."
+            helpText={resourceNameHelpText('role')}
+            isInvalid={showErrors}
           >
             <EuiFieldText
               value={roleName}
               onChange={(e) => {
                 setRoleName(e.target.value);
               }}
+              onBlur={() => {
+                checkForResourceNameErrors('role', roleName);
+              }}
               disabled={props.action === 'edit'}
+              isInvalid={showErrors}
             />
           </FormRow>
         </EuiForm>
@@ -242,7 +249,7 @@ export function RoleEdit(props: RoleEditDeps) {
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill onClick={updateRoleHandler}>
+          <EuiButton fill onClick={updateRoleHandler} disabled={showErrors}>
             {props.action === 'edit' ? 'Update' : 'Create'}
           </EuiButton>
         </EuiFlexItem>

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -15,7 +15,6 @@
 
 import {
   EuiButton,
-  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -31,7 +30,6 @@ import { BreadcrumbsPageDependencies } from '../../../types';
 import { CLUSTER_PERMISSIONS, INDEX_PERMISSIONS } from '../../constants';
 import { fetchActionGroups } from '../../utils/action-groups-utils';
 import { comboBoxOptionToString, stringToComboBoxOption } from '../../utils/combo-box-utils';
-import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { getRoleDetail, updateRole } from '../../utils/role-detail-utils';
 import { fetchTenantNameList } from '../../utils/tenant-utils';
@@ -57,7 +55,7 @@ import {
 import { setCrossPageToast } from '../../utils/storage-utils';
 import { ExternalLink } from '../../utils/display-utils';
 import { generateResourceName } from '../../utils/resource-utils';
-import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
+import { NameRow } from '../../utils/name-row';
 
 interface RoleEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -85,7 +83,7 @@ export function RoleEdit(props: RoleEditDeps) {
 
   const [toasts, addToast, removeToast] = useToastState();
 
-  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
+  const [isFormValid, setIsFormValid] = useState<boolean>(true);
 
   React.useEffect(() => {
     const action = props.action;
@@ -198,25 +196,16 @@ export function RoleEdit(props: RoleEditDeps) {
         </EuiText>
       </EuiPageHeader>
       <PanelWithHeader headerText="Name">
-        <EuiForm isInvalid={showErrors} error={errors}>
-          <FormRow
+        <EuiForm>
+          <NameRow
             headerText="Name"
             headerSubText="Specify a descriptive and unique role name. You cannot edit the name once the role is created."
-            helpText={resourceNameHelpText('role')}
-            isInvalid={showErrors}
-          >
-            <EuiFieldText
-              value={roleName}
-              onChange={(e) => {
-                setRoleName(e.target.value);
-              }}
-              onBlur={() => {
-                checkForResourceNameErrors('role', roleName);
-              }}
-              disabled={props.action === 'edit'}
-              isInvalid={showErrors}
-            />
-          </FormRow>
+            resourceName={roleName}
+            resourceType={'role'}
+            action={props.action}
+            setNameState={setRoleName}
+            setIsFormValid={setIsFormValid}
+          />
         </EuiForm>
       </PanelWithHeader>
       <EuiSpacer size="m" />
@@ -249,7 +238,7 @@ export function RoleEdit(props: RoleEditDeps) {
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill onClick={updateRoleHandler} disabled={showErrors}>
+          <EuiButton fill onClick={updateRoleHandler} disabled={!isFormValid}>
             {props.action === 'edit' ? 'Update' : 'Create'}
           </EuiButton>
         </EuiFlexItem>

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -30,6 +30,7 @@ import {
 import React, { useState } from 'react';
 import { Action } from '../../types';
 import { FormRow } from '../../utils/form-row';
+import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
 
 interface TenantEditModalDeps {
   tenantName: string;
@@ -49,6 +50,8 @@ export function TenantEditModal(props: TenantEditModalDeps) {
   const [tenantName, setTenantName] = useState<string>(props.tenantName);
   const [tenantDescription, setTenantDescription] = useState<string>(props.tenantDescription);
 
+  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
+
   const handleTenantNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTenantName(e.target.value);
   };
@@ -65,17 +68,22 @@ export function TenantEditModal(props: TenantEditModalDeps) {
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiForm>
+          <EuiForm isInvalid={showErrors} error={errors}>
             <FormRow
               headerText="Name"
               headerSubText="Specify a descriptive and unique tenant name that is easy to recognize. You cannot edit the name once the tenant is created."
-              helpText="The tenant name must contain from m to n characters. Valid characters are lowercase a-z, 0-9, and -(hyphen)."
+              helpText={resourceNameHelpText('tenant')}
+              isInvalid={showErrors}
             >
               <EuiFieldText
                 fullWidth
                 disabled={props.action === 'edit'}
                 value={tenantName}
                 onChange={handleTenantNameChange}
+                onBlur={() => {
+                  checkForResourceNameErrors('tenant', tenantName);
+                }}
+                isInvalid={showErrors}
               />
             </FormRow>
             <FormRow
@@ -101,6 +109,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               await props.handleSave(tenantName, tenantDescription);
             }}
             fill
+            disabled={showErrors}
           >
             {props.action === Action.create ? 'Create' : 'Save'}
           </EuiButton>

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -68,7 +68,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               headerText="Name"
               headerSubText="Specify a descriptive and unique tenant name that is easy to recognize. You cannot edit the name once the tenant is created."
               resourceName={tenantName}
-              resourceType={'tenant'}
+              resourceType="tenant"
               action={props.action}
               setNameState={setTenantName}
               setIsFormValid={setIsFormValid}

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -23,14 +23,13 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiForm,
-  EuiFieldText,
   EuiTextArea,
   EuiHorizontalRule,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { Action } from '../../types';
 import { FormRow } from '../../utils/form-row';
-import { resourceNameHelpText, useErrorState } from '../../utils/resource-validation-util';
+import { NameRow } from '../../utils/name-row';
 
 interface TenantEditModalDeps {
   tenantName: string;
@@ -50,11 +49,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
   const [tenantName, setTenantName] = useState<string>(props.tenantName);
   const [tenantDescription, setTenantDescription] = useState<string>(props.tenantDescription);
 
-  const { showErrors, errors, checkForResourceNameErrors } = useErrorState();
-
-  const handleTenantNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTenantName(e.target.value);
-  };
+  const [isFormValid, setIsFormValid] = useState<boolean>(true);
 
   const handleTenantDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTenantDescription(e.target.value);
@@ -68,24 +63,17 @@ export function TenantEditModal(props: TenantEditModalDeps) {
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiForm isInvalid={showErrors} error={errors}>
-            <FormRow
+          <EuiForm>
+            <NameRow
               headerText="Name"
               headerSubText="Specify a descriptive and unique tenant name that is easy to recognize. You cannot edit the name once the tenant is created."
-              helpText={resourceNameHelpText('tenant')}
-              isInvalid={showErrors}
-            >
-              <EuiFieldText
-                fullWidth
-                disabled={props.action === 'edit'}
-                value={tenantName}
-                onChange={handleTenantNameChange}
-                onBlur={() => {
-                  checkForResourceNameErrors('tenant', tenantName);
-                }}
-                isInvalid={showErrors}
-              />
-            </FormRow>
+              resourceName={tenantName}
+              resourceType={'tenant'}
+              action={props.action}
+              setNameState={setTenantName}
+              setIsFormValid={setIsFormValid}
+              fullWidth={true}
+            />
             <FormRow
               headerText="Description"
               headerSubText="Describe the purpose of the tenant."
@@ -109,7 +97,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               await props.handleSave(tenantName, tenantDescription);
             }}
             fill
-            disabled={showErrors}
+            disabled={!isFormValid}
           >
             {props.action === Action.create ? 'Create' : 'Save'}
           </EuiButton>

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -149,3 +149,11 @@ export interface ActionGroupItem extends ActionGroupUpdate {
 export interface ExpandedRowMapInterface {
   [key: string]: React.ReactNode;
 }
+
+export interface FormRowDeps {
+  headerText: string;
+  optional?: boolean;
+  headerSubText?: string;
+  helpLink?: string;
+  helpText?: string;
+}

--- a/public/apps/configuration/utils/form-row.tsx
+++ b/public/apps/configuration/utils/form-row.tsx
@@ -16,19 +16,15 @@
 import { EuiFormRow, EuiText } from '@elastic/eui';
 import React from 'react';
 import { ExternalLink } from './display-utils';
+import { FormRowDeps } from '../types';
 
-interface FormRowDeps {
-  headerText: string;
-  optional?: boolean;
-  headerSubText?: string;
-  helpLink?: string;
-  helpText?: string;
+export interface FormRowWithChildComponentDeps extends FormRowDeps {
   isInvalid?: boolean;
   error?: string[];
   children: React.ReactElement;
 }
 
-export function FormRow(props: FormRowDeps) {
+export function FormRow(props: FormRowWithChildComponentDeps) {
   return (
     <EuiFormRow
       fullWidth
@@ -43,7 +39,7 @@ export function FormRow(props: FormRowDeps) {
             {props.helpLink && (
               <>
                 {' '}
-                <ExternalLink href="{props.helpLink}" />
+                <ExternalLink href={props.helpLink} />
               </>
             )}
           </EuiText>

--- a/public/apps/configuration/utils/name-row.tsx
+++ b/public/apps/configuration/utils/name-row.tsx
@@ -1,0 +1,68 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import { EuiFieldText } from '@elastic/eui';
+import { FormRow } from './form-row';
+import { resourceNameHelpText, validateResourceName } from './resource-validation-util';
+import { FormRowDeps } from '../types';
+
+export interface NameRowDeps extends FormRowDeps {
+  resourceName: string;
+  resourceType: string;
+  action: string;
+  fullWidth?: boolean;
+  setNameState: (value: React.SetStateAction<string>) => void;
+  setIsFormValid: (value: React.SetStateAction<boolean>) => void;
+}
+
+export function NameRow(props: NameRowDeps) {
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const validateName = () => {
+    setErrors(validateResourceName(props.resourceType, props.resourceName));
+    const errorMessages = validateResourceName(props.resourceType, props.resourceName);
+    if (errorMessages.length > 0) {
+      props.setIsFormValid(false);
+      setErrors(errorMessages);
+    } else {
+      props.setIsFormValid(true);
+      setErrors([]);
+    }
+  };
+
+  return (
+    <FormRow
+      headerText={props.headerText}
+      headerSubText={props.headerSubText}
+      helpText={resourceNameHelpText(props.resourceType)}
+      isInvalid={errors.length > 0}
+      error={errors}
+    >
+      <EuiFieldText
+        fullWidth={props.fullWidth}
+        value={props.resourceName}
+        onChange={(e) => {
+          props.setNameState(e.target.value);
+        }}
+        onBlur={() => {
+          validateName();
+        }}
+        disabled={props.action === 'edit'}
+        isInvalid={errors.length > 0}
+      />
+    </FormRow>
+  );
+}

--- a/public/apps/configuration/utils/name-row.tsx
+++ b/public/apps/configuration/utils/name-row.tsx
@@ -34,13 +34,8 @@ export function NameRow(props: NameRowDeps) {
   const validateName = () => {
     setErrors(validateResourceName(props.resourceType, props.resourceName));
     const errorMessages = validateResourceName(props.resourceType, props.resourceName);
-    if (errorMessages.length > 0) {
-      props.setIsFormValid(false);
-      setErrors(errorMessages);
-    } else {
-      props.setIsFormValid(true);
-      setErrors([]);
-    }
+    props.setIsFormValid(!(errorMessages.length > 0));
+    setErrors(errorMessages);
   };
 
   return (

--- a/public/apps/configuration/utils/resource-validation-util.tsx
+++ b/public/apps/configuration/utils/resource-validation-util.tsx
@@ -1,0 +1,78 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+import { useState } from 'react';
+import XRegExp from 'xregexp';
+import { isEmpty } from 'lodash';
+import { m, n } from '../constants';
+
+const RESOURCE_ID_REGEX = XRegExp('^[\\p{L}\\p{N}\\p{P}-]+$', 'u');
+
+const VALID_LENGTH_HELP_TEXT = (resourceType: string) => {
+  return `The ${resourceType} name must contain from ${m} to ${n} characters.`;
+};
+
+const VALID_CHARACTERS_HELP_TEXT =
+  'Valid characters are A-Z, a-z, 0-9, (_)underscore, (-) hyphen and unicode characters.';
+
+export interface UseErrorState {
+  showErrors: boolean;
+  errors: string[];
+  checkForResourceNameErrors: (resourceType: string, resourceName: string) => void;
+}
+
+export function useErrorState(): UseErrorState {
+  const [showErrors, setShowErrors] = useState<boolean>(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const checkForResourceNameErrors = (resourceType: string, resourceName: string) => {
+    const errorMessages = validateResourceName(resourceType, resourceName);
+    if (errorMessages.length > 0) {
+      setShowErrors(true);
+      setErrors(errorMessages);
+    } else {
+      setShowErrors(false);
+      setErrors([]);
+    }
+  };
+
+  return { showErrors, errors, checkForResourceNameErrors };
+}
+export function validateResourceName(resourceType: string, resourceName: string): string[] {
+  const errors: string[] = [];
+  if (!isResourceNameLengthValid(resourceName)) {
+    errors.push(VALID_LENGTH_HELP_TEXT(resourceType));
+  }
+
+  if (!isResourceNameValid(resourceName)) {
+    errors.push(`Invalid characters found in ${resourceType} name. ${VALID_CHARACTERS_HELP_TEXT}`);
+  }
+  return errors;
+}
+
+export function isResourceNameLengthValid(resourceName: string): boolean {
+  if (resourceName.length < m || resourceName.length > n) return false;
+  return true;
+}
+
+export function isResourceNameValid(resourceName: string): boolean {
+  if (!isEmpty(resourceName) && !XRegExp.test(resourceName, RESOURCE_ID_REGEX)) {
+    return false;
+  }
+  return true;
+}
+
+export function resourceNameHelpText(resourceType: string): string {
+  return `${VALID_LENGTH_HELP_TEXT(resourceType)} ${VALID_CHARACTERS_HELP_TEXT}`;
+}

--- a/public/apps/configuration/utils/resource-validation-util.tsx
+++ b/public/apps/configuration/utils/resource-validation-util.tsx
@@ -12,43 +12,22 @@
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.
  */
-import { useState } from 'react';
 import XRegExp from 'xregexp';
 import { isEmpty } from 'lodash';
-import { m, n } from '../constants';
+import {
+  MIN_NUMBER_OF_CHARS_IN_RESOURCE_NAME,
+  MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME,
+} from '../constants';
 
 const RESOURCE_ID_REGEX = XRegExp('^[\\p{L}\\p{N}\\p{P}-]+$', 'u');
 
 const VALID_LENGTH_HELP_TEXT = (resourceType: string) => {
-  return `The ${resourceType} name must contain from ${m} to ${n} characters.`;
+  return `The ${resourceType} name must contain from ${MIN_NUMBER_OF_CHARS_IN_RESOURCE_NAME} to ${MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME} characters.`;
 };
 
 const VALID_CHARACTERS_HELP_TEXT =
   'Valid characters are A-Z, a-z, 0-9, (_)underscore, (-) hyphen and unicode characters.';
 
-export interface UseErrorState {
-  showErrors: boolean;
-  errors: string[];
-  checkForResourceNameErrors: (resourceType: string, resourceName: string) => void;
-}
-
-export function useErrorState(): UseErrorState {
-  const [showErrors, setShowErrors] = useState<boolean>(false);
-  const [errors, setErrors] = useState<string[]>([]);
-
-  const checkForResourceNameErrors = (resourceType: string, resourceName: string) => {
-    const errorMessages = validateResourceName(resourceType, resourceName);
-    if (errorMessages.length > 0) {
-      setShowErrors(true);
-      setErrors(errorMessages);
-    } else {
-      setShowErrors(false);
-      setErrors([]);
-    }
-  };
-
-  return { showErrors, errors, checkForResourceNameErrors };
-}
 export function validateResourceName(resourceType: string, resourceName: string): string[] {
   const errors: string[] = [];
   if (!isResourceNameLengthValid(resourceName)) {
@@ -62,7 +41,11 @@ export function validateResourceName(resourceType: string, resourceName: string)
 }
 
 export function isResourceNameLengthValid(resourceName: string): boolean {
-  if (resourceName.length < m || resourceName.length > n) return false;
+  if (
+    resourceName.length < MIN_NUMBER_OF_CHARS_IN_RESOURCE_NAME ||
+    resourceName.length > MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME
+  )
+    return false;
   return true;
 }
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Validate resource name (role name, user name, tenant name, permission group name/ single permission name)

*Validation Criteria:*

- The resource name must contain from 2 to 50 characters.

- Valid characters are A-Z, a-z, 0-9, (_)underscore, (-) hyphen and unicode characters.

*Testing:*

> Role name

![image](https://user-images.githubusercontent.com/63824432/93545422-32cac380-f915-11ea-9401-d2fe394856a1.png)

> User name

![image](https://user-images.githubusercontent.com/63824432/93545466-4c6c0b00-f915-11ea-8fda-f13c833f9f83.png)

> Tenant name

![image](https://user-images.githubusercontent.com/63824432/93545491-64438f00-f915-11ea-819b-dcba11d847c3.png)

> Permission

![image](https://user-images.githubusercontent.com/63824432/93545536-83dab780-f915-11ea-9f12-2f99c2f88f5a.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
