### PR TITLE
Fix default cookie sameSite config

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -42,7 +42,12 @@ export const configSchema = schema.object({
     ttl: schema.number({ defaultValue: 60 * 60 * 1000 }),
     domain: schema.nullable(schema.string()),
     isSameSite: schema.oneOf(
-      [schema.literal('Strict'), schema.literal('Lax'), schema.literal(false)],
+      [
+        schema.literal('Strict'),
+        schema.literal('Lax'),
+        schema.literal('None'),
+        schema.literal(false),
+      ],
       { defaultValue: false }
     ),
   }),

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -69,6 +69,6 @@ export function getSecurityCookieOptions(
       return { isValid: true, path: '/' };
     },
     isSecure: config.cookie.secure,
-    sameSite: config.cookie.isSameSite || 'None',
+    sameSite: config.cookie.isSameSite || undefined,
   };
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fix `FATAL  Error: "SameSite: None" requires Secure connection` due to cookie sameSite config.
When cookie sameSite is set to `None` explicitly, Kibana will fail to start when secure cookie is off. https://github.com/elastic/kibana/blob/master/src/core/server/http/cookie_session_storage.ts#L112 

This change default to not set the sameSite setting, which will let the browser to determine which option to use. This is also the same behavior as the legacy plugin


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
