### PR TITLE
extend session using session ttl config instead of cookie ttl

### DIFF
--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -100,7 +100,7 @@ export class BasicAuthRoutes {
           },
           authType: 'basicauth',
           isAnonymousAuth: false,
-          expiryTime: Date.now() + this.config.cookie.ttl,
+          expiryTime: Date.now() + this.config.session.ttl,
         };
 
         if (this.config.multitenancy?.enabled) {
@@ -172,7 +172,7 @@ export class BasicAuthRoutes {
             username: user.username,
             authType: 'basicauth',
             isAnonymousAuth: true,
-            expiryTime: Date.now() + this.config.cookie.ttl,
+            expiryTime: Date.now() + this.config.session.ttl,
           };
 
           if (this.config.multitenancy?.enabled) {

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -149,7 +149,7 @@ export class OpenIdAuthRoutes {
               expires_at: Date.now() + tokenResponse.expiresIn! * 1000, // expiresIn is in second
             },
             authType: 'openid',
-            expiryTime: Date.now() + this.config.cookie.ttl,
+            expiryTime: Date.now() + this.config.session.ttl,
           };
           this.sessionStorageFactory.asScoped(request).set(sessionStorage);
           return response.redirected({

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -120,7 +120,7 @@ export class SamlAuthRoutes {
               authHeaderValue: credentials.authorization,
             },
             authType: 'saml', // TODO: create constant
-            expiryTime: Date.now() + this.config.cookie.ttl,
+            expiryTime: Date.now() + this.config.session.ttl,
           };
           this.sessionStorageFactory.asScoped(request).set(cookie);
           return response.redirected({
@@ -167,7 +167,7 @@ export class SamlAuthRoutes {
               authHeaderValue: credentials.authorization,
             },
             authType: 'saml', // TODO: create constant
-            expiryTime: Date.now() + this.config.cookie.ttl,
+            expiryTime: Date.now() + this.config.session.ttl,
           };
           this.sessionStorageFactory.asScoped(request).set(cookie);
           return response.redirected({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* when extending session ttl, we should use session.ttl config instead of cookie ttl, this change fixed this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
