### PR TITLE
Show count of filtered table rows on authc and authz headers

### DIFF
--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -13,8 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-import React from 'react';
-import { EuiInMemoryTable } from '@elastic/eui';
+import React, { useState } from 'react';
+import { EuiInMemoryTable, EuiSearchBarProps, Query } from '@elastic/eui';
 import { keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { renderExpression } from '../../utils/display-utils';
@@ -69,6 +69,7 @@ const TRUE_STRING = 'True';
 const FALSE_STRING = 'False';
 
 export function AuthenticationSequencePanel(props: { authc: []; loading: boolean }) {
+  const [query, setQuery] = useState<string>('');
   const domains = keys(props.authc);
 
   const items = map(domains, function (domain: string) {
@@ -88,9 +89,13 @@ export function AuthenticationSequencePanel(props: { authc: []; loading: boolean
     };
   });
 
-  const search = {
+  const search: EuiSearchBarProps = {
     box: {
       placeholder: 'Search authentication domain',
+    },
+    onChange: (arg) => {
+      setQuery(arg.queryText);
+      return true;
     },
   };
 
@@ -103,7 +108,7 @@ export function AuthenticationSequencePanel(props: { authc: []; loading: boolean
       backend they should be authenticated. When there are multiple authentication domains, the plugin will authenticate
       the user sequentially against each backend until one succeeds."
       helpLink={DocLinks.BackendConfigurationAuthenticationDoc}
-      count={domains.length}
+      count={Query.execute(query, items).length}
     >
       <EuiInMemoryTable
         tableLayout={'auto'}

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -13,8 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-import React from 'react';
-import { EuiInMemoryTable, EuiEmptyPrompt } from '@elastic/eui';
+import React, { useState } from 'react';
+import { EuiInMemoryTable, EuiEmptyPrompt, EuiSearchBarProps, Query } from '@elastic/eui';
 import { keys, map, get } from 'lodash';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { renderExpression, ExternalLinkButton } from '../../utils/display-utils';
@@ -62,6 +62,7 @@ const emptyListMessage = (
 );
 
 export function AuthorizationPanel(props: { authz: []; loading: boolean }) {
+  const [query, setQuery] = useState<string>('');
   const domains = keys(props.authz);
 
   const items = map(domains, function (domain: string) {
@@ -76,9 +77,13 @@ export function AuthorizationPanel(props: { authz: []; loading: boolean }) {
     };
   });
 
-  const search = {
+  const search: EuiSearchBarProps = {
     box: {
       placeholder: 'Search authorization domain',
+    },
+    onChange: (arg) => {
+      setQuery(arg.queryText);
+      return true;
     },
   };
 
@@ -89,7 +94,7 @@ export function AuthorizationPanel(props: { authz: []; loading: boolean }) {
       headerText={headerText}
       headerSubText="After the user authenticates, the security plugin can collect external identities, such as LDAP groups, from authorization backends. These backends have no execution order; the plugin tries to collect external identities from all of them."
       helpLink={DocLinks.BackendConfigurationAuthorizationDoc}
-      count={domains.length}
+      count={Query.execute(query, items).length}
     >
       <EuiInMemoryTable
         tableLayout={'auto'}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Show count of filtered table rows on authentication and authorization headers.

Screenshots:
![image](https://user-images.githubusercontent.com/63824432/93950427-523c6480-fcf8-11ea-9918-bd7569901a97.png)

![image](https://user-images.githubusercontent.com/63824432/93950483-7435e700-fcf8-11ea-8bdb-12d41225770e.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
