### PR TITLE
Refresh page to login when session timeout

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -144,7 +144,11 @@ export class OpendistroSecurityPlugin
           httpErrorResponse.response?.status === 401 &&
           !window.location.pathname.includes('/login')
         ) {
-          window.location.reload();
+          if (config.auth.logout_url) {
+            window.location.href = config.auth.logout_url;
+          } else {
+            window.location.reload();
+          }
         }
       },
     });

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -137,24 +137,28 @@ export class OpendistroSecurityPlugin
 
     setupTopNavButton(core, config);
 
-    // refresh the page when getting 401 unauthorized, e.g. when session timedo out.
-    core.http.intercept({
-      responseError: (httpErrorResponse, controller) => {
-        if (
-          httpErrorResponse.response?.status === 401 &&
-          !(
-            window.location.pathname.toLowerCase().includes('/login') ||
-            window.location.pathname.toLowerCase().includes('error')
-          )
-        ) {
-          if (config.auth.logout_url) {
-            window.location.href = config.auth.logout_url;
-          } else {
-            window.location.reload();
+    if (config.ui.autologout) {
+      // logout the user when getting 401 unauthorized, e.g. when session timed out.
+      core.http.intercept({
+        responseError: (httpErrorResponse, controller) => {
+          if (
+            httpErrorResponse.response?.status === 401 &&
+            !(
+              window.location.pathname.toLowerCase().includes('/login') ||
+              window.location.pathname.toLowerCase().includes('error')
+            )
+          ) {
+            if (config.auth.logout_url) {
+              window.location.href = config.auth.logout_url;
+            } else {
+              // when session timed out, user credentials in cookie are wiped out
+              // refres the page will direct the user to go through login process
+              window.location.reload();
+            }
           }
-        }
-      },
-    });
+        },
+      });
+    }
 
     return {};
   }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -142,7 +142,10 @@ export class OpendistroSecurityPlugin
       responseError: (httpErrorResponse, controller) => {
         if (
           httpErrorResponse.response?.status === 401 &&
-          !window.location.pathname.includes('/login')
+          !(
+            window.location.pathname.toLowerCase().includes('/login') ||
+            window.location.pathname.toLowerCase().includes('error')
+          )
         ) {
           if (config.auth.logout_url) {
             window.location.href = config.auth.logout_url;

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -137,6 +137,18 @@ export class OpendistroSecurityPlugin
 
     setupTopNavButton(core, config);
 
+    // refresh the page when getting 401 unauthorized, e.g. when session timedo out.
+    core.http.intercept({
+      responseError: (httpErrorResponse, controller) => {
+        if (
+          httpErrorResponse.response?.status === 401 &&
+          !window.location.pathname.includes('/login')
+        ) {
+          window.location.reload();
+        }
+      },
+    });
+
     return {};
   }
 

--- a/public/types.ts
+++ b/public/types.ts
@@ -45,6 +45,7 @@ export interface ClientConfigType {
         buttonstyle: string;
       };
     };
+    autologout: boolean;
   };
   multitenancy: {
     enabled: boolean;

--- a/server/index.ts
+++ b/server/index.ts
@@ -182,6 +182,7 @@ export const configSchema = schema.object({
         buttonstyle: schema.string({ defaultValue: '' }),
       }),
     }),
+    autologout: schema.boolean({ defaultValue: true }),
   }),
 });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When session timeout, server side will return 401 to browser side, this change add an intercepter upon receiving 401 error, browser plugin refresh the page so that the user can re-login to start a new session.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
