### PR TITLE
generalize user descriptions related to role mapping for external users

### DIFF
--- a/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
+++ b/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
@@ -141,7 +141,7 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
             <h1>Map user</h1>
           </EuiTitle>
           Map users to this role to inherit role permissions. Two types of users are supported:
-          internal user, and external identity. <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
+          user, and external identity. <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
         </EuiText>
       </EuiPageHeader>
       <EuiSpacer size="m" />

--- a/public/apps/configuration/panels/role-mapping/users-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/users-panel.tsx
@@ -30,18 +30,19 @@ export function InternalUsersPanel(props: {
   setState: Dispatch<SetStateAction<ComboBoxOptions>>;
 }) {
   const { state, optionUniverse, setState } = props;
+  // TODO: improve UX by adding colors to user name pills to distinguish internal user and external user on field population.
   return (
     <PanelWithHeader
       headerText="Users"
       headerSubText="You can create an internal user in internal user database of the security plugin. An
       internal user can have its own backend role and host for an external authentication and
-      authorization."
+      authorization. External users from your identity provider are also supported."
       helpLink={DocLinks.CreateUsersDoc}
     >
       <EuiForm>
         <FormRow
           headerText="Users"
-          helpText="Look up by user name. You can also create new internal user."
+          helpText="Look up by user name. You can also create new internal user or enter external user."
         >
           <EuiFlexGroup>
             <EuiFlexItem style={{ maxWidth: '400px' }}>

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -175,7 +175,7 @@ export function RoleView(props: RoleViewProps) {
       titleSize="s"
       body={
         <EuiText size="s" color="subdued" grow={false}>
-          <p>You can map internal users or external identities to this role</p>
+          <p>You can map users or external identities to this role</p>
         </EuiText>
       }
       actions={
@@ -284,11 +284,10 @@ export function RoleView(props: RoleViewProps) {
                   </h3>
                 </EuiTitle>
                 <EuiText size="xs" color="subdued" className="panel-header-subtext">
-                  You can map two types of users: internal users and external identities. An
-                  internal user can have its own backend role and host for an external
-                  authentication and authorization. An external identity directly maps to roles
-                  through an external authentication system.{' '}
-                  <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
+                  You can map two types of users: users and external identities. A user can have its
+                  own backend role and host for an external authentication and authorization. An
+                  external identity directly maps to roles through an external authentication
+                  system. <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
                 </EuiText>
               </EuiPageContentHeaderSection>
               <EuiPageContentHeaderSection>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We had a PR to allow external users https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/pull/541
More text descriptions need to be update which is the focus of this PR. 

I will add tech writer to the PR for reviewing the text change and notifying for the doc change.

*Test*
|Before|After|
|--|--|
|<img width="1429" alt="Screen Shot 2020-10-21 at 4 03 39 PM" src="https://user-images.githubusercontent.com/60111637/96800759-ef9fbc80-13ba-11eb-8eb1-433dd6819f45.png">|<img width="1413" alt="Screen Shot 2020-10-21 at 4 16 21 PM" src="https://user-images.githubusercontent.com/60111637/96800521-612b3b00-13ba-11eb-89a8-c4cc7913b132.png">|
|<img width="1411" alt="Screen Shot 2020-10-21 at 4 02 31 PM" src="https://user-images.githubusercontent.com/60111637/96800620-959ef700-13ba-11eb-8521-d81decf9d2c2.png">|<img width="1419" alt="Screen Shot 2020-10-21 at 4 07 49 PM" src="https://user-images.githubusercontent.com/60111637/96800677-bbc49700-13ba-11eb-9e5a-04962239e031.png">|







By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
