### PR TITLE
[AuditLogging] add one more option for disabled_transport_categories

### DIFF
--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -95,6 +95,7 @@ const TRANSPORT_DISABLED_CATEGORIES: SettingContent = {
     'MISSING_PRIVILEGES',
     'GRANTED_PRIVILEGES',
     'SSL_EXCEPTION',
+    'OPENDISTRO_SECURITY_INDEX_ATTEMPT',
     'AUTHENTICATED',
   ],
   placeHolder: 'Select categories',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add one more option to bring parity with existing audit logging features.

https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/blob/opendistro-1.9/lib/configuration/validation/audit.js#L23

*Test*
<img width="2550" alt="Screen Shot 2020-09-29 at 1 02 25 PM" src="https://user-images.githubusercontent.com/60111637/94610902-d7be9800-0255-11eb-9fa1-587639ae644b.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
