### PR TITLE
Add unit test for login page

### DIFF
--- a/public/apps/login/__snapshots__/login-page.test.tsx.snap
+++ b/public/apps/login/__snapshots__/login-page.test.tsx.snap
@@ -1,0 +1,195 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Login page renders renders with config value 1`] = `
+<EuiListGroup
+  className="login-wrapper"
+>
+  <EuiImage
+    alt=""
+    url="http://localhost:5601/images/test.png"
+  />
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="m"
+    textAlign="center"
+  >
+    Title1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="s"
+    textAlign="center"
+  >
+    SubTitle1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiForm
+    component="form"
+  >
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        data-test-subj="user-name"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Username"
+        prepend={
+          <EuiIcon
+            type="user"
+          />
+        }
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      isInvalid={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        data-test-subj="password"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Password"
+        prepend={
+          <EuiIcon
+            type="lock"
+          />
+        }
+        type="password"
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        className="test-btn-style"
+        data-test-subj="submit"
+        fill={true}
+        onClick={[Function]}
+        size="s"
+        type="submit"
+      >
+        Log In
+      </EuiButton>
+    </EuiFormRow>
+  </EuiForm>
+</EuiListGroup>
+`;
+
+exports[`Login page renders renders with default value 1`] = `
+<EuiListGroup
+  className="login-wrapper"
+>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="m"
+    textAlign="center"
+  >
+    Please login to Kibana
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="s"
+    textAlign="center"
+  >
+    If you have forgotten your username or password, please ask your system administrator
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiForm
+    component="form"
+  >
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        data-test-subj="user-name"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Username"
+        prepend={
+          <EuiIcon
+            type="user"
+          />
+        }
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      isInvalid={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        data-test-subj="password"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Password"
+        prepend={
+          <EuiIcon
+            type="lock"
+          />
+        }
+        type="password"
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        className="btn-login"
+        data-test-subj="submit"
+        fill={true}
+        onClick={[Function]}
+        size="s"
+        type="submit"
+      >
+        Log In
+      </EuiButton>
+    </EuiFormRow>
+  </EuiForm>
+</EuiListGroup>
+`;

--- a/public/apps/login/login-page.test.tsx
+++ b/public/apps/login/login-page.test.tsx
@@ -1,0 +1,104 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { ClientConfigType } from '../../types';
+import { LoginPage } from './login-page';
+import { validateCurrentPassword } from '../../utils/login-utils';
+
+jest.mock('../../utils/login-utils', () => ({
+  validateCurrentPassword: jest.fn(),
+}));
+
+describe('Login page', () => {
+  const mockHttpStart = {
+    basePath: {
+      serverBasePath: '/app/kibana',
+    },
+  };
+
+  describe('renders', () => {
+    it('renders with config value', () => {
+      const config: ClientConfigType['ui']['basicauth']['login'] = {
+        title: 'Title1',
+        subtitle: 'SubTitle1',
+        showbrandimage: true,
+        brandimage: 'http://localhost:5601/images/test.png',
+        buttonstyle: 'test-btn-style',
+      };
+      const component = shallow(<LoginPage http={mockHttpStart as any} config={config as any} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('renders with default value', () => {
+      const component = shallow(<LoginPage http={mockHttpStart as any} config={{} as any} />);
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('event trigger testing', () => {
+    let component;
+    const setState = jest.fn();
+    const useState = jest.spyOn(React, 'useState');
+
+    beforeEach(() => {
+      useState.mockImplementation((initialValue) => [initialValue, setState]);
+      component = shallow(<LoginPage http={mockHttpStart as any} config={{} as any} />);
+    });
+
+    it('should update user name field on change event', () => {
+      const event = {
+        target: { value: 'dummy' },
+      } as React.ChangeEvent<HTMLInputElement>;
+      component.find('[data-test-subj="user-name"]').simulate('change', event);
+      expect(setState).toBeCalledWith('dummy');
+    });
+
+    it('should update password field on change event', () => {
+      const event = {
+        target: { value: 'dummy' },
+      } as React.ChangeEvent<HTMLInputElement>;
+      component.find('[data-test-subj="password"]').simulate('change', event);
+      expect(setState).toBeCalledWith('dummy');
+    });
+  });
+
+  describe('handle submit event', () => {
+    let component;
+    const useState = jest.spyOn(React, 'useState');
+    const setState = jest.fn();
+
+    beforeEach(() => {
+      useState.mockImplementation(() => ['user1', setState]);
+      useState.mockImplementation(() => ['password1', setState]);
+      component = shallow(<LoginPage http={mockHttpStart as any} config={{} as any} />);
+    });
+
+    it('submit click event', () => {
+      window = Object.create(window);
+      const url = 'http://dummy.com';
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: url,
+        },
+      });
+      component.find('[data-test-subj="submit"]').simulate('click', {
+        preventDefault: () => {},
+      });
+      expect(validateCurrentPassword).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -31,6 +31,7 @@ import { CoreStart } from '../../../../../src/core/public';
 import { ClientConfigType } from '../../types';
 import defaultBrandImage from '../../assets/open_distro_for_elasticsearch_logo_h.svg';
 import { SELECT_TENANT_PAGE_URI } from '../../../common';
+import { validateCurrentPassword } from '../../utils/login-utils';
 
 interface LoginPageDeps {
   http: CoreStart['http'];
@@ -38,8 +39,8 @@ interface LoginPageDeps {
 }
 
 export function LoginPage(props: LoginPageDeps) {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
   const [loginFailed, setloginFailed] = useState(false);
   const [usernameValidationFailed, setUsernameValidationFailed] = useState(false);
   const [passwordValidationFailed, setPasswordValidationFailed] = useState(false);
@@ -74,13 +75,7 @@ export function LoginPage(props: LoginPageDeps) {
     }
 
     try {
-      // @ts-ignore : response not used
-      const response = await props.http.post('/auth/login', {
-        body: JSON.stringify({
-          username,
-          password,
-        }),
-      });
+      await validateCurrentPassword(props.http, username, password);
       // Forward search to keep nextUrl argument
       window.location.href =
         props.http.basePath.serverBasePath + SELECT_TENANT_PAGE_URI + window.location.search;
@@ -110,6 +105,7 @@ export function LoginPage(props: LoginPageDeps) {
       <EuiForm component="form">
         <EuiFormRow>
           <EuiFieldText
+            data-test-subj="user-name"
             placeholder="Username"
             prepend={<EuiIcon type="user" />}
             onChange={(e) => setUsername(e.target.value)}
@@ -119,6 +115,7 @@ export function LoginPage(props: LoginPageDeps) {
         </EuiFormRow>
         <EuiFormRow isInvalid={passwordValidationFailed}>
           <EuiFieldText
+            data-test-subj="password"
             placeholder="Password"
             prepend={<EuiIcon type="lock" />}
             type="password"
@@ -129,6 +126,7 @@ export function LoginPage(props: LoginPageDeps) {
         </EuiFormRow>
         <EuiFormRow>
           <EuiButton
+            data-test-subj="submit"
             fill
             size="s"
             type="submit"

--- a/public/utils/login-utils.tsx
+++ b/public/utils/login-utils.tsx
@@ -1,0 +1,29 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { HttpStart } from 'kibana/public';
+
+export async function validateCurrentPassword(
+  http: HttpStart,
+  userName: string,
+  currentPassword: string
+): Promise<void> {
+  await http.post('/auth/login', {
+    body: JSON.stringify({
+      username: userName,
+      password: currentPassword,
+    }),
+  });
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add unit test for login page

```
opendistro_security % yarn test:jest_ui public/apps/login** -u           
yarn run v1.22.4
$ node ./test/run_jest_tests.js --config ./test/jest.config.ui.js public/apps/login -u
 PASS  public/apps/login/login-page.test.tsx
  Login page
    renders
      ✓ renders with config value (11ms)
      ✓ renders with default value (1ms)
    event trigger testing
      ✓ should update user name field on change event (4ms)
      ✓ should update password field on change event (2ms)
    handle submit event
      ✓ submit click event (2ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   2 passed, 2 total
Time:        4.02s
Ran all test suites matching /public\/apps\/login/i.
✨  Done in 8.61s.
```

Before:
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                            |   65.99 |    63.72 |   53.17 |   66.55 |                    

After:
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s    
-----------------------------------------------------|---------|----------|---------|---------|----------------------
All files                                            |   67.35 |    66.37 |   53.88 |   67.95 |       

- Ran yarn tsc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
