### PR TITLE
Display error message given from server on internal user update

### DIFF
--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -44,6 +44,7 @@ import { ExternalLink } from '../../utils/display-utils';
 import { generateResourceName } from '../../utils/resource-utils';
 import { NameRow } from '../../utils/name-row';
 import { DocLinks } from '../../constants';
+import { constructErrorMessageAndLog } from '../../../error-utils';
 
 interface InternalUserEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -114,12 +115,9 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
       // Redirect to user listing
       window.location.href = buildHashUrl(ResourceType.users);
     } catch (e) {
-      if (e.message) {
-        addToast(createErrorToast('updateUserFailed', 'Update error', e.message));
-      } else {
-        addToast(createUnknownErrorToast('updateUserFailed', `${props.action} user`));
-        console.error(e);
-      }
+      addToast(
+        createErrorToast('updateUserFailed', 'Update error', constructErrorMessageAndLog(e, ''))
+      );
     }
   };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Display error message given from server on internal user update. Example server response:

~~~JSON
{
  "statusCode":400,
  "error":"Bad Request",
  "message":"Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
}
~~~

And it is stored in exception.body.

Before:
![image](https://user-images.githubusercontent.com/63078162/97620623-0eb3d500-19df-11eb-8f93-65caac375b75.png)

After:
![image](https://user-images.githubusercontent.com/63078162/97620851-563a6100-19df-11eb-9f36-f7c9ac3d2a2c.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
