### PR TITLE
Update validateNextUrl function

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:es": "node ../../scripts/eslint",
     "lint:sass": "node ../../scripts/sasslint",
     "lint": "yarn run lint:es && yarn run lint:sass",
-    "test:jest_server": "node ./test/run_jest_tests.js --config ./test/jest.config.integration.js",
+    "test:jest_server": "node ./test/run_jest_tests.js --config ./test/jest.config.server.js",
     "test:jest_ui": "node ./test/run_jest_tests.js --config ./test/jest.config.ui.js"
   },
   "devDependencies": {

--- a/server/utils/next_url.test.ts
+++ b/server/utils/next_url.test.ts
@@ -50,5 +50,4 @@ describe('test validateNextUrl', () => {
     const url = '/test/path?key=a@b&k2=v';
     expect(validateNextUrl(url)).toEqual(undefined);
   });
-
 });

--- a/server/utils/next_url.test.ts
+++ b/server/utils/next_url.test.ts
@@ -1,0 +1,54 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { validateNextUrl, INVALID_NEXT_URL_PARAMETER_MESSAGE } from './next_url';
+
+describe('test validateNextUrl', () => {
+  test('accept relative url', () => {
+    const url = '/relative/path';
+    expect(validateNextUrl(url)).toEqual(undefined);
+  });
+
+  test('accept relative url with # and query', () => {
+    const url = '/relative/path#hash?a=b';
+    expect(validateNextUrl(url)).toEqual(undefined);
+  });
+
+  test('reject url not start with /', () => {
+    const url = 'exmaple.com/relative/path';
+    expect(validateNextUrl(url)).toEqual(INVALID_NEXT_URL_PARAMETER_MESSAGE);
+  });
+
+  test('reject absolute url', () => {
+    const url = 'https://exmaple.com/relative/path';
+    expect(validateNextUrl(url)).toEqual(INVALID_NEXT_URL_PARAMETER_MESSAGE);
+  });
+
+  test('reject url starts with //', () => {
+    const url = '//exmaple.com/relative/path';
+    expect(validateNextUrl(url)).toEqual(INVALID_NEXT_URL_PARAMETER_MESSAGE);
+  });
+
+  test('reject url path contains @', () => {
+    const url = '/a@b/path';
+    expect(validateNextUrl(url)).toEqual(INVALID_NEXT_URL_PARAMETER_MESSAGE);
+  });
+
+  test('accpet url has @ in query parameters', () => {
+    const url = '/test/path?key=a@b&k2=v';
+    expect(validateNextUrl(url)).toEqual(undefined);
+  });
+
+});

--- a/server/utils/next_url.ts
+++ b/server/utils/next_url.ts
@@ -32,7 +32,8 @@ export const INVALID_NEXT_URL_PARAMETER_MESSAGE = 'Invalid nextUrl parameter.';
  *   1. starts with '/'
  *   2. not start with '//'
  *   3. does not contain '@' in the path
- * @param url
+ * @param url url string.
+ * @returns error message if nextUrl is invalid, otherwise void.
  */
 export const validateNextUrl = (url: string | undefined): string | void => {
   if (url) {

--- a/server/utils/next_url.ts
+++ b/server/utils/next_url.ts
@@ -25,7 +25,7 @@ export function composeNextUrlQeuryParam(request: KibanaRequest, basePath: strin
   return stringify({ nextUrl });
 }
 
-export const INVALID_NEXT_URL_PARAMETER_MESSAGE = 'Invalid nextUrl parameter.'
+export const INVALID_NEXT_URL_PARAMETER_MESSAGE = 'Invalid nextUrl parameter.';
 
 /**
  * Ensures the nextUrl parameter is a relative url, the nextUrl parameter should:

--- a/server/utils/next_url.ts
+++ b/server/utils/next_url.ts
@@ -25,8 +25,20 @@ export function composeNextUrlQeuryParam(request: KibanaRequest, basePath: strin
   return stringify({ nextUrl });
 }
 
+export const INVALID_NEXT_URL_PARAMETER_MESSAGE = 'Invalid nextUrl parameter.'
+
+/**
+ * Ensures the nextUrl parameter is a relative url, the nextUrl parameter should:
+ *   1. starts with '/'
+ *   2. not start with '//'
+ *   3. does not contain '@' in the path
+ * @param url
+ */
 export const validateNextUrl = (url: string | undefined): string | void => {
-  if (url && url.toLowerCase().includes('//')) {
-    return 'invalid nextUrl parameter';
+  if (url) {
+    const path = url.split('?')[0];
+    if (!path.startsWith('/') || path.startsWith('//') || path.includes('@')) {
+      return INVALID_NEXT_URL_PARAMETER_MESSAGE;
+    }
   }
 };

--- a/test/jest.config.server.js
+++ b/test/jest.config.server.js
@@ -18,13 +18,13 @@ import config from '../../../src/dev/jest/config';
 export default {
   ...config,
   roots: ['<rootDir>/plugins/opendistro_security'],
-  testMatch: ['**/test/jest_integration/**/*.test.ts'],
+  testMatch: ['**/test/jest_integration/**/*.test.ts', '**/server/**/*.test.ts'],
   testPathIgnorePatterns: config.testPathIgnorePatterns.filter(
     (pattern) => !pattern.includes('integration_tests')
   ),
   setupFilesAfterEnv: [
     '<rootDir>/src/dev/jest/setup/after_env.integration.js',
-    '<rootDir>/plugins/opendistro_security/test/es/setup_es.js',
+    // '<rootDir>/plugins/opendistro_security/test/es/setup_es.js',
   ],
   collectCoverageFrom: [
     '<rootDir>/plugins/opendistro_security/server/**/*.{ts,tsx}',

--- a/test/jest.config.server.js
+++ b/test/jest.config.server.js
@@ -24,7 +24,7 @@ export default {
   ),
   setupFilesAfterEnv: [
     '<rootDir>/src/dev/jest/setup/after_env.integration.js',
-    // '<rootDir>/plugins/opendistro_security/test/es/setup_es.js',
+    '<rootDir>/plugins/opendistro_security/test/es/setup_es.js',
   ],
   collectCoverageFrom: [
     '<rootDir>/plugins/opendistro_security/server/**/*.{ts,tsx}',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Update the `validateNextUrl` function to ensure nextUrl is a relative url.
```
% yarn test:jest_server ./server/utils/next_url.test.ts
yarn run v1.22.0
$ node ./test/run_jest_tests.js --config ./test/jest.config.server.js ./server/utils/next_url.test.ts
 PASS  server/utils/next_url.test.ts
  test validateNextUrl
    ✓ accept relative url (4ms)
    ✓ accept relative url with # and query
    ✓ reject url not start with /
    ✓ reject absolute url (1ms)
    ✓ reject url starts with //
    ✓ reject url path contains @
    ✓ accpet url has @ in query parameters

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        3.036s
Ran all test suites matching /.\/server\/utils\/next_url.test.ts/i.
✨  Done in 9.18s.
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
