### PR TITLE
Fix error log when non admin user calls restapiinfo API

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -727,7 +727,9 @@ export function defineRoutes(router: IRouter) {
           body: esResponse,
         });
       } catch (error) {
-        return errorResponse(response, error);
+        return response.badRequest({
+          body: error,
+        });
       }
     }
   );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently when non admin user calls `restapiinfo` API, the error handling function will fail and log an error log in kibana.log, this change fixed this issue and the response looks like following now
```
{"statusCode":400,"error":"Bad Request","message":"java.lang.UnsupportedOperationException"}
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
