### PR TITLE
always try to fetch security tenant from cookie

### DIFF
--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -68,7 +68,7 @@ export class BasicAuthentication extends AuthenticationType {
     return {};
   }
 
-  async getCookie(request: KibanaRequest, authInfo: any): Promise<SecuritySessionCookie> {
+  getCookie(request: KibanaRequest, authInfo: any): SecuritySessionCookie {
     if (
       this.config.auth.anonymous_auth_enabled &&
       authInfo.user_name === 'opendistro_security_anonymous'
@@ -76,7 +76,7 @@ export class BasicAuthentication extends AuthenticationType {
       return {
         username: authInfo.user_name,
         authType: this.type,
-        expiryTime: Date.now() + this.config.cookie.ttl,
+        expiryTime: Date.now() + this.config.session.ttl,
         isAnonymousAuth: true,
       };
     }
@@ -86,7 +86,7 @@ export class BasicAuthentication extends AuthenticationType {
         authHeaderValue: request.headers[BasicAuthentication.AUTH_HEADER_NAME],
       },
       authType: this.type,
-      expiryTime: Date.now() + this.config.cookie.ttl,
+      expiryTime: Date.now() + this.config.session.ttl,
     };
   }
 

--- a/server/auth/types/jwt/jwt_auth.ts
+++ b/server/auth/types/jwt/jwt_auth.ts
@@ -97,17 +97,17 @@ export class JwtAuthentication extends AuthenticationType {
     return header;
   }
 
-  protected async getCookie(
+  protected getCookie(
     request: KibanaRequest<unknown, unknown, unknown, any>,
     authInfo: any
-  ): Promise<SecuritySessionCookie> {
+  ): SecuritySessionCookie {
     return {
       username: authInfo.user_name,
       credentials: {
         authHeaderValue: this.getBearerToken(request),
       },
       authType: this.type,
-      expiryTime: Date.now() + this.config.cookie.ttl,
+      expiryTime: Date.now() + this.config.session.ttl,
     };
   }
 

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -114,14 +114,14 @@ export class OpenIdAuthentication extends AuthenticationType {
     return {};
   }
 
-  async getCookie(request: KibanaRequest, authInfo: any): Promise<SecuritySessionCookie> {
+  getCookie(request: KibanaRequest, authInfo: any): SecuritySessionCookie {
     return {
       username: authInfo.user_name,
       credentials: {
         authHeaderValue: request.headers.authorization,
       },
       authType: this.type,
-      expiryTime: Date.now() + this.config.cookie.ttl,
+      expiryTime: Date.now() + this.config.session.ttl,
     };
   }
 

--- a/server/auth/types/proxy/proxy_auth.ts
+++ b/server/auth/types/proxy/proxy_auth.ts
@@ -89,13 +89,13 @@ export class ProxyAuthentication extends AuthenticationType {
     return authHeaders;
   }
 
-  async getCookie(request: KibanaRequest, authInfo: any): Promise<SecuritySessionCookie> {
+  getCookie(request: KibanaRequest, authInfo: any): SecuritySessionCookie {
     const cookie: SecuritySessionCookie = {
       username: authInfo.username,
       credentials: {},
       authType: this.authType,
       isAnonymousAuth: false,
-      expiryTime: Date.now() + this.config.cookie.ttl,
+      expiryTime: Date.now() + this.config.session.ttl,
     };
 
     if (this.userHeaderName && request.headers[this.userHeaderName]) {
@@ -109,12 +109,6 @@ export class ProxyAuthentication extends AuthenticationType {
     }
     if (request.headers.authorization) {
       cookie.credentials.authorization = request.headers.authorization;
-    }
-
-    // set tenant from cookie if exist
-    const browserCookie = await this.sessionStorageFactory.asScoped(request).get();
-    if (browserCookie && isValidTenant(browserCookie.tenant)) {
-      cookie.tenant = browserCookie.tenant;
     }
     return cookie;
   }

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -79,14 +79,14 @@ export class SamlAuthentication extends AuthenticationType {
     return {};
   }
 
-  async getCookie(request: KibanaRequest, authInfo: any): Promise<SecuritySessionCookie> {
+  getCookie(request: KibanaRequest, authInfo: any): SecuritySessionCookie {
     return {
       username: authInfo.user_name,
       credentials: {
         authHeaderValue: request.headers[SamlAuthentication.AUTH_HEADER_NAME],
       },
       authType: this.type,
-      expiryTime: Date.now() + this.config.cookie.ttl,
+      expiryTime: Date.now() + this.config.session.ttl,
     };
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The existing implementation will ignore browser cookie when auth headers are provided in the request, but this will ignore the tenant selection when customer has a proxy to inject auth header but still auth types like basic auth.

With this change, Kibana will alway try to extract the tenant from cookie when auth header is provided in the request.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
