### PR TITLE
Fix a url injection issue caused by resource name

### DIFF
--- a/common/index.test.ts
+++ b/common/index.test.ts
@@ -1,0 +1,46 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { isValidResourceName } from './index';
+
+describe('Test isValidResourceName', () => {
+  it('Empty is invalid', () => {
+    expect(isValidResourceName('')).toBe(false);
+  });
+
+  it('Length 1 is valid', () => {
+    expect(isValidResourceName('a')).toBe(true);
+  });
+
+  it('Dash, underscore, bracket, number and letter are valid', () => {
+    expect(isValidResourceName('-_(1)a')).toBe(true);
+  });
+
+  it('Dot is invalid', () => {
+    expect(isValidResourceName('.')).toBe(false);
+  });
+
+  it('Slash is invalid', () => {
+    expect(isValidResourceName('/')).toBe(false);
+  });
+
+  it('Percent sign is invalid', () => {
+    expect(isValidResourceName('%')).toBe(false);
+  });
+
+  it('Unicode is valid', () => {
+    expect(isValidResourceName('Düsseldorf_Köln_Москва_北京市_إسرائيل')).toBe(true);
+  });
+});

--- a/common/index.test.ts
+++ b/common/index.test.ts
@@ -40,6 +40,18 @@ describe('Test isValidResourceName', () => {
     expect(isValidResourceName('%')).toBe(false);
   });
 
+  it('Question mark is invalid', () => {
+    expect(isValidResourceName('?')).toBe(false);
+  });
+
+  it('Hash is invalid', () => {
+    expect(isValidResourceName('#')).toBe(false);
+  });
+
+  it('And sign is invalid', () => {
+    expect(isValidResourceName('&')).toBe(false);
+  });
+
   it('Unicode is valid', () => {
     expect(isValidResourceName('Düsseldorf_Köln_Москва_北京市_إسرائيل')).toBe(true);
   });

--- a/common/index.ts
+++ b/common/index.ts
@@ -31,3 +31,14 @@ export enum AuthType {
   SAML = 'saml',
   PROXY = 'proxy',
 }
+
+/**
+ * A valid resource name should contain only letters (can be unicode chars), numbers, dash and underscore.
+ * Here we don't limit length (except empty) or block brackets to be more compatible with previous version.
+ * Dot (.), slash (/) and percent sign (%) are prohibited as they raise url injection issue.
+ * @param resourceName resource name to be validated
+ */
+export function isValidResourceName(resourceName: string): boolean {
+  // see: https://javascript.info/regexp-unicode
+  return /^[\p{L}\p{N}\p{Pc}\p{Pd}\p{Ps}\p{Pe}]+$/u.test(resourceName);
+}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   "dependencies": {
     "@hapi/wreck": "17.0.0",
     "@hapi/cryptiles": "5.0.0",
-    "html-entities": "1.3.1",
-    "xregexp": "4.3.0",
-    "@types/xregexp": "4.3.0"
+    "html-entities": "1.3.1"
   }
 }

--- a/public/apps/configuration/utils/resource-validation-util.tsx
+++ b/public/apps/configuration/utils/resource-validation-util.tsx
@@ -12,14 +12,12 @@
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.
  */
-import XRegExp from 'xregexp';
-import { isEmpty } from 'lodash';
+
+import { isValidResourceName } from '../../../../common';
 import {
   MIN_NUMBER_OF_CHARS_IN_RESOURCE_NAME,
   MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME,
 } from '../constants';
-
-const RESOURCE_ID_REGEX = XRegExp('^[\\p{L}\\p{N}\\p{P}-]+$', 'u');
 
 const VALID_LENGTH_HELP_TEXT = (resourceType: string) => {
   return `The ${resourceType} name must contain from ${MIN_NUMBER_OF_CHARS_IN_RESOURCE_NAME} to ${MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME} characters.`;
@@ -34,7 +32,7 @@ export function validateResourceName(resourceType: string, resourceName: string)
     errors.push(VALID_LENGTH_HELP_TEXT(resourceType));
   }
 
-  if (!isResourceNameValid(resourceName)) {
+  if (!isValidResourceName(resourceName)) {
     errors.push(`Invalid characters found in ${resourceType} name. ${VALID_CHARACTERS_HELP_TEXT}`);
   }
   return errors;
@@ -46,13 +44,6 @@ export function isResourceNameLengthValid(resourceName: string): boolean {
     resourceName.length > MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME
   )
     return false;
-  return true;
-}
-
-export function isResourceNameValid(resourceName: string): boolean {
-  if (!isEmpty(resourceName) && !XRegExp.test(resourceName, RESOURCE_ID_REGEX)) {
-    return false;
-  }
   return true;
 }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,11 +15,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { IRouter, ResponseError, IKibanaResponse, KibanaResponseFactory } from 'kibana/server';
-import XRegExp from 'xregexp';
-import { API_PREFIX, CONFIGURATION_API_PREFIX } from '../../common';
-
-// see: https://www.npmjs.com/package/xregexp & https://javascript.info/regexp-unicode
-const RESOURCE_ID_REGEX = XRegExp('^[\\p{L}\\p{N}]+[\\p{L}\\p{N}\\p{P}-]*$', 'u');
+import { API_PREFIX, CONFIGURATION_API_PREFIX, isValidResourceName } from '../../common';
 
 // TODO: consider to extract entity CRUD operations and put it into a client class
 export function defineRoutes(router: IRouter) {
@@ -82,7 +78,7 @@ export function defineRoutes(router: IRouter) {
   }
 
   function validateEntityId(resourceName: string) {
-    if (!XRegExp.test(resourceName, RESOURCE_ID_REGEX)) {
+    if (!isValidResourceName(resourceName)) {
       return 'Invalid entity name or id.';
     }
   }

--- a/test/jest.config.ui.js
+++ b/test/jest.config.ui.js
@@ -18,7 +18,7 @@ import config from '../../../src/dev/jest/config';
 export default {
   ...config,
   roots: ['<rootDir>/plugins/opendistro_security'],
-  testMatch: ['**/public/**/*.test.{ts,tsx}', '**/public/**/*.test.{js,jsx}'],
+  testMatch: ['**/public/**/*.test.{ts,tsx,js,jsx}', '**/common/*.test.{ts, tsx}'],
   testPathIgnorePatterns: [
     '<rootDir>/plugins/opendistro_security/build/',
     '<rootDir>/plugins/opendistro_security/node_modules/',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
User can create some resource name like "a/../../roles/roleName" to inject url manipulation. Previously leading punctuation (including dot) is but it is not complete. It can starts with other chars and then dot (like "a/../../roles/roleName"), and also starts with "/" or "%2F".

This PR does:
1. Replace punctuation script `\p{P}` with some subsets (`\p{Pc}\p{Pd}\p{Ps}\p{Pe}`). Basically it includes `-_()`, see also [link](https://javascript.info/regexp-unicode) for more details.
2. Remove XRegExp as unicode is supported natively since node 8 (kibana 7.9 is using node 10). See [node website](https://node.green/) and search for `"u" flag`.
3. Add unit test to cover unknown cases.

Test:
`yarn test:jest_ui common/index.test.ts` passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
