### PR TITLE
Respect opendistro_security.auth.logout_url after logout

### DIFF
--- a/public/apps/account/__snapshots__/account-nav-button.test.tsx.snap
+++ b/public/apps/account/__snapshots__/account-nav-button.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`Account navigation button renders 1`] = `
               />
             </EuiListGroup>
             <EuiListGroupItem
+              color="subdued"
               key="tenant"
               label={
                 <EuiText

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -29,7 +29,6 @@ import {
 import { CoreStart } from 'kibana/public';
 import React, { useState } from 'react';
 import { RoleInfoPanel } from './role-info-panel';
-import { logout } from './utils';
 import { PasswordResetPanel } from './password-reset-panel';
 import { TenantSwitchPanel } from './tenant-switch-panel';
 import { ClientConfigType } from '../../types';
@@ -110,6 +109,7 @@ export function AccountNavButton(props: {
                   coreStart={props.coreStart}
                   username={props.username}
                   handleClose={() => setModal(null)}
+                  logoutUrl={props.config.auth.logout_url}
                 />
               )
             }
@@ -122,6 +122,7 @@ export function AccountNavButton(props: {
         authType={props.config.auth.type}
         http={props.coreStart.http}
         divider={horizontalRule}
+        logoutUrl={props.config.auth.logout_url}
       />
     </div>
   );

--- a/public/apps/account/log-out-button.test.tsx
+++ b/public/apps/account/log-out-button.test.tsx
@@ -30,8 +30,8 @@ describe('Account menu - Log out button', () => {
   }
   const mockHttpStart = {
     basePath: {
-      serverBasePath: "",
-    }
+      serverBasePath: '',
+    },
   };
   const mockDivider = <></>;
 

--- a/public/apps/account/log-out-button.test.tsx
+++ b/public/apps/account/log-out-button.test.tsx
@@ -29,7 +29,9 @@ describe('Account menu - Log out button', () => {
     Proxy = 'proxy',
   }
   const mockHttpStart = {
-    http: 1,
+    basePath: {
+      serverBasePath: "",
+    }
   };
   const mockDivider = <></>;
 

--- a/public/apps/account/log-out-button.tsx
+++ b/public/apps/account/log-out-button.tsx
@@ -18,7 +18,12 @@ import { EuiButtonEmpty } from '@elastic/eui';
 import { HttpStart } from 'kibana/public';
 import { logout } from './utils';
 
-export function LogoutButton(props: { authType: string; http: HttpStart; divider: JSX.Element; logoutUrl?: string}) {
+export function LogoutButton(props: {
+  authType: string;
+  http: HttpStart;
+  divider: JSX.Element;
+  logoutUrl?: string;
+}) {
   if (props.authType === 'openid' || props.authType === 'saml') {
     return (
       <div>

--- a/public/apps/account/log-out-button.tsx
+++ b/public/apps/account/log-out-button.tsx
@@ -18,7 +18,7 @@ import { EuiButtonEmpty } from '@elastic/eui';
 import { HttpStart } from 'kibana/public';
 import { logout } from './utils';
 
-export function LogoutButton(props: { authType: string; http: HttpStart; divider: JSX.Element }) {
+export function LogoutButton(props: { authType: string; http: HttpStart; divider: JSX.Element; logoutUrl?: string}) {
   if (props.authType === 'openid' || props.authType === 'saml') {
     return (
       <div>
@@ -43,7 +43,7 @@ export function LogoutButton(props: { authType: string; http: HttpStart; divider
           data-test-subj="log-out-2"
           color="danger"
           size="xs"
-          onClick={() => logout(props.http)}
+          onClick={() => logout(props.http, props.logoutUrl)}
         >
           Log out
         </EuiButtonEmpty>

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -36,6 +36,7 @@ interface PasswordResetPanelProps {
   coreStart: CoreStart;
   username: string;
   handleClose: () => void;
+  logoutUrl?: string;
 }
 
 export function PasswordResetPanel(props: PasswordResetPanelProps) {
@@ -69,7 +70,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
     try {
       await updateNewPassword(http, newPassword, currentPassword);
 
-      await logout(http);
+      await logout(http, props.logoutUrl);
     } catch (e) {
       setErrorCallOut(constructErrorMessageAndLog(e, 'Failed to reset password.'));
     }

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -27,9 +27,9 @@ export async function fetchAccountInfoSafe(http: HttpStart): Promise<AccountInfo
   return getWithIgnores<AccountInfo>(http, API_ENDPOINT_ACCOUNT_INFO, [401]);
 }
 
-export async function logout(http: HttpStart): Promise<void> {
+export async function logout(http: HttpStart, logoutUrl?: string): Promise<void> {
   await http.post(API_AUTH_LOGOUT);
-  window.location.href = http.basePath.serverBasePath;
+  window.location.href = logoutUrl || http.basePath.serverBasePath;
 }
 
 export async function validateCurrentPassword(

--- a/public/types.ts
+++ b/public/types.ts
@@ -55,6 +55,7 @@ export interface ClientConfigType {
   };
   auth: {
     type: string;
+    logout_url: string;
   };
   clusterPermissions: {
     include: string[];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some IDP needs additional clear up step, which redirect to custom logout page. This change is to respect `opendistro_security.auth.logout_url` as it used to be.

Test:
* yarn tsc 
* yarn test:jest_ui public/apps/account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
