### PR TITLE
Fix login pop up when requesting bootstrap.js

### DIFF
--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -80,6 +80,8 @@ export function isMultitenantPath(request: KibanaRequest): boolean {
     request.url.pathname?.startsWith('/elasticsearch') ||
     request.url.pathname?.startsWith('/api') ||
     request.url.pathname?.startsWith('/app') ||
+    // bootstrap.js depends on tenant info to fetch kibana configs in tenant index
+    (request.url.pathname?.indexOf('bootstrap.js') || -1) > -1 ||
     request.url.pathname === '/'
   );
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/503

*Description of changes:*

the PR https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/pull/512 will cause login pop up. because `bootstrap.js` is configured using `try` auth. when requesting `bootstrap.js` it will make [a call to get uiSettings](https://github.com/elastic/kibana/blob/019e2ad9a55246f3740eb02deb9f7defe21af62e/src/legacy/ui/ui_render/ui_render_mixin.js#L84-L87) if authenticated, which is essentially a SavedObject call. 

This saved object call requires to be authenticated. So when on log in page, the user is not authenticated, and the saved object call will result in login pop up if auth challenge is configured on ES side.

This fix will still allow requests to pass auth info when requesting assets, and still use `notHandled` auth to get default bootstrap config when the user is not authenticated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
