### PR TITLE
Adds coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,14 @@ jobs:
         run: |
           cd ./kibana/plugins/opendistro_security
           yarn tsc
-          yarn test:jest_ui
+      - name: Run unit test
+        run: |
+          cd ./kibana/plugins/opendistro_security
+          yarn test:jest_ui --coverage
+      - name: Uploads coverage
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: build security plugin
         run: |
           cd ./kibana/plugins/opendistro_security


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use Codecov to visualize the code coverage result
- Add Coverage Report Upload action in `CI workflow`

This change refers to https://github.com/opendistro-for-elasticsearch/index-management/pull/230 for adding Coverage Report Upload action in `CI workflow`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
