### PR TITLE
add fault tolerance to DLS rendering

### DIFF
--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -132,7 +132,15 @@ function getColumns(
           return EMPTY_FIELD_VALUE;
         }
 
-        return renderExpression('Document-level security', JSON.parse(dls));
+        // TODO: unify the experience for both cases which may require refactoring of renderExpression.
+        try {
+          return renderExpression('Document-level security', JSON.parse(dls));
+        } catch (e) {
+          // support the use case for $expression in DLS.
+
+          console.warn('Failed to parse dls as json!');
+          return dls;
+        }
       },
     },
     {

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -136,7 +136,7 @@ function getColumns(
         try {
           return renderExpression('Document-level security', JSON.parse(dls));
         } catch (e) {
-          // support the use case for $expression in DLS.
+          // Support the use case for $variable without double quotes in DLS, e.g. variable is an array.
 
           console.warn('Failed to parse dls as json!');
           return dls;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
DLS can contain $expression which will fail the json parse. Display as it is instead of failing the page.

*Test*:
Before the change, the view role page will be broken with this error
<img width="784" alt="Screen Shot 2020-10-08 at 4 51 53 PM" src="https://user-images.githubusercontent.com/60111637/95528010-c54a0a00-098b-11eb-9525-0180967d8335.png">

With this change, this is a working page.
<img width="2554" alt="Screen Shot 2020-10-08 at 5 33 15 PM" src="https://user-images.githubusercontent.com/60111637/95528236-6042e400-098c-11eb-9c6b-e75d703e6bf3.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
