### PR TITLE
Skip tenant selection if tenent is specified in URL

### DIFF
--- a/public/apps/account/tenant-selection-page.tsx
+++ b/public/apps/account/tenant-selection-page.tsx
@@ -29,6 +29,13 @@ function redirect(serverBasePath: string) {
   window.location.href = nextUrl + window.location.hash;
 }
 
+function tenantSpecifiedInUrl() {
+  return (
+    window.location.search.includes('security_tenant') ||
+    window.location.search.includes('securitytenant')
+  );
+}
+
 export async function renderPage(
   coreStart: CoreStart,
   params: AppMountParameters,
@@ -40,7 +47,7 @@ export async function renderPage(
   // Skip either:
   // 1. multitenancy is disabled
   // 2. security manager (user with api permission)
-  if (!config.multitenancy.enabled || hasApiPermission) {
+  if (!config.multitenancy.enabled || hasApiPermission || tenantSpecifiedInUrl()) {
     handleModalClose();
     return () => {};
   } else {

--- a/public/apps/account/tenant-selection-page.tsx
+++ b/public/apps/account/tenant-selection-page.tsx
@@ -47,6 +47,7 @@ export async function renderPage(
   // Skip either:
   // 1. multitenancy is disabled
   // 2. security manager (user with api permission)
+  // 3. user specified tenant as url query parameter
   if (!config.multitenancy.enabled || hasApiPermission || tenantSpecifiedInUrl()) {
     handleModalClose();
     return () => {};


### PR DESCRIPTION
*Issue #, if available:* #552

*Description of changes:* When `securitytenant` is specified in URL, we skip showing the tenant selection dialog.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
