### PR TITLE
refactor error message for tenant switch and password reset panel

### DIFF
--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -17,6 +17,7 @@ import React, { useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiCallOut,
   EuiFieldPassword,
   EuiModal,
   EuiModalBody,
@@ -24,13 +25,13 @@ import {
   EuiOverlayMask,
   EuiSpacer,
   EuiTitle,
-  EuiCallOut,
 } from '@elastic/eui';
 import { CoreStart } from 'kibana/public';
 import { FormRow } from '../configuration/utils/form-row';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
 import { logout } from './utils';
 import { PASSWORD_INSTRUCTION } from '../apps-constants';
+import { constructErrorMessage } from '../error-utils';
 
 interface PasswordResetPanelProps {
   coreStart: CoreStart;
@@ -64,9 +65,9 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
         }),
       });
     } catch (e) {
+      console.error(e);
       setIsCurrentPasswordInvalid(true);
-      setCurrentPasswordError(['Invalid current password due to error: ' + e?.body?.message]);
-      return;
+      setCurrentPasswordError([constructErrorMessage(e, 'Invalid current password.')]);
     }
 
     // update new password
@@ -80,7 +81,8 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
 
       await logout(http);
     } catch (e) {
-      setErrorCallOut('Failed to reset password due to error: ' + e?.body?.message);
+      console.error(e);
+      setErrorCallOut(constructErrorMessage(e, 'Failed to reset password.'));
     }
   };
 

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -31,7 +31,7 @@ import { FormRow } from '../configuration/utils/form-row';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
 import { logout } from './utils';
 import { PASSWORD_INSTRUCTION } from '../apps-constants';
-import { constructErrorMessage } from '../error-utils';
+import { constructErrorMessageAndLog } from '../error-utils';
 
 interface PasswordResetPanelProps {
   coreStart: CoreStart;
@@ -65,9 +65,8 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
         }),
       });
     } catch (e) {
-      console.error(e);
       setIsCurrentPasswordInvalid(true);
-      setCurrentPasswordError([constructErrorMessage(e, 'Invalid current password.')]);
+      setCurrentPasswordError([constructErrorMessageAndLog(e, 'Invalid current password.')]);
     }
 
     // update new password
@@ -81,8 +80,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
 
       await logout(http);
     } catch (e) {
-      console.error(e);
-      setErrorCallOut(constructErrorMessage(e, 'Failed to reset password.'));
+      setErrorCallOut(constructErrorMessageAndLog(e, 'Failed to reset password.'));
     }
   };
 

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -31,7 +31,6 @@ import { CoreStart } from 'kibana/public';
 import { keys } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { ClientConfigType } from '../../types';
-import { GENERIC_ERROR_INSTRUCTION } from '../apps-constants';
 import {
   RESOLVED_GLOBAL_TENANT,
   RESOLVED_PRIVATE_TENANT,
@@ -39,6 +38,7 @@ import {
   selectTenant,
 } from '../configuration/utils/tenant-utils';
 import { fetchAccountInfo } from './utils';
+import { constructErrorMessage } from '../error-utils';
 
 interface TenantSwitchPanelProps {
   coreStart: CoreStart;
@@ -212,11 +212,8 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         await changeTenant(tenantName);
         props.handleClose();
       } catch (e) {
-        if (e.body) {
-          setErrorCallOut('Failed to switch tenant due to ' + e.body?.message);
-        } else {
-          setErrorCallOut('Failed to switch tenant. ' + GENERIC_ERROR_INSTRUCTION);
-        }
+        console.error(e);
+        setErrorCallOut(constructErrorMessage(e, 'Failed to switch tenant.'));
       }
     }
   };

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -38,7 +38,7 @@ import {
   selectTenant,
 } from '../configuration/utils/tenant-utils';
 import { fetchAccountInfo } from './utils';
-import { constructErrorMessage } from '../error-utils';
+import { constructErrorMessageAndLog } from '../error-utils';
 
 interface TenantSwitchPanelProps {
   coreStart: CoreStart;
@@ -212,8 +212,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         await changeTenant(tenantName);
         props.handleClose();
       } catch (e) {
-        console.error(e);
-        setErrorCallOut(constructErrorMessage(e, 'Failed to switch tenant.'));
+        setErrorCallOut(constructErrorMessageAndLog(e, 'Failed to switch tenant.'));
       }
     }
   };

--- a/public/apps/error-utils.ts
+++ b/public/apps/error-utils.ts
@@ -16,7 +16,9 @@
 import { GENERIC_ERROR_INSTRUCTION } from './apps-constants';
 
 // TODO: use this util function for error message construction.
-export function constructErrorMessage(exception: object, messagePrefix: string) {
+export function constructErrorMessageAndLog(exception: object, messagePrefix: string) {
+  console.error(JSON.stringify(exception));
+
   const message = exception?.body?.message || GENERIC_ERROR_INSTRUCTION;
 
   if (messagePrefix) {

--- a/public/apps/error-utils.ts
+++ b/public/apps/error-utils.ts
@@ -1,0 +1,27 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { GENERIC_ERROR_INSTRUCTION } from './apps-constants';
+
+// TODO: use this util function for error message construction.
+export function constructErrorMessage(exception: object, messagePrefix: string) {
+  const message = exception?.body?.message || GENERIC_ERROR_INSTRUCTION;
+
+  if (messagePrefix) {
+    return messagePrefix + ' ' + message;
+  }
+
+  return message;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change introduces a util function to construct error message and also applied it to two functions.

*Test*
Tenant switch:
<img width="1140" alt="Screen Shot 2020-09-16 at 6 17 42 PM" src="https://user-images.githubusercontent.com/60111637/93408978-b2d82700-f84a-11ea-834d-19da4a37e647.png">

Password reset:
<img width="2552" alt="Screen Shot 2020-09-16 at 6 11 51 PM" src="https://user-images.githubusercontent.com/60111637/93408997-bb306200-f84a-11ea-9aa9-074dbea036ab.png">

<img width="2526" alt="Screen Shot 2020-09-16 at 6 11 39 PM" src="https://user-images.githubusercontent.com/60111637/93409009-c08dac80-f84a-11ea-8923-18dd08b9b91d.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
