### PR TITLE
Show count of filtered table rows on headers

### DIFF
--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -31,6 +31,7 @@ import {
   EuiTitle,
   RIGHT_ALIGNMENT,
   EuiButtonEmpty,
+  Query,
 } from '@elastic/eui';
 import { difference } from 'lodash';
 import React, { Dispatch, ReactNode, SetStateAction, useCallback, useState } from 'react';
@@ -186,6 +187,8 @@ export function PermissionList(props: AppDependencies) {
 
   const [loading, setLoading] = useState(false);
 
+  const [query, setQuery] = useState<string>('');
+
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
@@ -334,7 +337,10 @@ export function PermissionList(props: AppDependencies) {
             <EuiTitle size="s">
               <h3>
                 Permissions
-                <span className="panel-header-count"> ({permissionList.length})</span>
+                <span className="panel-header-count">
+                  {' '}
+                  ({Query.execute(query, permissionList).length})
+                </span>
               </h3>
             </EuiTitle>
             <EuiText size="xs" color="subdued">
@@ -360,7 +366,13 @@ export function PermissionList(props: AppDependencies) {
             items={permissionList}
             itemId={'name'}
             pagination
-            search={SEARCH_OPTIONS}
+            search={{
+              ...SEARCH_OPTIONS,
+              onChange: (arg) => {
+                setQuery(arg.queryText);
+                return true;
+              },
+            }}
             selection={{ onSelectionChange: setSelection }}
             sorting={{ sort: { field: 'type', direction: 'asc' } }}
             error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -28,6 +28,8 @@ import {
   EuiInMemoryTable,
   EuiBasicTableColumn,
   EuiButtonEmpty,
+  EuiSearchBarProps,
+  Query,
 } from '@elastic/eui';
 import { difference } from 'lodash';
 import { AppDependencies } from '../../types';
@@ -178,9 +180,14 @@ export function RoleList(props: AppDependencies) {
 
   const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);
 
-  const [searchOptions, setSearchOptions] = useState({});
+  const [searchOptions, setSearchOptions] = useState<EuiSearchBarProps>({});
+  const [query, setQuery] = useState<string>('');
   useEffect(() => {
     setSearchOptions({
+      onChange: (arg) => {
+        setQuery(arg.queryText);
+        return true;
+      },
       filters: [
         {
           type: 'field_value_selection',
@@ -245,7 +252,10 @@ export function RoleList(props: AppDependencies) {
             <EuiTitle size="s">
               <h3>
                 Roles
-                <span className="panel-header-count"> ({roleData.length})</span>
+                <span className="panel-header-count">
+                  {' '}
+                  ({Query.execute(query, roleData).length})
+                </span>
               </h3>
             </EuiTitle>
             <EuiText size="xs" color="subdued">

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -29,6 +29,7 @@ import {
   EuiText,
   EuiTitle,
   EuiGlobalToastList,
+  Query,
 } from '@elastic/eui';
 import React, { ReactNode, useEffect, useState, useCallback } from 'react';
 import { difference } from 'lodash';
@@ -68,6 +69,8 @@ export function TenantList(props: AppDependencies) {
   const [editModal, setEditModal] = useState<ReactNode>(null);
   const [toasts, addToast, removeToast] = useToastState();
   const [loading, setLoading] = useState(false);
+
+  const [query, setQuery] = useState<string>('');
 
   // Configuration
   const isPrivateEnabled = props.config.multitenancy.tenants.enable_private;
@@ -328,7 +331,10 @@ export function TenantList(props: AppDependencies) {
             <EuiTitle size="s">
               <h3>
                 Tenants
-                <span className="panel-header-count"> ({tenantData.length})</span>
+                <span className="panel-header-count">
+                  {' '}
+                  ({Query.execute(query, tenantData).length})
+                </span>
               </h3>
             </EuiTitle>
             <EuiText size="xs" color="subdued">
@@ -363,7 +369,13 @@ export function TenantList(props: AppDependencies) {
             items={tenantData}
             itemId={'tenant'}
             pagination
-            search={{ box: { placeholder: 'Find tenant' } }}
+            search={{
+              box: { placeholder: 'Find tenant' },
+              onChange: (arg) => {
+                setQuery(arg.queryText);
+                return true;
+              },
+            }}
             selection={{ onSelectionChange: setSelection }}
             sorting
             error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -28,6 +28,7 @@ import {
   EuiPageHeader,
   EuiText,
   EuiTitle,
+  Query,
 } from '@elastic/eui';
 import { Dictionary, difference, isEmpty, map } from 'lodash';
 import React, { useState } from 'react';
@@ -95,6 +96,7 @@ export function UserList(props: AppDependencies) {
   const [selection, setSelection] = useState<InternalUsersListing[]>([]);
   const [currentUsername, setCurrentUsername] = useState('');
   const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState<string>('');
 
   React.useEffect(() => {
     const fetchData = async () => {
@@ -195,7 +197,10 @@ export function UserList(props: AppDependencies) {
             <EuiTitle size="s">
               <h3>
                 Internal users
-                <span className="panel-header-count"> ({userData.length})</span>
+                <span className="panel-header-count">
+                  {' '}
+                  ({Query.execute(query, userData).length})
+                </span>
               </h3>
             </EuiTitle>
             <EuiText size="xs" color="subdued">
@@ -226,7 +231,13 @@ export function UserList(props: AppDependencies) {
             items={userData}
             itemId={'username'}
             pagination
-            search={{ box: { placeholder: 'Search internal users' } }}
+            search={{
+              box: { placeholder: 'Search internal users' },
+              onChange: (arg) => {
+                setQuery(arg.queryText);
+                return true;
+              },
+            }}
             selection={{ onSelectionChange: setSelection }}
             sorting
             error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Show count of filtered table rows on headers.

TODO: refactor to have a shared component for all tables with search bar. Didn't do it in this PR due to high risk on a tight release schedule.

Screenshots:
![image](https://user-images.githubusercontent.com/63078162/93811659-58054d80-fc05-11ea-920e-2e4435341630.png)
![image](https://user-images.githubusercontent.com/63078162/93811698-65223c80-fc05-11ea-945a-a4acf11f2b32.png)
![image](https://user-images.githubusercontent.com/63078162/93811717-6bb0b400-fc05-11ea-9468-1c2ae23e1ca5.png)
![image](https://user-images.githubusercontent.com/63078162/93811737-71a69500-fc05-11ea-91aa-fd3ad1b71aa6.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
