### PR TITLE
fix the extra horizontal rule on profile button for non internal user

### DIFF
--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -99,9 +99,9 @@ export function AccountNavButton(props: {
       >
         Switch tenants
       </EuiButtonEmpty>
-      {horizontalRule}
       {props.isInternalUser && (
         <>
+          {horizontalRule}
           <EuiButtonEmpty
             size="xs"
             onClick={() =>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When isInternalUser is false, there is an extra horizontal rule because logout button has a build in horizontal rule.

*Test*
before
<img width="2553" alt="Screen Shot 2020-10-21 at 11 43 47 AM" src="https://user-images.githubusercontent.com/60111637/96769087-8062a200-1393-11eb-8d8f-fb85489adc08.png">

after
<img width="1283" alt="Screen Shot 2020-10-21 at 11 44 07 AM" src="https://user-images.githubusercontent.com/60111637/96769105-8789b000-1393-11eb-89b3-b8844929cdf8.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
