### PR TITLE
use Kibana yml for optional configurations

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -28,7 +28,7 @@ export const API_ENDPOINT_AUDITLOGGING = API_ENDPOINT + '/audit';
 export const API_ENDPOINT_AUDITLOGGING_UPDATE = API_ENDPOINT_AUDITLOGGING + '/config';
 export const API_ENDPOINT_PERMISSIONS_INFO = API_PREFIX + '/restapiinfo';
 
-export const CLUSTER_PERMISSIONS = [
+export const CLUSTER_PERMISSIONS: string[] = [
   'cluster:admin/ingest/pipeline/delete',
   'cluster:admin/ingest/pipeline/get',
   'cluster:admin/ingest/pipeline/put',
@@ -69,7 +69,13 @@ export const CLUSTER_PERMISSIONS = [
   'cluster:monitor/tasks/list',
 ];
 
-export const INDEX_PERMISSIONS = [
+export function includeClusterPermissions(clusterPermissionsToInclude: string[]) {
+  if (clusterPermissionsToInclude) {
+    CLUSTER_PERMISSIONS.push(...clusterPermissionsToInclude);
+  }
+}
+
+export const INDEX_PERMISSIONS: string[] = [
   'indices:admin/aliases',
   'indices:admin/aliases/exists',
   'indices:admin/aliases/get',
@@ -133,6 +139,12 @@ export const INDEX_PERMISSIONS = [
   'indices:monitor/stats',
   'indices:monitor/upgrade',
 ];
+
+export function includeIndexPermissions(indexPermissionsToInclude: string[]) {
+  if (indexPermissionsToInclude) {
+    INDEX_PERMISSIONS.push(...indexPermissionsToInclude);
+  }
+}
 
 export const TENANT_READ_PERMISSION = 'kibana_all_read';
 export const TENANT_WRITE_PERMISSION = 'kibana_all_write';

--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -12,6 +12,7 @@
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.
  */
+import { pullAll } from 'lodash';
 
 export const CONFIG_LABELS = {
   AUDIT_LOGGING: 'Audit logging',
@@ -75,6 +76,10 @@ const REST_DISABLED_CATEGORIES: SettingContent = {
   placeHolder: 'Select categories',
 };
 
+export function excludeFromDisabledRestCategories(optionsToExclude: string[]) {
+  pullAll(REST_DISABLED_CATEGORIES.options || [], optionsToExclude);
+}
+
 const TRANSPORT_LAYER: SettingContent = {
   title: 'Transport layer',
   path: 'audit.enable_transport',
@@ -92,14 +97,19 @@ const TRANSPORT_DISABLED_CATEGORIES: SettingContent = {
   options: [
     'BAD_HEADERS',
     'FAILED_LOGIN',
-    'MISSING_PRIVILEGES',
     'GRANTED_PRIVILEGES',
+    'INDEX_EVENT',
+    'MISSING_PRIVILEGES',
     'SSL_EXCEPTION',
     'OPENDISTRO_SECURITY_INDEX_ATTEMPT',
     'AUTHENTICATED',
   ],
   placeHolder: 'Select categories',
 };
+
+export function excludeFromDisabledTransportCategories(optionsToExclude: string[]) {
+  pullAll(TRANSPORT_DISABLED_CATEGORIES.options || [], optionsToExclude);
+}
 
 const BULK_REQUESTS: SettingContent = {
   title: 'Bulk requests',

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -30,9 +30,17 @@ import {
   ClientConfigType,
 } from './types';
 import { LOGIN_PAGE_URI, PLUGIN_NAME, SELECT_TENANT_PAGE_URI } from '../common';
-import { API_ENDPOINT_PERMISSIONS_INFO } from './apps/configuration/constants';
+import {
+  API_ENDPOINT_PERMISSIONS_INFO,
+  includeClusterPermissions,
+  includeIndexPermissions,
+} from './apps/configuration/constants';
 import { setupTopNavButton } from './apps/account/account-app';
 import { fetchAccountInfoSafe } from './apps/account/utils';
+import {
+  excludeFromDisabledRestCategories,
+  excludeFromDisabledTransportCategories,
+} from './apps/configuration/panels/audit-logging/constants';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -70,6 +78,14 @@ export class OpendistroSecurityPlugin
         mount: async (params: AppMountParameters) => {
           const { renderApp } = await import('./apps/configuration/configuration-app');
           const [coreStart, depsStart] = await core.getStartServices();
+
+          // merge Kibana yml configuration
+          includeClusterPermissions(config.clusterPermissions.include);
+          includeIndexPermissions(config.indexPermissions.include);
+
+          excludeFromDisabledTransportCategories(config.disabledTransportCategories.exclude);
+          excludeFromDisabledRestCategories(config.disabledRestCategories.exclude);
+
           return renderApp(coreStart, depsStart as AppPluginStartDependencies, params, config);
         },
       });

--- a/public/types.ts
+++ b/public/types.ts
@@ -56,4 +56,16 @@ export interface ClientConfigType {
   auth: {
     type: string;
   };
+  clusterPermissions: {
+    include: string[];
+  };
+  indexPermissions: {
+    include: string[];
+  };
+  disabledTransportCategories: {
+    exclude: string[];
+  };
+  disabledRestCategories: {
+    exclude: string[];
+  };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,18 @@ export const configSchema = schema.object({
   readonly_mode: schema.object({
     roles: schema.arrayOf(schema.string(), { defaultValue: [] }),
   }),
+  clusterPermissions: schema.object({
+    include: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  }),
+  indexPermissions: schema.object({
+    include: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  }),
+  disabledTransportCategories: schema.object({
+    exclude: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  }),
+  disabledRestCategories: schema.object({
+    exclude: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  }),
   cookie: schema.object({
     secure: schema.boolean({ defaultValue: true }),
     name: schema.string({ defaultValue: 'security_authentication' }),
@@ -192,6 +204,10 @@ export const config: PluginConfigDescriptor<SecurityPluginConfigType> = {
     ui: true,
     multitenancy: true,
     readonly_mode: true,
+    clusterPermissions: true,
+    indexPermissions: true,
+    disabledTransportCategories: true,
+    disabledRestCategories: true,
   },
   schema: configSchema,
   deprecations: ({ rename, unused }) => [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use Kibana yml for optional configurations. This allows more flexibility for customization.

This is how the new parameters look like in the yml.

`opendistro_security.clusterPermissions.include: ["cluster:admin/ultrawarm/migration/list"]
`

`opendistro_security.indexPermissions.include: ["indices:admin/ultrawarm/migration/get", "indices:admin/ultrawarm/migration/hot", "indices:admin/ultrawarm/migration/warm"]
`
`opendistro_security.disabledTransportCategories.exclude: ["BAD_HEADERS", "SSL_EXCEPTION"]
`
`opendistro_security.disabledRestCategories.exclude: ["BAD_HEADERS", "SSL_EXCEPTION"]
`

*Test*:
Without the configuration above, this is how the UI looks like
<img width="2556" alt="Screen Shot 2020-10-09 at 8 17 06 PM" src="https://user-images.githubusercontent.com/60111637/95644612-a1aac080-0a6c-11eb-9e8a-9a8161098e0f.png">

<img width="2557" alt="Screen Shot 2020-10-09 at 8 17 33 PM" src="https://user-images.githubusercontent.com/60111637/95644613-a53e4780-0a6c-11eb-9796-c51a686fcf84.png">

<img width="2554" alt="Screen Shot 2020-10-09 at 8 17 26 PM" src="https://user-images.githubusercontent.com/60111637/95644625-c4d57000-0a6c-11eb-9ea2-ea54526bd88a.png">

With the configuration above, this is how the UI looks like
<img width="2555" alt="Screen Shot 2020-10-09 at 8 15 04 PM" src="https://user-images.githubusercontent.com/60111637/95644636-d0c13200-0a6c-11eb-8646-5e8ef24a2cfd.png">
<img width="2556" alt="Screen Shot 2020-10-09 at 8 15 14 PM" src="https://user-images.githubusercontent.com/60111637/95644638-d3238c00-0a6c-11eb-916c-ae6f837e5465.png">
<img width="2552" alt="Screen Shot 2020-10-09 at 8 14 47 PM" src="https://user-images.githubusercontent.com/60111637/95644641-d585e600-0a6c-11eb-95fd-a75d5b265256.png">




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
