### PR TITLE
Allow arbitrary query parameters for OIDC

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Create plugins dir
         run: |
           cd ./kibana
-          mkdir plugins
+          mkdir -p plugins
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create plugins dir
         run: |
           cd ./kibana
-          mkdir plugins
+          mkdir -p plugins
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendistro_security",
-  "version": "1.10.1.1",
+  "version": "1.10.1.2",
   "main": "target/plugins/opendistro_security",
   "kibana": {
     "version": "7.9.1",

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -58,6 +58,7 @@ export function transformTenantData(
   rawTenantData: DataObject<Tenant>,
   isPrivateEnabled: boolean
 ): Tenant[] {
+  // @ts-ignore
   const tenantList: Tenant[] = map<Tenant, Tenant>(rawTenantData, (v: Tenant, k?: string) => ({
     tenant: k === globalTenantName ? GLOBAL_USER_DICT.Label : k || '',
     reserved: v.reserved,

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -54,14 +54,17 @@ export class OpenIdAuthRoutes {
       {
         path: `/auth/openid/login`,
         validate: {
-          query: schema.object({
-            code: schema.maybe(schema.string()),
-            nextUrl: schema.maybe(schema.string()),
-            state: schema.maybe(schema.string()),
-            refresh: schema.maybe(schema.string()),
-          }, {
-            unknowns: 'allow',
-          }),
+          query: schema.object(
+            {
+              code: schema.maybe(schema.string()),
+              nextUrl: schema.maybe(schema.string()),
+              state: schema.maybe(schema.string()),
+              refresh: schema.maybe(schema.string()),
+            },
+            {
+              unknowns: 'allow',
+            }
+          ),
         },
         options: {
           authRequired: false,

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -59,6 +59,8 @@ export class OpenIdAuthRoutes {
             nextUrl: schema.maybe(schema.string()),
             state: schema.maybe(schema.string()),
             refresh: schema.maybe(schema.string()),
+          }, {
+            unknowns: 'allow',
           }),
         },
         options: {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/416

*Description of changes:* current Kibana API by default requires to explicitly list all query/url/body parameters, and undeclared parameters will result in request rejected. This change allows session_state and other parameters for OIDC login API to support IDPs that support session management.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
