### PR TITLE
Mark requests to /bundles default authenticated

### DIFF
--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -73,7 +73,7 @@ export function transformRoleData(rawRoleData: any, rawRoleMappingData: any): Ro
       .flatten()
       .compact()
       .value() as string[],
-    internalUsers: rawRoleMappingData.data[k || ''].users || [],
+    internalUsers: rawRoleMappingData.data[k || '']?.users || [],
     backendRoles: rawRoleMappingData.data[k || '']?.backend_roles || [],
   }));
 }

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -77,7 +77,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
   public authHandler: AuthenticationHandler = async (request, response, toolkit) => {
     // allow access to assets
     if (request.url.pathname && request.url.pathname.startsWith('/bundles/')) {
-      return toolkit.notHandled();
+      return toolkit.authenticated();
     }
 
     // skip auth for APIs that do not require auth


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/503

*Description of changes:*  currently requests to `/bundles` are marked as auth not handled. it can still serve the static files, but dark mode flag in kibana requires request to be authenticated to adopt dark mode, see related kibana code https://github.com/elastic/kibana/blob/82a6d39ba22d9f2abae2b4e3079fdd9869a12e71/src/legacy/ui/ui_render/ui_render_mixin.js#L84-L87

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
