### PR TITLE
More test cases for Account menu

### DIFF
--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -27,7 +27,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { CoreStart } from 'kibana/public';
-import React, { useState } from 'react';
+import React from 'react';
 import { RoleInfoPanel } from './role-info-panel';
 import { PasswordResetPanel } from './password-reset-panel';
 import { TenantSwitchPanel } from './tenant-switch-panel';
@@ -42,8 +42,8 @@ export function AccountNavButton(props: {
   tenant?: string;
   config: ClientConfigType;
 }) {
-  const [isPopoverOpen, setPopoverOpen] = useState<boolean>(false);
-  const [modal, setModal] = useState<React.ReactNode>(null);
+  const [isPopoverOpen, setPopoverOpen] = React.useState<boolean>(false);
+  const [modal, setModal] = React.useState<React.ReactNode>(null);
   const horizontalRule = <EuiHorizontalRule margin="xs" />;
   const username = props.username;
   const contextMenuPanel = (
@@ -74,6 +74,7 @@ export function AccountNavButton(props: {
 
       {horizontalRule}
       <EuiButtonEmpty
+        data-test-subj="view-roles-and-identities"
         size="xs"
         onClick={() => setModal(<RoleInfoPanel {...props} handleClose={() => setModal(null)} />)}
       >
@@ -81,6 +82,7 @@ export function AccountNavButton(props: {
       </EuiButtonEmpty>
       {horizontalRule}
       <EuiButtonEmpty
+        data-test-subj="switch-tenants"
         size="xs"
         onClick={() =>
           setModal(
@@ -102,6 +104,7 @@ export function AccountNavButton(props: {
         <>
           {horizontalRule}
           <EuiButtonEmpty
+            data-test-subj="reset-password"
             size="xs"
             onClick={() =>
               setModal(
@@ -128,6 +131,7 @@ export function AccountNavButton(props: {
   );
   return (
     <EuiHeaderSectionItemButton
+      data-test-subj="account-header-section-button"
       onClick={() => {
         setPopoverOpen((prevState) => !prevState);
       }}

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -56,6 +56,8 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   const [tenants, setTenants] = React.useState<string[]>([]);
   const [username, setUsername] = React.useState<string>('');
   const [errorCallOut, setErrorCallOut] = React.useState<string>('');
+  const [tenantSwitchRadioIdSelected, setTenantSwitchRadioIdSelected] = React.useState<string>();
+  const [selectedCustomTenantOption, setSelectedCustomTenantOption] = React.useState<string>('');
 
   const setCurrentTenant = (currentRawTenantName: string, currentUserName: string) => {
     const resolvedTenantName = resolveTenantName(currentRawTenantName, currentUserName);
@@ -93,7 +95,6 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   }, [props.coreStart.http]);
 
   // Custom tenant super select related.
-  const [selectedCustomTenantOption, setSelectedCustomTenantOption] = React.useState<string>('');
   const onCustomTenantChange = (selectedOption: string) => {
     setSelectedCustomTenantOption(selectedOption);
     setTenantSwitchRadioIdSelected(CUSTOM_TENANT_RADIO_ID);
@@ -179,7 +180,6 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
     },
   ];
 
-  const [tenantSwitchRadioIdSelected, setTenantSwitchRadioIdSelected] = React.useState<string>();
   const onTenantSwitchRadioChange = (radioId: string) => {
     setTenantSwitchRadioIdSelected(radioId);
     setErrorCallOut('');

--- a/public/apps/account/test/__snapshots__/account-nav-button.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/account-nav-button.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Account navigation button renders 1`] = `
 <EuiHeaderSectionItemButton
+  data-test-subj="account-header-section-button"
   onClick={[Function]}
 >
   <EuiPopover
@@ -75,6 +76,7 @@ exports[`Account navigation button renders 1`] = `
           margin="xs"
         />
         <EuiButtonEmpty
+          data-test-subj="view-roles-and-identities"
           onClick={[Function]}
           size="xs"
         >
@@ -84,6 +86,7 @@ exports[`Account navigation button renders 1`] = `
           margin="xs"
         />
         <EuiButtonEmpty
+          data-test-subj="switch-tenants"
           onClick={[Function]}
           size="xs"
         >
@@ -93,6 +96,7 @@ exports[`Account navigation button renders 1`] = `
           margin="xs"
         />
         <EuiButtonEmpty
+          data-test-subj="reset-password"
           onClick={[Function]}
           size="xs"
         >

--- a/public/apps/account/test/__snapshots__/role-info-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/role-info-panel.test.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Account menu - Role info panel renders 1`] = `
+<EuiOverlayMask>
+  <EuiModal
+    data-test-subj="role-info-modal"
+    onClose={[MockFunction]}
+  >
+    <EuiSpacer />
+    <EuiModalBody>
+      <EuiTitle>
+        <h4>
+          Roles (
+          2
+          )
+        </h4>
+      </EuiTitle>
+      <EuiText
+        color="subdued"
+      >
+        Roles you are currently mapped to by your administrator.
+      </EuiText>
+      <EuiSpacer />
+      <EuiText
+        key="role1"
+      >
+        role1
+        <br />
+      </EuiText>
+      <EuiText
+        key="role2"
+      >
+        role2
+        <br />
+      </EuiText>
+      <EuiHorizontalRule />
+      <EuiTitle>
+        <h4>
+          External identities (
+          2
+          )
+        </h4>
+      </EuiTitle>
+      <EuiText
+        color="subdued"
+      >
+        External identities you are currently mapped to by your administrator.
+      </EuiText>
+      <EuiSpacer />
+      <EuiText
+        key="backend_role1"
+      >
+        backend_role1
+        <br />
+      </EuiText>
+      <EuiText
+        key="backend_role2"
+      >
+        backend_role2
+        <br />
+      </EuiText>
+    </EuiModalBody>
+  </EuiModal>
+</EuiOverlayMask>
+`;

--- a/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
@@ -1,0 +1,325 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Account menu -tenant switch panel confirm button and renders renders when both global and private tenant enabled 1`] = `
+<EuiOverlayMask>
+  <EuiModal
+    data-test-subj="tenant-switch-modal"
+    onClose={[MockFunction]}
+  >
+    <EuiSpacer />
+    <EuiModalBody>
+      <EuiTitle>
+        <h4>
+          Select your tenant
+        </h4>
+      </EuiTitle>
+      <EuiSpacer />
+      <EuiText
+        color="subdued"
+        size="s"
+      >
+        Tenants are useful for safely sharing your work with other Kibana users. You can switch your tenant anytime by clicking the user avatar on top right.
+      </EuiText>
+      <EuiSpacer />
+      <EuiRadioGroup
+        data-test-subj="tenant-switch-radios"
+        name="tenantSwitchRadios"
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "disabled": false,
+              "id": "global",
+              "label": <React.Fragment>
+                Global
+                <EuiText
+                  size="s"
+                >
+                  The global tenant is shared between every Kibana user.
+                </EuiText>
+                <EuiSpacer />
+              </React.Fragment>,
+            },
+            Object {
+              "disabled": false,
+              "id": "private",
+              "label": <React.Fragment>
+                Private
+                <EuiText
+                  size="s"
+                >
+                  The private tenant is exclusive to each user and can't be shared. You might use the private tenant for exploratory work.
+                </EuiText>
+                <EuiSpacer />
+              </React.Fragment>,
+            },
+            Object {
+              "disabled": false,
+              "id": "custom",
+              "label": <React.Fragment>
+                Choose from custom
+                <EuiSuperSelect
+                  compressed={false}
+                  fullWidth={false}
+                  hasDividers={false}
+                  isInvalid={false}
+                  isLoading={false}
+                  onChange={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "inputDisplay": "tenant1",
+                        "value": "tenant1",
+                      },
+                    ]
+                  }
+                  style={
+                    Object {
+                      "width": 400,
+                    }
+                  }
+                  valueOfSelected=""
+                />
+              </React.Fragment>,
+            },
+          ]
+        }
+      />
+      <EuiSpacer />
+    </EuiModalBody>
+    <EuiModalFooter>
+      <EuiButtonEmpty
+        onClick={[MockFunction]}
+      >
+        Cancel
+      </EuiButtonEmpty>
+      <EuiButton
+        data-test-subj="confirm"
+        disabled={false}
+        fill={true}
+        onClick={[Function]}
+      >
+        Confirm
+      </EuiButton>
+    </EuiModalFooter>
+  </EuiModal>
+</EuiOverlayMask>
+`;
+
+exports[`Account menu -tenant switch panel confirm button and renders renders when global tenant disabled 1`] = `
+<EuiOverlayMask>
+  <EuiModal
+    data-test-subj="tenant-switch-modal"
+    onClose={[MockFunction]}
+  >
+    <EuiSpacer />
+    <EuiModalBody>
+      <EuiTitle>
+        <h4>
+          Select your tenant
+        </h4>
+      </EuiTitle>
+      <EuiSpacer />
+      <EuiText
+        color="subdued"
+        size="s"
+      >
+        Tenants are useful for safely sharing your work with other Kibana users. You can switch your tenant anytime by clicking the user avatar on top right.
+      </EuiText>
+      <EuiSpacer />
+      <EuiRadioGroup
+        data-test-subj="tenant-switch-radios"
+        name="tenantSwitchRadios"
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "disabled": true,
+              "id": "global",
+              "label": <React.Fragment>
+                Global
+                <EuiText
+                  size="s"
+                >
+                  The global tenant is shared between every Kibana user.
+                </EuiText>
+                <i>
+                  Contact the administrator to enable global tenant.
+                </i>
+                <EuiSpacer />
+              </React.Fragment>,
+            },
+            Object {
+              "disabled": false,
+              "id": "private",
+              "label": <React.Fragment>
+                Private
+                <EuiText
+                  size="s"
+                >
+                  The private tenant is exclusive to each user and can't be shared. You might use the private tenant for exploratory work.
+                </EuiText>
+                <EuiSpacer />
+              </React.Fragment>,
+            },
+            Object {
+              "disabled": false,
+              "id": "custom",
+              "label": <React.Fragment>
+                Choose from custom
+                <EuiSuperSelect
+                  compressed={false}
+                  fullWidth={false}
+                  hasDividers={false}
+                  isInvalid={false}
+                  isLoading={false}
+                  onChange={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "inputDisplay": "tenant1",
+                        "value": "tenant1",
+                      },
+                    ]
+                  }
+                  style={
+                    Object {
+                      "width": 400,
+                    }
+                  }
+                  valueOfSelected=""
+                />
+              </React.Fragment>,
+            },
+          ]
+        }
+      />
+      <EuiSpacer />
+    </EuiModalBody>
+    <EuiModalFooter>
+      <EuiButtonEmpty
+        onClick={[MockFunction]}
+      >
+        Cancel
+      </EuiButtonEmpty>
+      <EuiButton
+        data-test-subj="confirm"
+        disabled={false}
+        fill={true}
+        onClick={[Function]}
+      >
+        Confirm
+      </EuiButton>
+    </EuiModalFooter>
+  </EuiModal>
+</EuiOverlayMask>
+`;
+
+exports[`Account menu -tenant switch panel confirm button and renders renders when private tenant disabled 1`] = `
+<EuiOverlayMask>
+  <EuiModal
+    data-test-subj="tenant-switch-modal"
+    onClose={[MockFunction]}
+  >
+    <EuiSpacer />
+    <EuiModalBody>
+      <EuiTitle>
+        <h4>
+          Select your tenant
+        </h4>
+      </EuiTitle>
+      <EuiSpacer />
+      <EuiText
+        color="subdued"
+        size="s"
+      >
+        Tenants are useful for safely sharing your work with other Kibana users. You can switch your tenant anytime by clicking the user avatar on top right.
+      </EuiText>
+      <EuiSpacer />
+      <EuiRadioGroup
+        data-test-subj="tenant-switch-radios"
+        name="tenantSwitchRadios"
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "disabled": false,
+              "id": "global",
+              "label": <React.Fragment>
+                Global
+                <EuiText
+                  size="s"
+                >
+                  The global tenant is shared between every Kibana user.
+                </EuiText>
+                <EuiSpacer />
+              </React.Fragment>,
+            },
+            Object {
+              "disabled": true,
+              "id": "private",
+              "label": <React.Fragment>
+                Private
+                <EuiText
+                  size="s"
+                >
+                  The private tenant is exclusive to each user and can't be shared. You might use the private tenant for exploratory work.
+                </EuiText>
+                <i>
+                  Contact the administrator to enable private tenant.
+                </i>
+                <EuiSpacer />
+              </React.Fragment>,
+            },
+            Object {
+              "disabled": false,
+              "id": "custom",
+              "label": <React.Fragment>
+                Choose from custom
+                <EuiSuperSelect
+                  compressed={false}
+                  fullWidth={false}
+                  hasDividers={false}
+                  isInvalid={false}
+                  isLoading={false}
+                  onChange={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "inputDisplay": "tenant1",
+                        "value": "tenant1",
+                      },
+                    ]
+                  }
+                  style={
+                    Object {
+                      "width": 400,
+                    }
+                  }
+                  valueOfSelected=""
+                />
+              </React.Fragment>,
+            },
+          ]
+        }
+      />
+      <EuiSpacer />
+    </EuiModalBody>
+    <EuiModalFooter>
+      <EuiButtonEmpty
+        onClick={[MockFunction]}
+      >
+        Cancel
+      </EuiButtonEmpty>
+      <EuiButton
+        data-test-subj="confirm"
+        disabled={false}
+        fill={true}
+        onClick={[Function]}
+      >
+        Confirm
+      </EuiButton>
+    </EuiModalFooter>
+  </EuiModal>
+</EuiOverlayMask>
+`;

--- a/public/apps/account/test/account-nav-button.test.tsx
+++ b/public/apps/account/test/account-nav-button.test.tsx
@@ -40,9 +40,9 @@ describe('Account navigation button', () => {
   let component;
   const setState = jest.fn();
   const useStateSpy = jest.spyOn(React, 'useState');
-  useStateSpy.mockImplementation((init) => [init, setState]);
 
   beforeEach(() => {
+    useStateSpy.mockImplementation((init) => [init, setState]);
     component = shallow(
       <AccountNavButton
         coreStart={mockCoreStart}
@@ -58,9 +58,27 @@ describe('Account navigation button', () => {
     jest.clearAllMocks();
   });
 
-  const handleClose = jest.fn();
-
   it('renders', () => {
     expect(component).toMatchSnapshot();
+  });
+
+  it('should set modal when click on "View roles and identities" button', () => {
+    component.find('[data-test-subj="view-roles-and-identities"]').simulate('click');
+    expect(setState).toBeCalledTimes(1);
+  });
+
+  it('should set modal when click on "Switch tenants" button', () => {
+    component.find('[data-test-subj="switch-tenants"]').simulate('click');
+    expect(setState).toBeCalledTimes(1);
+  });
+
+  it('should set modal when click on "Reset password" button', () => {
+    component.find('[data-test-subj="reset-password"]').simulate('click');
+    expect(setState).toBeCalledTimes(1);
+  });
+
+  it('should set isPopoverOpen to true when click on Avatar in header section', () => {
+    component.find('[data-test-subj="account-header-section-button"]').simulate('click');
+    expect(setState).toBeCalledTimes(1);
   });
 });

--- a/public/apps/account/test/role-info-panel.test.tsx
+++ b/public/apps/account/test/role-info-panel.test.tsx
@@ -55,11 +55,33 @@ describe('Account menu - Role info panel', () => {
     });
   });
 
+  it('fetch data error', (done) => {
+    (fetchAccountInfo as jest.Mock).mockImplementationOnce(() => {
+      throw Error();
+    });
+    // Hide the error message
+    jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+    shallow(<RoleInfoPanel coreStart={mockCoreStart as any} handleClose={handleClose} />);
+    process.nextTick(() => {
+      expect(setState).toBeCalledTimes(0);
+      done();
+    });
+  });
+
   it('should call handleClose on close event', () => {
     const component = shallow(
       <RoleInfoPanel coreStart={mockCoreStart as any} handleClose={handleClose} />
     );
     component.find('[data-test-subj="role-info-modal"]').simulate('close');
     expect(handleClose).toBeCalled();
+  });
+
+  it('renders', () => {
+    useState.mockImplementationOnce(() => [['role1', 'role2'], setState]);
+    useState.mockImplementationOnce(() => [['backend_role1', 'backend_role2'], setState]);
+    const component = shallow(
+      <RoleInfoPanel coreStart={mockCoreStart as any} handleClose={handleClose} />
+    );
+    expect(component).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added more unit and functional tests for account menu

*Testing:*

- Ran `yarn tsc`
- Ran `yarn test:jest_ui --coverage `

Folder-level coverage:
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s    
-----------------------------------------------------|---------|----------|---------|---------|----------------------
public/apps/account                                 |   78.31 |    72.06 |   59.18 |   80.75 |                      
  account-app.tsx                                    |       0 |        0 |       0 |       0 | 24-40                
  account-nav-button.tsx                             |   58.82 |       75 |   45.45 |   66.67 | 92-95,114,144        
  constants.tsx                                      |     100 |      100 |     100 |     100 |                      
  log-out-button.tsx                                 |     100 |      100 |     100 |     100 |                      
  password-reset-panel.tsx                           |     100 |       50 |     100 |     100 | 140                  
  role-info-panel.tsx                                |     100 |      100 |     100 |     100 |                      
  tenant-selection-page.tsx                          |       0 |        0 |       0 |       0 | 24-56                
  tenant-switch-panel.tsx                            |   96.05 |     87.5 |   92.31 |   96.05 | 99-101               
  types.ts                                           |       0 |        0 |       0 |       0 |                      
  utils.tsx                                          |       0 |        0 |       0 |       0 | 23-53  

All before:
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s    
-----------------------------------------------------|---------|----------|---------|---------|----------------------
All files                                            |   67.81 |    67.74 |   54.47 |   68.35 |     

All after:
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s    
-----------------------------------------------------|---------|----------|---------|---------|----------------------
All files                                            |   69.85 |    71.15 |    56.5 |   70.45 |        


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
