### PR TITLE
Fix url encoding of resource names

### DIFF
--- a/public/apps/configuration/backend_api/client.js
+++ b/public/apps/configuration/backend_api/client.js
@@ -32,6 +32,7 @@ uiModules.get('apps/opendistro_security/configuration', [])
         };
 
         this.get = function(resourceName, id) {
+            id = encodeURIComponent(id);
             return $http.get(`${AUTH_BACKEND_API_ROOT}/configuration/${resourceName}/${id}`)
                 .then((response) => {
                     return response.data;
@@ -50,6 +51,7 @@ uiModules.get('apps/opendistro_security/configuration', [])
         };
 
         this.getSilent = function(resourceName, id, showError) {
+            id = encodeURIComponent(id);
             showError = typeof showError !== 'undefined' ? showError : true;
             return $http.get(`${AUTH_BACKEND_API_ROOT}/configuration/${resourceName}/${id}`)
                 .then((response) => {
@@ -61,6 +63,7 @@ uiModules.get('apps/opendistro_security/configuration', [])
         };
 
         this.save = (resourceName, id, data, showToastOnError = true) => {
+            id = encodeURIComponent(id);
             let url = `${AUTH_BACKEND_API_ROOT}/configuration/${resourceName}/${id}`;
             return $http.post(url, data)
                 .then((response) => {
@@ -101,6 +104,7 @@ uiModules.get('apps/opendistro_security/configuration', [])
         };
 
         this.delete = (resourceName, id) => {
+            id = encodeURIComponent(id);
             return $http.delete(`${AUTH_BACKEND_API_ROOT}/configuration/${resourceName}/${id}`)
                 .then((response) => {
                     toastNotifications.addSuccess({

--- a/public/apps/configuration/base_controller.js
+++ b/public/apps/configuration/base_controller.js
@@ -170,7 +170,7 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
 
     // --- Start navigation
     $scope.edit = function(resourcename) {
-        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/edit/' + encodeURIComponent(encodeURIComponent(resourcename)));
+        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/edit' + '?resourcename=' + encodeURIComponent(resourcename));
     }
 
     $scope.new = function(query) {
@@ -178,7 +178,7 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
     }
 
     $scope.clone = function(resourcename) {
-        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/clone/' + encodeURIComponent(encodeURIComponent(resourcename)));
+        kbnUrl.change('/' +$scope.endpoint.toLowerCase() + '/clone' + '?resourcename=' + encodeURIComponent(resourcename));
     }
 
     $scope.cancel = function () {
@@ -188,7 +188,7 @@ app.controller('securityBaseController', function ($scope, $element, $route, $wi
 
     $scope.delete = function() {
         $scope.displayModal = false;
-        var name = encodeURIComponent($scope.deleteModalResourceName);
+        var name = $scope.deleteModalResourceName;
         $scope.deleteModalResourceName = "";
         $scope.service.delete(name)
             .then(() => $scope.cancel());

--- a/public/apps/configuration/sections/actiongroups/index.js
+++ b/public/apps/configuration/sections/actiongroups/index.js
@@ -13,10 +13,10 @@ uiRoutes
     .when('/actiongroups', {
       template: sectionTemplate
     })
-    .when('/actiongroups/edit/:resourcename', {
+    .when('/actiongroups/edit', {
       template: editTemplate
     })
-    .when('/actiongroups/clone/:resourcename', {
+    .when('/actiongroups/clone', {
         template: editTemplate
     })
     .when('/actiongroups/new', {

--- a/public/apps/configuration/sections/internalusers/index.js
+++ b/public/apps/configuration/sections/internalusers/index.js
@@ -12,10 +12,10 @@ uiRoutes
     .when('/internalusers', {
         template: sectionTemplate
     })
-    .when('/internalusers/edit/:resourcename', {
+    .when('/internalusers/edit', {
         template: editTemplate
     })
-    .when('/internalusers/clone/:resourcename', {
+    .when('/internalusers/clone', {
         template: editTemplate
     })
     .when('/internalusers/new', {

--- a/public/apps/configuration/sections/roles/index.js
+++ b/public/apps/configuration/sections/roles/index.js
@@ -17,12 +17,9 @@ uiRoutes
     .when('/roles/new', {
         template: editRoleTemplate
     })
-    .when('/roles/clone/:resourcename', {
+    .when('/roles/clone', {
         template: editRoleTemplate
     })
-    .when('/roles/edit/:resourcename', {
+    .when('/roles/edit', {
       template: editRoleTemplate
-    })
-    .when('/roles/edit/:resourcename/:indexname*', {
-        template: editRoleTemplate
     })

--- a/public/apps/configuration/sections/roles/views/index.html
+++ b/public/apps/configuration/sections/roles/views/index.html
@@ -89,7 +89,7 @@
                                 <td class="kuiTableRowCell cellAlignTop">
                                     <div class="kuiTableRowCell__liner">
                                             <span ng-repeat="indexname in extractPatternsFromObjectArray(resources[rolename].index_permissions, 'index_patterns')">
-                                                <a title="{{indexname}}" class="kuiLink" ng-href="#/roles/edit/{{rolename}}/{{indexname | escape}}" >
+                                                <a title="{{indexname}}" class="kuiLink" ng-href="#/roles/edit?resourcename={{rolename | escape}}&indexname={{indexname | escape}}" >
                                                     {{indexname}}
                                                 </a>
                                                 <br/>

--- a/public/apps/configuration/sections/rolesmapping/index.js
+++ b/public/apps/configuration/sections/rolesmapping/index.js
@@ -12,10 +12,10 @@ uiRoutes
     .when('/rolesmapping', {
       template: sectionTemplate
     })
-    .when('/rolesmapping/edit/:resourcename', {
+    .when('/rolesmapping/edit', {
       template: editTemplate
     })
-    .when('/rolesmapping/clone/:resourcename', {
+    .when('/rolesmapping/clone', {
         template: editTemplate
     })
     .when('/rolesmapping/new', {

--- a/public/apps/configuration/sections/tenants/index.js
+++ b/public/apps/configuration/sections/tenants/index.js
@@ -11,10 +11,10 @@ uiRoutes
     .when('/tenants', {
       template: sectionTemplate
     })
-    .when('/tenants/edit/:resourcename', {
+    .when('/tenants/edit', {
       template: editTemplate
     })
-    .when('/tenants/clone/:resourcename', {
+    .when('/tenants/clone', {
         template: editTemplate
     })
     .when('/tenants/new', {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- PR #502 fixed the navigation and encoding issue of resource names by double encoding it which is an open angular [issue](https://github.com/angular/angular.js/issues/10479).
- Above fix however makes a lot of resource names containing special characters unreadable. 
- Converting route path params into query params. Query params need resource names to be encoded only once. Eg: `internalusers/edit/test123` is converted to`internalusers/edit?resourcename=test123`.
- Change is compatible with (https://docs.angularjs.org/api/ngRoute/service/$routeParams) 
- URL encoding only once before the backend API is called 

Testing:
- Created internal user with `<html><script>test123</script></html>` . Could clone, get and update the user details.
- Created internal user with `шеллы.  Could clone, get and update the user details.
- Created role, rolesmapping and tenant with similar names.
- Could directly navigate to index permissions from roles page. 

- Internal users api
```
{
  "шеллы" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [ ],
    "attributes" : { },
    "opendistro_security_roles" : [
      "alerting_full_access",
      "kibana_user",
      "readall_and_monitor"
    ],
    "static" : false
  },
  "<html><script>test123</script></html>" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [ ],
    "attributes" : { },
    "opendistro_security_roles" : [
      "alerting_full_access",
      "kibana_read_only",
      "kibana_user"
    ],
    "static" : false
  },
  "Привет" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [ ],
    "attributes" : { },
    "opendistro_security_roles" : [ ],
    "static" : false
  }
....
}
```


<img width="1392" alt="Screen Shot 2020-10-29 at 4 56 14 PM" src="https://user-images.githubusercontent.com/5506137/97645089-3ddf3c00-1a09-11eb-870a-eb7784fa013c.png">
<img width="1392" alt="Screen Shot 2020-10-29 at 4 56 24 PM" src="https://user-images.githubusercontent.com/5506137/97645093-40419600-1a09-11eb-89f0-5eeea66212e5.png">
<img width="1392" alt="Screen Shot 2020-10-29 at 4 56 44 PM" src="https://user-images.githubusercontent.com/5506137/97645098-43d51d00-1a09-11eb-8f16-9dc53de70590.png">
<img width="1392" alt="Screen Shot 2020-10-29 at 5 06 40 PM" src="https://user-images.githubusercontent.com/5506137/97645113-4b94c180-1a09-11eb-97c4-1deaf7ff5f99.png">
<img width="1392" alt="Screen Shot 2020-10-29 at 5 06 48 PM" src="https://user-images.githubusercontent.com/5506137/97645120-50597580-1a09-11eb-8036-9d03471a098f.png">
<img width="1392" alt="Screen Shot 2020-10-29 at 5 08 53 PM" src="https://user-images.githubusercontent.com/5506137/97645178-71ba6180-1a09-11eb-87be-5c033a6fcf1f.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
