### PR TITLE
Fix tenant parameter not appused in url

### DIFF
--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -22,7 +22,7 @@ const PRIVATE_TENANT_SYMBOL: string = '__user__';
 const GLOBAL_TENANT_SYMBOL: string = '';
 
 export const PRIVATE_TENANTS: string[] = [PRIVATE_TENANT_SYMBOL, 'private'];
-export const GLOBAL_TENANTS: string[] = ['', GLOBAL_TENANT_SYMBOL];
+export const GLOBAL_TENANTS: string[] = ['global', GLOBAL_TENANT_SYMBOL];
 /**
  * Resovles the tenant the user is using.
  *
@@ -42,7 +42,7 @@ export function resolveTenant(
   cookie: SecuritySessionCookie
 ): string | undefined {
   let selectedTenant: string | undefined;
-  const query: any = request.query as any;
+  const query: any = request.url.query as any;
   if (query && (query.security_tenant || query.securitytenant)) {
     selectedTenant = query.security_tenant ? query.security_tenant : query.securitytenant;
   } else if (request.headers.securitytenant || request.headers.security_tenant) {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/505

*Description of changes:* the new Kibana platform exposes two `query` fields in `KibanaRequest` while only the `request.url.query` includes the query parameters. Fix this issue to solve tenant parameter not used in url issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
