### PR TITLE
include read only tenants in tenant switch

### DIFF
--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -74,7 +74,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
       try {
         const accountInfo = await fetchAccountInfo(props.coreStart.http);
         const tenantsInfo = accountInfo.data.tenants || {};
-        setTenants(keys(tenantsInfo).filter((tenantName) => tenantsInfo[tenantName]));
+        setTenants(keys(tenantsInfo));
 
         const currentUserName = accountInfo.data.user_name;
         setUsername(currentUserName);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Originally we thought that tenant with false attribute is disabled tenant. However, it actually means read only tenant.

Thus this PR removes the false check and allows users to switch to a read only tenant.

*Test*:
We created a user whose role has read only access to a tenant.

This is how the tenant switch panel looks like before the change. Notice that custom radio is disabled.

<img width="1227" alt="Screen Shot 2020-09-21 at 2 31 06 PM" src="https://user-images.githubusercontent.com/60111637/93824274-01553f00-fc18-11ea-98e2-ddc19c9249ae.png">

After the PR,
<img width="1025" alt="Screen Shot 2020-09-21 at 2 32 45 PM" src="https://user-images.githubusercontent.com/60111637/93824296-0b773d80-fc18-11ea-943f-7cc8d084079f.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
