### PR TITLE
Remove client side validation for security resources

### DIFF
--- a/lib/configuration/validation/audit.js
+++ b/lib/configuration/validation/audit.js
@@ -4,25 +4,9 @@ export default Joi.object().keys({
   enabled: Joi.boolean(),
   audit: Joi.object().keys({
     enable_rest: Joi.boolean(),
-    disabled_rest_categories: Joi.array().items(
-      'AUTHENTICATED',
-      'BAD_HEADERS',
-      'FAILED_LOGIN',
-      'GRANTED_PRIVILEGES',
-      'MISSING_PRIVILEGES',
-      'SSL_EXCEPTION'
-    ),
+    disabled_rest_categories: Joi.array().items(Joi.string()),
     enable_transport: Joi.boolean(),
-    disabled_transport_categories: Joi.array().items(
-      'AUTHENTICATED',
-      'BAD_HEADERS',
-      'FAILED_LOGIN',
-      'GRANTED_PRIVILEGES',
-      'INDEX_EVENT',
-      'MISSING_PRIVILEGES',
-      'OPENDISTRO_SECURITY_INDEX_ATTEMPT',
-      'SSL_EXCEPTION'
-    ),
+    disabled_transport_categories: Joi.array().items(Joi.string()),
     resolve_bulk_requests: Joi.boolean(),
     log_request_body: Joi.boolean(),
     resolve_indices: Joi.boolean(),

--- a/public/apps/configuration/base_controller.js
+++ b/public/apps/configuration/base_controller.js
@@ -169,7 +169,7 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
 
     // --- Start navigation
     $scope.edit = function(resourcename) {
-        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/edit/' + resourcename );
+        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/edit/' + encodeURIComponent(encodeURIComponent(resourcename)));
     }
 
     $scope.new = function(query) {
@@ -177,7 +177,7 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
     }
 
     $scope.clone = function(resourcename) {
-        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/clone/' + resourcename);
+        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/clone/' + encodeURIComponent(encodeURIComponent(resourcename)));
     }
 
     $scope.cancel = function () {
@@ -187,7 +187,7 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
 
     $scope.delete = function() {
         $scope.displayModal = false;
-        var name = $scope.deleteModalResourceName;
+        var name = encodeURIComponent($scope.deleteModalResourceName);
         $scope.deleteModalResourceName = "";
         $scope.service.delete(name)
             .then(() => $scope.cancel());

--- a/public/apps/configuration/sections/actiongroups/controller.js
+++ b/public/apps/configuration/sections/actiongroups/controller.js
@@ -105,12 +105,6 @@ app.controller('securityEditActionGroupsController', function ($scope, $element,
             event.preventDefault();
         }
 
-        // not dots in keys allowed
-        if ($scope.resourcename.indexOf('.') != -1) {
-            $scope.errorMessage = 'Please do not use dots in the action group name.';
-            return;
-        }
-
         const form = $element.find('form[name="objectForm"]');
 
         if (form.hasClass('ng-invalid-required')) {

--- a/public/apps/configuration/sections/internalusers/controller.js
+++ b/public/apps/configuration/sections/internalusers/controller.js
@@ -113,13 +113,6 @@ app.controller('securityEditInternalUsersController', function ($scope, $element
             return;
         }
 
-        if ($scope.resourcename.indexOf("*") != -1 || $scope.resourcename.indexOf('.') != -1 ||
-            $scope.resourcename.indexOf("{") != -1 || $scope.resourcename.indexOf("}") != -1) {
-            $scope.errorMessage = "Username must not contain '*', '.' or curly brackets";
-            return;
-        }
-
-
         if (form.hasClass('ng-invalid-required')) {
             $scope.errorMessage = 'Please fill in all the required parameters.';
             return;

--- a/public/apps/configuration/sections/internalusers/controller.js
+++ b/public/apps/configuration/sections/internalusers/controller.js
@@ -103,11 +103,6 @@ app.controller('securityEditInternalUsersController', function ($scope, $element
 
         const form = $element.find('form[name="objectForm"]');
 
-        if ($scope.isNew && $scope.resourcename.length < 3) {
-            $scope.errorMessage = 'Username needs to have at least 3 characters.';
-            return;
-        }
-
         if ($scope.isNew && $scope.resourcenames.indexOf($scope.resourcename) != -1) {
             $scope.errorMessage = 'Username already exists, please choose another one.';
             return;

--- a/public/apps/configuration/sections/roles/controller.js
+++ b/public/apps/configuration/sections/roles/controller.js
@@ -304,13 +304,6 @@ app.controller('securityEditRolesController', function ($rootScope, $scope, $ele
             event.preventDefault();
         }
 
-        // no dots, curly brackets or * allowed 
-        if ($scope.resourcename.indexOf("*") != -1 || $scope.resourcename.indexOf('.') != -1 ||
-            $scope.resourcename.indexOf("{") != -1 || $scope.resourcename.indexOf("}") != -1) {
-            $scope.errorMessage = "Role name must not contain '*', '.' or curly brackets";
-            return;
-        }
-
         const form = $element.find('form[name="objectForm"]');
 
         // role name is required

--- a/public/apps/configuration/sections/rolesmapping/controller.js
+++ b/public/apps/configuration/sections/rolesmapping/controller.js
@@ -123,12 +123,6 @@ app.controller('securityEditRoleMappingsController', function ($scope, $element,
             event.preventDefault();
         }
 
-        // no dots or curly brackets allowed 
-        if ($scope.resourcename.indexOf('.') != -1 || $scope.resourcename.indexOf("{") != -1 || $scope.resourcename.indexOf("}") != -1) {   
-            $scope.errorMessage = 'Please do not use dots or curly brackets in role mappings name.';   
-            return; 
-        }
-
         const form = $element.find('form[name="objectForm"]');
 
         if (form.hasClass('ng-invalid-required')) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Removed validation of disabled audit categories. This validation will be done on server side based on configuration
- Removed resource name validation check for rolesmapping, roles, internal users and action groups as this limitation is not there in opendistro security backend API and customers can directly make resources with specified resource names (which fail client side validation).
-  URL encode resources to account for non-alphanumeric characters. Double encoding for URL (from https://github.com/angular/angular.js/issues/10479) 
- Creating resources with non-alphanumeric characters such as `%3chtml%3e%3cscript%3etest123%3c%2fscript%3e%3c%2fhtml%3e` does not allow the resource to be accessed via URL and cannot be deleted due to lack of URL encoding on resource names.

<img width="1609" alt="92908347-ff4edd00-f3da-11ea-909a-8c351a6780d0" src="https://user-images.githubusercontent.com/5506137/94664750-20ab3680-02c0-11eb-9d15-69984e57a9f9.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
