### PR TITLE
Fix invalid search

### DIFF
--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -69,7 +69,7 @@ const TRUE_STRING = 'True';
 const FALSE_STRING = 'False';
 
 export function AuthenticationSequencePanel(props: { authc: []; loading: boolean }) {
-  const [query, setQuery] = useState<string>('');
+  const [query, setQuery] = useState<Query | null>(null);
   const domains = keys(props.authc);
 
   const items = map(domains, function (domain: string) {
@@ -99,7 +99,7 @@ export function AuthenticationSequencePanel(props: { authc: []; loading: boolean
       placeholder: 'Search authentication domain',
     },
     onChange: (arg) => {
-      setQuery(arg.queryText);
+      setQuery(arg.query);
       return true;
     },
   };
@@ -113,7 +113,7 @@ export function AuthenticationSequencePanel(props: { authc: []; loading: boolean
       backend they should be authenticated. When there are multiple authentication domains, the plugin will authenticate
       the user sequentially against each backend until one succeeds."
       helpLink={DocLinks.BackendConfigurationAuthenticationDoc}
-      count={Query.execute(query, items).length}
+      count={Query.execute(query || '', items).length}
     >
       <EuiInMemoryTable
         tableLayout={'auto'}

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -62,7 +62,7 @@ const emptyListMessage = (
 );
 
 export function AuthorizationPanel(props: { authz: []; loading: boolean }) {
-  const [query, setQuery] = useState<string>('');
+  const [query, setQuery] = useState<Query | null>(null);
   const domains = keys(props.authz);
 
   const items = map(domains, function (domain: string) {
@@ -85,7 +85,7 @@ export function AuthorizationPanel(props: { authz: []; loading: boolean }) {
       placeholder: 'Search authorization domain',
     },
     onChange: (arg) => {
-      setQuery(arg.queryText);
+      setQuery(arg.query);
       return true;
     },
   };
@@ -97,7 +97,7 @@ export function AuthorizationPanel(props: { authz: []; loading: boolean }) {
       headerText={headerText}
       headerSubText="After the user authenticates, the security plugin can collect external identities, such as LDAP groups, from authorization backends. These backends have no execution order; the plugin tries to collect external identities from all of them."
       helpLink={DocLinks.BackendConfigurationAuthorizationDoc}
-      count={Query.execute(query, items).length}
+      count={Query.execute(query || '', items).length}
     >
       <EuiInMemoryTable
         tableLayout={'auto'}

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -146,6 +146,7 @@ const SEARCH_OPTIONS: EuiSearchBarProps = {
       field: 'type',
       name: 'All types',
       options: [{ value: 'Action group' }, { value: 'Single permission' }],
+      multiSelect: false,
     },
     {
       type: 'field_value_selection',
@@ -188,7 +189,7 @@ export function PermissionList(props: AppDependencies) {
 
   const [loading, setLoading] = useState(false);
 
-  const [query, setQuery] = useState<string>('');
+  const [query, setQuery] = useState<Query | null>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -340,7 +341,7 @@ export function PermissionList(props: AppDependencies) {
                 Permissions
                 <span className="panel-header-count">
                   {' '}
-                  ({Query.execute(query, permissionList).length})
+                  ({Query.execute(query || '', permissionList).length})
                 </span>
               </h3>
             </EuiTitle>
@@ -370,7 +371,7 @@ export function PermissionList(props: AppDependencies) {
             search={{
               ...SEARCH_OPTIONS,
               onChange: (arg) => {
-                setQuery(arg.queryText);
+                setQuery(arg.query);
                 return true;
               },
             }}

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -182,11 +182,11 @@ export function RoleList(props: AppDependencies) {
   const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);
 
   const [searchOptions, setSearchOptions] = useState<EuiSearchBarProps>({});
-  const [query, setQuery] = useState<string>('');
+  const [query, setQuery] = useState<Query | null>(null);
   useEffect(() => {
     setSearchOptions({
       onChange: (arg) => {
-        setQuery(arg.queryText);
+        setQuery(arg.query);
         return true;
       },
       filters: [
@@ -194,30 +194,35 @@ export function RoleList(props: AppDependencies) {
           type: 'field_value_selection',
           field: 'clusterPermissions',
           name: 'Cluster permissions',
+          multiSelect: 'or',
           options: buildSearchFilterOptions(roleData, 'clusterPermissions'),
         },
         {
           type: 'field_value_selection',
           field: 'indexPermissions',
           name: 'Index permissions',
+          multiSelect: 'or',
           options: buildSearchFilterOptions(roleData, 'indexPermissions'),
         },
         {
           type: 'field_value_selection',
           field: 'internalUsers',
           name: 'Internal users',
+          multiSelect: 'or',
           options: buildSearchFilterOptions(roleData, 'internalUsers'),
         },
         {
           type: 'field_value_selection',
           field: 'backendRoles',
           name: 'External identities',
+          multiSelect: 'or',
           options: buildSearchFilterOptions(roleData, 'backendRoles'),
         },
         {
           type: 'field_value_selection',
           field: 'tenantPermissions',
           name: 'Tenants',
+          multiSelect: 'or',
           options: buildSearchFilterOptions(roleData, 'tenantPermissions'),
         },
         {
@@ -255,7 +260,7 @@ export function RoleList(props: AppDependencies) {
                 Roles
                 <span className="panel-header-count">
                   {' '}
-                  ({Query.execute(query, roleData).length})
+                  ({Query.execute(query || '', roleData).length})
                 </span>
               </h3>
             </EuiTitle>

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -72,7 +72,7 @@ export function TenantList(props: AppDependencies) {
   const [toasts, addToast, removeToast] = useToastState();
   const [loading, setLoading] = useState(false);
 
-  const [query, setQuery] = useState<string>('');
+  const [query, setQuery] = useState<Query | null>(null);
 
   // Configuration
   const isPrivateEnabled = props.config.multitenancy.tenants.enable_private;
@@ -339,7 +339,7 @@ export function TenantList(props: AppDependencies) {
                 Tenants
                 <span className="panel-header-count">
                   {' '}
-                  ({Query.execute(query, tenantData).length})
+                  ({Query.execute(query || '', tenantData).length})
                 </span>
               </h3>
             </EuiTitle>
@@ -379,7 +379,7 @@ export function TenantList(props: AppDependencies) {
             search={{
               box: { placeholder: 'Find tenant' },
               onChange: (arg) => {
-                setQuery(arg.queryText);
+                setQuery(arg.query);
                 return true;
               },
             }}

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -96,7 +96,7 @@ export function UserList(props: AppDependencies) {
   const [selection, setSelection] = useState<InternalUsersListing[]>([]);
   const [currentUsername, setCurrentUsername] = useState('');
   const [loading, setLoading] = useState(false);
-  const [query, setQuery] = useState<string>('');
+  const [query, setQuery] = useState<Query | null>(null);
 
   React.useEffect(() => {
     const fetchData = async () => {
@@ -199,7 +199,7 @@ export function UserList(props: AppDependencies) {
                 Internal users
                 <span className="panel-header-count">
                   {' '}
-                  ({Query.execute(query, userData).length})
+                  ({Query.execute(query || '', userData).length})
                 </span>
               </h3>
             </EuiTitle>
@@ -235,7 +235,7 @@ export function UserList(props: AppDependencies) {
             search={{
               box: { placeholder: 'Search internal users' },
               onChange: (arg) => {
-                setQuery(arg.queryText);
+                setQuery(arg.query);
                 return true;
               },
             }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added `OR` condition in multi select.
- Issue Fix: If user enters invalid search text (e.g. `(cluster`, `cluster)`, `[cluster`, `cluster]`, etc.) in the search bar, it was causing whole page to disappear. Fix the issue.

Steps to reproduce the issue:
1. Type `name: (tenant2` in the search bar and press enter.
![image](https://user-images.githubusercontent.com/63824432/96947074-f8fe5700-1496-11eb-87a5-d4e535a1f4a9.png)

2. Result: Tenant page disappeared. 
![image](https://user-images.githubusercontent.com/63824432/96947100-0f0c1780-1497-11eb-874e-88582563bb89.png)

After fixing issue:
If user enters invalid search text in search bar, it will return full list and highlight the search bar with red underline.
![image](https://user-images.githubusercontent.com/63824432/96947192-6316fc00-1497-11eb-9db5-cd7b16dc7c46.png)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
