### PR TITLE
Preserve hash for nextUrl redirection

### DIFF
--- a/public/apps/account/tenant-selection-page.tsx
+++ b/public/apps/account/tenant-selection-page.tsx
@@ -26,7 +26,7 @@ function redirect(serverBasePath: string) {
   if (!nextUrl || nextUrl.toLowerCase().includes('//')) {
     nextUrl = serverBasePath;
   }
-  window.location.href = nextUrl;
+  window.location.href = nextUrl + window.location.hash;
 }
 
 export async function renderPage(

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -78,7 +78,10 @@ export function LoginPage(props: LoginPageDeps) {
       await validateCurrentPassword(props.http, username, password);
       // Forward search to keep nextUrl argument
       window.location.href =
-        props.http.basePath.serverBasePath + SELECT_TENANT_PAGE_URI + window.location.search;
+        props.http.basePath.serverBasePath +
+        SELECT_TENANT_PAGE_URI +
+        window.location.search +
+        window.location.hash;
     } catch (error) {
       console.log(error);
       setloginFailed(true);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If user session is timeout, it will be redirect to login page and a `nextUrl` parameter in url argument is used to redirect back after login. Previously it doesn't care about the hash part. Sample urls:
* http://localhost:5601/app/opendistro_security#/roles
* http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(filters:!(),refreshInterval:(pause:!f,value:900000),time:(from:now-24h,to:now))&_a=(description:'Analyze%20mock%20flight%20data%20for%20ES-Air,%20Logstash%20Airways,%20Kibana%20Airlines%20and%20JetBeats',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'%5BFlights%5D%20Global%20Flight%20Dashboard',viewMode:view)

This change will preserve hash part so it redirect back to the same page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
