### PR TITLE
add instruction view for tenant list when multitenancy is disabled

### DIFF
--- a/public/apps/configuration/panels/tenant-list/tenant-instruction-view.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-instruction-view.tsx
@@ -30,7 +30,7 @@ export function TenantInstructionView() {
       </EuiText>
 
       <EuiText textAlign="center" size="xs" color="subdued" className="instruction-text">
-        Contact the administrator to enable multi tenancy.
+        Contact your administrator to enable multi tenancy.
       </EuiText>
     </>
   );

--- a/public/apps/configuration/panels/tenant-list/tenant-instruction-view.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-instruction-view.tsx
@@ -1,0 +1,37 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+
+export function TenantInstructionView() {
+  return (
+    <>
+      <EuiTitle size="l">
+        <h1>Tenants</h1>
+      </EuiTitle>
+
+      <EuiSpacer size="xxl" />
+
+      <EuiText textAlign="center">
+        <h2>You have not enabled multi tenancy</h2>
+      </EuiText>
+
+      <EuiText textAlign="center" size="xs" color="subdued" className="instruction-text">
+        Contact the administrator to enable multi tenancy.
+      </EuiText>
+    </>
+  );
+}

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -31,7 +31,7 @@ import {
   EuiGlobalToastList,
   Query,
 } from '@elastic/eui';
-import React, { ReactNode, useEffect, useState, useCallback } from 'react';
+import React, { ReactNode, useState, useCallback } from 'react';
 import { difference } from 'lodash';
 import { getCurrentUser } from '../../../../utils/auth-info-utils';
 import { AppDependencies } from '../../../types';
@@ -59,6 +59,7 @@ import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
 import { useContextMenuState } from '../../utils/context-menu';
 import { generateResourceName } from '../../utils/resource-utils';
 import { DocLinks } from '../../constants';
+import { TenantInstructionView } from './tenant-instruction-view';
 
 export function TenantList(props: AppDependencies) {
   const [tenantData, setTenantData] = React.useState<Tenant[]>([]);
@@ -318,6 +319,10 @@ export function TenantList(props: AppDependencies) {
       />
     );
   };
+
+  if (!props.config.multitenancy.enabled) {
+    return <TenantInstructionView />;
+  }
 
   return (
     <>


### PR DESCRIPTION
*Issue #, if available:* 521

*Description of changes:*
Currently if multitenancy is disabled, the page still tries to display the same layout as if it was enabled. Thus there is an error shown in the table view which is confusing for customers. Thus this PR would display an instruction view. (The layout of the instruction view refers to that for authentication and authorization view.)

V2
The new screenshot is:
<img width="2550" alt="Screen Shot 2020-10-21 at 11 25 51 AM" src="https://user-images.githubusercontent.com/60111637/96766718-5cea2800-1390-11eb-9f6d-637946012ca4.png">


V1
*Test*
before:
<img width="2549" alt="Screen Shot 2020-10-19 at 6 07 08 PM" src="https://user-images.githubusercontent.com/60111637/96528542-e1756300-1237-11eb-93c3-f3c8f94bcbb5.png">

after:
<img width="2558" alt="Screen Shot 2020-10-19 at 6 04 36 PM" src="https://user-images.githubusercontent.com/60111637/96528558-ea663480-1237-11eb-8f57-299c9c36e7fe.png">

As a reference, this is how authentication and authorization view shows instructions.
<img width="2559" alt="Screen Shot 2020-10-19 at 6 04 44 PM" src="https://user-images.githubusercontent.com/60111637/96528584-fc47d780-1237-11eb-8ed4-efc778750c67.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
