### PR TITLE
Fix nav link replace url to use baseUrl

### DIFF
--- a/public/services/chrome_wrapper.js
+++ b/public/services/chrome_wrapper.js
@@ -61,7 +61,7 @@ function resetLastSubUrl(id) {
   }
 
    if (getNewPlatform) {
-    updateNavLinkProperty(id, 'url', navLink.subUrlBase);
+    updateNavLinkProperty(id, 'url', navLink.baseUrl);
   } else {
     navLink.lastSubUrl = navLink.url;
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- While selecting multi-tenant we are incorrectly replacing the urls of the apps kibana:visualize kibana:dashboard kibana:discover timelion
- `subUrlBase` does not have the Kibana base path prefixed. If base path is configured, accessing the above app url complains it cannot find them because 

`/app/kibana#/discover` is used instead of `_plugin/kibana/app/kibana#/discover` if `_plugin/kibana` is the base path. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
