### PR TITLE
Perform index migrations sequentially

### DIFF
--- a/server/multitenancy/tenant_index.ts
+++ b/server/multitenancy/tenant_index.ts
@@ -94,7 +94,7 @@ export async function migrateTenantIndices(
     log: logger,
   });
 
-  Object.keys(tenentInfo).forEach(async (indexName, i, array) => {
+  for (const indexName of Object.keys(tenentInfo)) {
     const indexMap = createIndexMap({
       kibanaIndexName: indexName,
       indexMap: mergeTypes(typeRegistry.getAllTypes()),
@@ -125,5 +125,5 @@ export async function migrateTenantIndices(
       logger.error(error);
       throw error;
     }
-  });
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*

#580

*Description of changes:*

The `forEach` loop iterates over the tenants performing many asynchronous migrations. Switching to a `for..of` loop performs the migrations sequentially.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
