### PR TITLE
introduce cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,6 @@
+{
+    "defaultCommandTimeout": 30000,
+    "env": {
+      "kibana": "localhost:5601"
+    }
+}

--- a/cypress/integration/login_spec.ts
+++ b/cypress/integration/login_spec.ts
@@ -1,0 +1,42 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+describe('Login succeeds', () => {
+  it('successfully logs in', () => {
+    cy.visit(`${Cypress.env('kibana')}`);
+    // change URL to match your dev URL
+
+    cy.get('[data-test-subj="user-name"]', { timeout: 60000 }).type('admin', { force: true });
+
+    // {enter} causes the form to submit
+    cy.get('[data-test-subj="password"]').type('admin{enter}', { force: true });
+
+    cy.url().should('contain', '/home');
+  });
+});
+
+describe('Login fails', () => {
+  it('logs in fails', () => {
+    cy.visit(`${Cypress.env('kibana')}`);
+    // change URL to match your dev URL
+
+    cy.get('[data-test-subj="user-name"]', { timeout: 60000 }).type('admin2', { force: true });
+
+    // {enter} causes the form to submit
+    cy.get('[data-test-subj="password"]').type('admin{enter}', { force: true });
+
+    cy.get('#error').should('exist');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,16 +15,18 @@
     "lint:sass": "node ../../scripts/sasslint",
     "lint": "yarn run lint:es && yarn run lint:sass",
     "test:jest_server": "node ./test/run_jest_tests.js --config ./test/jest.config.server.js",
-    "test:jest_ui": "node ./test/run_jest_tests.js --config ./test/jest.config.ui.js"
+    "test:jest_ui": "node ./test/run_jest_tests.js --config ./test/jest.config.ui.js",
+    "cypress:open": "cypress open"
   },
   "devDependencies": {
-    "typescript": "3.9.5",
+    "@testing-library/react-hooks": "^3.4.1",
+    "cypress": "^5.5.0",
     "gulp-rename": "2.0.0",
-    "@testing-library/react-hooks": "^3.4.1"
+    "typescript": "3.9.5"
   },
   "dependencies": {
-    "@hapi/wreck": "17.0.0",
     "@hapi/cryptiles": "5.0.0",
+    "@hapi/wreck": "17.0.0",
     "html-entities": "1.3.1"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change introduces Cypress and sets up the integration workflow. It also adds an actual test for login success and failure.

This change refers to https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/pull/172/files for the Cypress setup and login screen tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
