### PR TITLE
Revert removal of resource id restrict and update pattern

### DIFF
--- a/common/index.test.ts
+++ b/common/index.test.ts
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { isValidResourceName } from './index';
+
+describe('Test isValidResourceName', () => {
+  it('Empty is invalid', () => {
+    expect(isValidResourceName('')).toBe(false);
+  });
+
+  it('Length 1 is valid', () => {
+    expect(isValidResourceName('a')).toBe(true);
+  });
+
+  it('Dash, underscore, bracket, number and letter are valid', () => {
+    expect(isValidResourceName('-_(1)a')).toBe(true);
+  });
+
+  it('Dot is valid', () => {
+    expect(isValidResourceName('.')).toBe(true);
+  });
+
+  it('Slash is valid', () => {
+    expect(isValidResourceName('/')).toBe(true);
+  });
+
+  it('Percent sign is invalid', () => {
+    expect(isValidResourceName('%')).toBe(false);
+  });
+
+  it('Question mark is valid', () => {
+    expect(isValidResourceName('?')).toBe(true);
+  });
+
+  it('Hash is valid', () => {
+    expect(isValidResourceName('#')).toBe(true);
+  });
+
+  it('And sign is valid', () => {
+    expect(isValidResourceName('&')).toBe(true);
+  });
+
+  it('Unicode is valid', () => {
+    expect(isValidResourceName('Düsseldorf_Köln_Москва_北京市_إسرائيل')).toBe(true);
+  });
+});

--- a/common/index.ts
+++ b/common/index.ts
@@ -38,3 +38,13 @@ export enum AuthType {
   SAML = 'saml',
   PROXY = 'proxy',
 }
+
+/**
+ * A valid resource name should not containing percent sign (%) as they raise url injection issue.
+ * And also should not be empty.
+ * @param resourceName resource name to be validated
+ */
+export function isValidResourceName(resourceName: string): boolean {
+  // see: https://javascript.info/regexp-unicode
+  return !/[\p{C}%]/u.test(resourceName) && resourceName.length > 0;
+}

--- a/public/apps/configuration/utils/resource-validation-util.tsx
+++ b/public/apps/configuration/utils/resource-validation-util.tsx
@@ -13,6 +13,7 @@
  *   permissions and limitations under the License.
  */
 
+import { isValidResourceName } from '../../../../common';
 import {
   MIN_NUMBER_OF_CHARS_IN_RESOURCE_NAME,
   MAX_NUMBER_OF_CHARS_IN_RESOURCE_NAME,
@@ -26,10 +27,15 @@ const VALID_CHARACTERS_HELP_TEXT =
   'Valid characters are A-Z, a-z, 0-9, (_)underscore, (-) hyphen and unicode characters.';
 
 export function validateResourceName(resourceType: string, resourceName: string): string[] {
+  const errors: string[] = [];
   if (!isResourceNameLengthValid(resourceName)) {
-    return [VALID_LENGTH_HELP_TEXT(resourceType)];
+    errors.push(VALID_LENGTH_HELP_TEXT(resourceType));
   }
-  return [];
+
+  if (!isValidResourceName(resourceName)) {
+    errors.push(`Invalid characters found in ${resourceType} name. ${VALID_CHARACTERS_HELP_TEXT}`);
+  }
+  return errors;
 }
 
 export function isResourceNameLengthValid(resourceName: string): boolean {

--- a/public/apps/configuration/utils/test/resource-validation-util.test.tsx
+++ b/public/apps/configuration/utils/test/resource-validation-util.test.tsx
@@ -18,6 +18,7 @@ import { resourceNameHelpText, validateResourceName } from '../resource-validati
 describe('Resource validation util', () => {
   const resourceType = 'dummy';
   const validResourceName = 'resource1';
+  const resourceNameWithInvalidChar = 'resource1%';
   const resourceNameWithInvalidLength1 = 'r';
   const resourceNameWithInvalidLength2 = 'rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr'; // 51 Characters
 
@@ -33,6 +34,11 @@ describe('Resource validation util', () => {
 
   it('should return error when resource name length is greater than max valid length', () => {
     const errors = validateResourceName(resourceType, resourceNameWithInvalidLength2);
+    expect(errors).not.toHaveLength(0);
+  });
+
+  it('should return error when resource name contains invalid character', () => {
+    const errors = validateResourceName(resourceType, resourceNameWithInvalidChar);
     expect(errors).not.toHaveLength(0);
   });
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,7 +15,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { IRouter, ResponseError, IKibanaResponse, KibanaResponseFactory } from 'kibana/server';
-import { API_PREFIX, CONFIGURATION_API_PREFIX } from '../../common';
+import { API_PREFIX, CONFIGURATION_API_PREFIX, isValidResourceName } from '../../common';
 
 // TODO: consider to extract entity CRUD operations and put it into a client class
 export function defineRoutes(router: IRouter) {
@@ -75,6 +75,12 @@ export function defineRoutes(router: IRouter) {
       throw new Error(`Unknown resource ${resourceName}`);
     }
     inputSchema.validate(requestBody); // throws error if validation fail
+  }
+
+  function validateEntityId(resourceName: string) {
+    if (!isValidResourceName(resourceName)) {
+      return 'Invalid entity name or id.';
+    }
   }
 
   /**
@@ -432,7 +438,9 @@ export function defineRoutes(router: IRouter) {
       validate: {
         params: schema.object({
           resourceName: schema.string(),
-          id: schema.string(),
+          id: schema.string({
+            validate: validateEntityId,
+          }),
         }),
         body: schema.any(),
       },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert removal of resource id restrict and update to only restrict % and control chars.

The current code does not work with `%` as it will be decode twice and raises error.
Control char like `%00` also raises unexpected error.

This PR revert part of 682b45f4f806e2e60058df70363e3e213764c612 and update the regex pattern to disallow `%` and control chars.

Test:  

~~~
[15:04] ~
% curl -u 'admin:!23qweAs' "http://localhost:5603/zlw/api/v1/configuration/roles/t" -XPOST -H 'Content-Type: application/json' -H'kbn-xsrf:abc' -d '{
    "cluster_permissions" : [ ],
    "index_permissions" : [ ],
    "tenant_permissions" : [ ]
  }'
{"message":"'t' created."}%      

[15:05] ~
% curl -u 'admin:********' "http://localhost:5603/zlw/api/v1/configuration/roles/t%00" -XPOST -H 'Content-Type: application/json' -H'kbn-xsrf:abc' -d '{
    "cluster_permissions" : [ ],
    "index_permissions" : [ ],
    "tenant_permissions" : [ ]
  }'
{"statusCode":400,"error":"Bad Request","message":"[request params.id]: Invalid entity name or id."}%                                                   

[15:05] ~
% curl -u 'admin:********' "http://localhost:5603/zlw/api/v1/configuration/roles/t%20" -XPOST -H 'Content-Type: application/json' -H'kbn-xsrf:abc' -d '{
    "cluster_permissions" : [ ],
    "index_permissions" : [ ],
    "tenant_permissions" : [ ]
  }'
{"message":"'t ' created."}%                                                                                                                            

[15:05] ~
% curl -u 'admin:********' "http://localhost:5603/zlw/api/v1/configuration/roles/t%25" -XPOST -H 'Content-Type: application/json' -H'kbn-xsrf:abc' -d '{
    "cluster_permissions" : [ ],
    "index_permissions" : [ ],
    "tenant_permissions" : [ ]
  }'
{"statusCode":400,"error":"Bad Request","message":"[request params.id]: Invalid entity name or id."}%                                                   

[15:06] ~
% curl -u 'admin:********' "http://localhost:5603/zlw/api/v1/configuration/roles/t%" -XPOST -H 'Content-Type: application/json' -H'kbn-xsrf:abc' -d '{
    "cluster_permissions" : [ ],
    "index_permissions" : [ ],
    "tenant_permissions" : [ ]
  }'
{"statusCode":400,"error":"Bad Request","message":"Bad Request"}%
~~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
