### PR TITLE
fix failed audit logging unit test

### DIFF
--- a/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
@@ -31,6 +31,7 @@ describe('Audit logs', () => {
 
   beforeEach(() => {
     jest.spyOn(React, 'useState').mockImplementation((initialValue) => [initialValue, setState]);
+    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
   });
 
   it('Render disabled', () => {
@@ -53,8 +54,6 @@ describe('Audit logs', () => {
   });
 
   it('Render enabled', (done) => {
-    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
-
     const mockAuditLoggingData = {
       enabled: true,
       audit: '',
@@ -74,11 +73,10 @@ describe('Audit logs', () => {
   });
 
   it('Render error', (done) => {
-    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
     // Hide the error message
     jest.spyOn(console, 'log').mockImplementationOnce(() => {});
 
-    mockAuditLoggingUtils.getAuditLogging.mockImplementationOnce(() => {
+    mockAuditLoggingUtils.getAuditLogging = jest.fn().mockImplementationOnce(() => {
       throw Error();
     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the syntax.

Now the result is 


a483e79af39a:opendistro_security tianleh$ yarn test:jest_ui public/apps/configuration/panels/audit-logging
yarn run v1.22.5
$ node ./test/run_jest_tests.js --config ./test/jest.config.ui.js public/apps/configuration/panels/audit-logging
 PASS  public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
 PASS  public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
 PASS  public/apps/configuration/panels/audit-logging/test/view-setting-group.test.tsx
 PASS  public/apps/configuration/panels/audit-logging/test/edit-setting-group.test.tsx
 PASS  public/apps/configuration/panels/audit-logging/test/code-editor.test.tsx

Test Suites: 5 passed, 5 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        6.907s, estimated 8s
Ran all test suites matching /public\/apps\/configuration\/panels\/audit-logging/i.
✨  Done in 12.99s.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
