### PR TITLE
Add tenant parameter to shared url

### DIFF
--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -131,6 +131,8 @@ export function TenantList(props: AppDependencies) {
   const switchToSelectedTenant = async (tenantValue: string, tenantName: string) => {
     try {
       await changeTenant(tenantValue);
+      // refresh the page to let the page to reload app configs, like dark mode etc.
+      // also refresh the tenant to ensure tenant is set correctly when sharing urls.
       window.location.reload();
     } catch (e) {
       console.log(e);

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -131,12 +131,7 @@ export function TenantList(props: AppDependencies) {
   const switchToSelectedTenant = async (tenantValue: string, tenantName: string) => {
     try {
       await changeTenant(tenantValue);
-      setSelection([]);
-      addToast({
-        id: 'selectSucceeded',
-        title: `Selected tenant is now ${tenantName}`,
-        color: 'success',
-      });
+      window.location.reload();
     } catch (e) {
       console.log(e);
       addToast(createUnknownErrorToast('selectFailed', `select ${tenantName} tenant`));

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -50,6 +50,7 @@ import {
   OpendistroSecurityPluginSetup,
   OpendistroSecurityPluginStart,
 } from './types';
+import { addTenantToShareURL } from './services/shared-link';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -186,6 +187,9 @@ export class OpendistroSecurityPlugin
       });
     }
 
+    if (config.multitenancy.enabled) {
+      addTenantToShareURL(core);
+    }
     return {};
   }
 

--- a/public/services/shared-link.ts
+++ b/public/services/shared-link.ts
@@ -1,0 +1,100 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { parse } from 'url';
+import { CoreStart } from 'kibana/public';
+import { API_ENDPOINT_MULTITENANCY } from '../apps/configuration/constants';
+
+// refer to https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/blob/master/public/chrome/multitenancy/enable_multitenancy.js
+export async function addTenantToShareURL(core: CoreStart) {
+  let tenant = '';
+  try {
+    tenant = await core.http.get(API_ENDPOINT_MULTITENANCY);
+    if (!tenant) {
+      tenant = 'global';
+    } else if (tenant === '__user__') {
+      tenant = 'private';
+    }
+  } catch (error) {
+    console.log(`failed to get user tenant: ${error}`);
+    return;
+  }
+  // Add the tenant to URLs copied from the share panel
+  document.addEventListener('copy', (event) => {
+    const shareButton = document.querySelector('[data-share-url]');
+    const target = document.querySelector('body > span');
+    // The copy event listens to Cmd + C too, so we need to make sure
+    // that we're actually copied something via the share panel
+    if (
+      shareButton &&
+      target &&
+      shareButton.getAttribute('data-share-url') === target.textContent
+    ) {
+      const originalValue = target.textContent;
+      let urlPart = originalValue;
+
+      // We need to figure out where in the value to add the tenant.
+      // Since Kibana sometimes adds values that aren't in the current location/url,
+      // we need to use the actual input values to do a sanity check.
+      try {
+        // For the iFrame urls we need to parse out the src
+        if (originalValue && originalValue.toLowerCase().indexOf('<iframe') === 0) {
+          const regex = /<iframe[^>]*src="([^"]*)"/i;
+          const match = regex.exec(originalValue);
+          if (match) {
+            urlPart = match[1]; // Contains the matched src, [0] contains the string where the match was found
+          }
+        }
+
+        const newValue = addTenantToURL(urlPart!, originalValue!, tenant);
+
+        if (newValue !== originalValue) {
+          target.textContent = newValue;
+        }
+      } catch (error) {
+        // Probably wasn't an url, so we just ignore this
+      }
+    }
+  });
+}
+
+function addTenantToURL(
+  url: string,
+  originalValue: string | undefined,
+  userRequestedTenant: string
+) {
+  const tenantKey = 'security_tenant';
+  const tenantKeyAndValue = tenantKey + '=' + encodeURIComponent(userRequestedTenant);
+
+  if (!originalValue) {
+    originalValue = url;
+  }
+
+  const { host, pathname, search } = parse(url);
+  const queryDelimiter = !search ? '?' : '&';
+
+  // The url parser returns null if the search is empty. Change that to an empty
+  // string so that we can use it to build the values later
+  if (search && search.toLowerCase().indexOf(tenantKey) > -1) {
+    // If we for some reason already have a tenant in the URL we skip any updates
+    return originalValue;
+  }
+
+  // A helper for finding the part in the string that we want to extend/replace
+  const valueToReplace = host! + pathname! + (search || '');
+  const replaceWith = valueToReplace + queryDelimiter + tenantKeyAndValue;
+
+  return originalValue.replace(valueToReplace, replaceWith);
+}

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -80,6 +80,8 @@ export function isMultitenantPath(request: KibanaRequest): boolean {
     request.url.pathname?.startsWith('/elasticsearch') ||
     request.url.pathname?.startsWith('/api') ||
     request.url.pathname?.startsWith('/app') ||
+    // short url path
+    request.url.pathname?.startsWith('/goto') ||
     // bootstrap.js depends on tenant info to fetch kibana configs in tenant index
     (request.url.pathname?.indexOf('bootstrap.js') || -1) > -1 ||
     request.url.pathname === '/'


### PR DESCRIPTION
*Issue #, if available:* #591

*Description of changes:*
* add `security_tenant=<tenant_name>` as query parameter to shared urls e.g. `http://localhost:5601/xdj/goto/81eb5d0c993fc4d4a37713383368abb5?security_tenant=global`
* refresh page when admin switch tenant on tenant list page


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
