### PR TITLE
[AuditLogging] use i18n to allow customization of messages and doc links

### DIFF
--- a/public/apps/configuration/configuration-app.tsx
+++ b/public/apps/configuration/configuration-app.tsx
@@ -17,6 +17,7 @@ import './_index.scss';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { I18nProvider } from '@kbn/i18n/react';
 import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
 import { AppPluginStartDependencies, ClientConfigType } from '../../types';
 import { AppRouter } from './app-router';
@@ -28,6 +29,11 @@ export function renderApp(
   config: ClientConfigType
 ) {
   const deps = { coreStart, navigation, params, config };
-  ReactDOM.render(<AppRouter {...deps} />, params.element);
+  ReactDOM.render(
+    <I18nProvider>
+      <AppRouter {...deps} />
+    </I18nProvider>,
+    params.element
+  );
   return () => ReactDOM.unmountComponentAtNode(params.element);
 }

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -14,6 +14,7 @@
  */
 
 import { API_PREFIX } from '../../../common';
+import { translateMessage } from '../translation-utils';
 
 export const API_ENDPOINT = API_PREFIX + '/configuration';
 export const API_ENDPOINT_ROLES = API_ENDPOINT + '/roles';
@@ -141,24 +142,44 @@ export const LEARN_MORE = 'Learn more';
 export const RoleViewTenantInvalidText = 'N/A';
 
 // External Links
-export enum DocLinks {
-  BackendConfigurationDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/configuration/',
-  BackendConfigurationAuthenticationDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/configuration/#authentication',
-  BackendConfigurationAuthorizationDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/configuration/#authorization',
-  AuthenticationFlowDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/concepts/',
-  UsersAndRolesDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/',
-  CreateRolesDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#create-roles',
-  MapUsersToRolesDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles',
-  CreateUsersDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#create-users',
-  AuditLogsDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/',
-  AuditLogsStorageDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/storage-types/',
-  PermissionsDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/default-action-groups/',
-  ClusterPermissionsDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/default-action-groups/#cluster-level',
-  IndexPermissionsDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/default-action-groups/#index-level',
-  DocumentLevelSecurityDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/document-level-security/',
-  TenantPermissionsDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/multi-tenancy/',
-  AttributeBasedSecurityDoc = 'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/document-level-security/#attribute-based-security',
-}
+export const DocLinks = {
+  BackendConfigurationDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/configuration/',
+  BackendConfigurationAuthenticationDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/configuration/#authentication',
+  BackendConfigurationAuthorizationDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/configuration/#authorization',
+  AuthenticationFlowDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/concepts/',
+  UsersAndRolesDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/',
+  CreateRolesDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#create-roles',
+  MapUsersToRolesDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles',
+  CreateUsersDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#create-users',
+  AuditLogsDoc: translateMessage(
+    'audit.logs.docLink',
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/'
+  ),
+  AuditLogsStorageDoc: translateMessage(
+    'audit.logs.storageDocLink',
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/audit-logs/storage-types/'
+  ),
+  PermissionsDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/default-action-groups/',
+  ClusterPermissionsDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/default-action-groups/#cluster-level',
+  IndexPermissionsDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/default-action-groups/#index-level',
+  DocumentLevelSecurityDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/document-level-security/',
+  TenantPermissionsDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/multi-tenancy/',
+  AttributeBasedSecurityDoc:
+    'https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/document-level-security/#attribute-based-security',
+};
 
 export enum ToolTipContent {
   DocumentLevelSecurity = 'Document-level security lets you restrict a role to a subset of documents in an index.',

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -29,6 +29,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import React from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
 import { AppDependencies } from '../../../types';
 import { ResourceType } from '../../types';
 import { getAuditLogging, updateAuditLogging } from '../../utils/audit-logging-utils';
@@ -58,10 +59,15 @@ function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: bool
         <EuiDescribedFormGroup title={<h3>Storage location</h3>} className="described-form-group">
           <EuiFormRow className="form-row">
             <EuiText color="subdued" grow={false}>
-              Configure the output location and storage types in{' '}
-              <EuiCode>elasticsearch.yml</EuiCode>. The default storage location is{' '}
-              <EuiCode>internal_elasticsearch</EuiCode>, which stores the logs in an index on this
-              cluster. <ExternalLink href={DocLinks.AuditLogsStorageDoc} />
+              <FormattedMessage
+                id="audit.logs.storageInstruction"
+                defaultMessage="Configure the output location and storage types in {elasticsearchCode}. The default storage location is {internalElasticsearchCode}, which stores the logs in an index on this cluster."
+                values={{
+                  elasticsearchCode: <EuiCode>elasticsearch.yml</EuiCode>,
+                  internalElasticsearchCode: <EuiCode>internal_elasticsearch</EuiCode>,
+                }}
+              />{' '}
+              <ExternalLink href={DocLinks.AuditLogsStorageDoc} />
             </EuiText>
           </EuiFormRow>
         </EuiDescribedFormGroup>

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -27,6 +27,7 @@ import {
   EuiPageHeader,
 } from '@elastic/eui';
 import React from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
 import { AppDependencies } from '../../types';
 import securityStepsDiagram from '../../../assets/get_started.svg';
 import { buildHashUrl } from '../utils/url-builder';
@@ -196,8 +197,11 @@ export function GetStarted(props: AppDependencies) {
           </EuiTitle>
           <EuiText size="s" color="subdued">
             <p>
-              Audit logs let you track user access to your Elasticsearch cluster and are useful for
-              compliance purposes. <ExternalLink href={DocLinks.AuditLogsDoc} />
+              <FormattedMessage
+                id="audit.logs.introduction"
+                defaultMessage="Audit logs let you track user access to your Elasticsearch cluster and are useful for compliance purposes."
+              />{' '}
+              <ExternalLink href={DocLinks.AuditLogsDoc} />
             </p>
             <EuiButton
               data-test-subj="review-audit-log-configuration"

--- a/public/apps/translation-utils.ts
+++ b/public/apps/translation-utils.ts
@@ -1,0 +1,20 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export function translateMessage(messageId: string, defaultMessage: string) {
+  return i18n.translate(messageId, { defaultMessage });
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To allow customization of messages and doc links, this PR leverages i18n pgk provided by Kibana.

*Test*
The en.json in Kibana is configured in this way.
`    
"audit.logs.introduction": "Audit logs let you track user access to your Elasticsearch cluster and are useful for compliance purposes. If you enable this feature, Amazon Elasticsearch Service publishes the audit logs to CloudWatch Logs, where you can monitor and search them.",`

`
    "audit.logs.storageInstruction": "Amazon Elasticsearch Service publishes audit logs to CloudWatch Logs, where you can monitor and search them. Set up the CloudWatch Logs log group in the Logs section of the Amazon Elasticsearch Service console for this domain.",`

`
    "audit.logs.docLink": "https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/audit-logs.html",`

`
    "audit.logs.storageDocLink": "https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/audit-logs.html#audit-log-enabling"`

This is how it looks like and also the doc link is verified to jump to the specified one above.
<img width="2554" alt="Screen Shot 2020-10-09 at 6 43 03 PM" src="https://user-images.githubusercontent.com/60111637/95642781-82f1fd00-0a5f-11eb-8662-e879d0d522fd.png">

<img width="2554" alt="Screen Shot 2020-10-09 at 6 43 15 PM" src="https://user-images.githubusercontent.com/60111637/95642785-86858400-0a5f-11eb-9ba5-2e8370cf7864.png">

We also test the case where the strings are not configured. We expect the messages and links will have the default values.
<img width="2557" alt="Screen Shot 2020-10-09 at 6 47 54 PM" src="https://user-images.githubusercontent.com/60111637/95642852-14fa0580-0a60-11eb-9c46-65f682351011.png">

<img width="2555" alt="Screen Shot 2020-10-09 at 6 47 24 PM" src="https://user-images.githubusercontent.com/60111637/95642857-19262300-0a60-11eb-8b55-a373f574e23d.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
