### PR TITLE
More functional test cases

### DIFF
--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -102,7 +102,7 @@ const columns: Array<EuiBasicTableColumn<RoleListing>> = [
 export function RoleList(props: AppDependencies) {
   const [roleData, setRoleData] = React.useState<RoleListing[]>([]);
   const [errorFlag, setErrorFlag] = React.useState(false);
-  const [selection, setSelection] = useState<RoleListing[]>([]);
+  const [selection, setSelection] = React.useState<RoleListing[]>([]);
   const [loading, setLoading] = useState(false);
 
   React.useEffect(() => {
@@ -147,6 +147,7 @@ export function RoleList(props: AppDependencies) {
 
   const actionsMenuItems = [
     <EuiButtonEmpty
+      data-test-subj="edit"
       key="edit"
       onClick={() => {
         window.location.href = buildHashUrl(ResourceType.roles, Action.edit, selection[0].roleName);
@@ -157,6 +158,7 @@ export function RoleList(props: AppDependencies) {
     </EuiButtonEmpty>,
     // TODO: Change duplication to a popup window
     <EuiButtonEmpty
+      data-test-subj="duplicate"
       key="duplicate"
       onClick={() => {
         window.location.href = buildHashUrl(
@@ -284,6 +286,7 @@ export function RoleList(props: AppDependencies) {
         </EuiPageContentHeader>
         <EuiPageBody>
           <EuiInMemoryTable
+            data-test-subj="role-list"
             tableLayout={'auto'}
             loading={roleData === [] && !errorFlag}
             columns={columns}

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -102,6 +102,24 @@ export function renderFieldLevelSecurity() {
   };
 }
 
+export function renderDocumentLevelSecurity() {
+  return (dls: string) => {
+    if (!dls) {
+      return EMPTY_FIELD_VALUE;
+    }
+
+    // TODO: unify the experience for both cases which may require refactoring of renderExpression.
+    try {
+      return renderExpression('Document-level security', JSON.parse(dls));
+    } catch (e) {
+      // Support the use case for $variable without double quotes in DLS, e.g. variable is an array.
+
+      console.warn('Failed to parse dls as json!');
+      return dls;
+    }
+  };
+}
+
 function getColumns(
   itemIdToExpandedRowMap: ExpandedRowMapInterface,
   actionGroupDict: DataObject<ActionGroupItem>,
@@ -127,21 +145,7 @@ function getColumns(
         'Document-level security',
         ToolTipContent.DocumentLevelSecurity
       ),
-      render: (dls: string) => {
-        if (!dls) {
-          return EMPTY_FIELD_VALUE;
-        }
-
-        // TODO: unify the experience for both cases which may require refactoring of renderExpression.
-        try {
-          return renderExpression('Document-level security', JSON.parse(dls));
-        } catch (e) {
-          // Support the use case for $variable without double quotes in DLS, e.g. variable is an array.
-
-          console.warn('Failed to parse dls as json!');
-          return dls;
-        }
-      },
+      render: renderDocumentLevelSecurity(),
     },
     {
       field: 'fls',

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -188,7 +188,7 @@ export function RoleView(props: RoleViewProps) {
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiButton
-              data-test-subj="edit-rolemapping"
+              data-test-subj="map-users"
               fill
               onClick={() => {
                 window.location.href = buildHashUrl(
@@ -299,6 +299,7 @@ export function RoleView(props: RoleViewProps) {
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiButton
+                      data-test-subj="manage-mapping"
                       onClick={() => {
                         window.location.href = buildHashUrl(
                           ResourceType.roles,

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -140,7 +140,9 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
         }
         return (
           <>
-            <EuiLink onClick={() => viewDashboard(tenant)}>View dashboard</EuiLink>
+            <EuiLink data-test-subj="view-dashboard" onClick={() => viewDashboard(tenant)}>
+              View dashboard
+            </EuiLink>
           </>
         );
       },
@@ -158,7 +160,9 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
         }
         return (
           <>
-            <EuiLink onClick={() => viewVisualization(tenant)}>View visualizations</EuiLink>
+            <EuiLink data-test-subj="view-visualizations" onClick={() => viewVisualization(tenant)}>
+              View visualizations
+            </EuiLink>
           </>
         );
       },

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/index-permission-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/index-permission-panel.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Role view - index permission panel Render document level security renders document level security when dls is invalid json 1`] = `
+<Fragment>
+  {"key": "value"%%%}
+</Fragment>
+`;
+
+exports[`Role view - index permission panel Render document level security renders document level security when dls is valid json 1`] = `
+<Fragment>
+  <ExpressionModal
+    expression={
+      Object {
+        "key": "value",
+      }
+    }
+    title="Document-level security"
+  />
+</Fragment>
+`;
+
+exports[`Role view - index permission panel Render document level security renders em-dash when document level security is empty 1`] = `
+<Fragment>
+  <span>
+    —
+  </span>
+</Fragment>
+`;
+
+exports[`Role view - index permission panel Render row expanstion arrow renders when arrow expanded 1`] = `
+<Fragment>
+  <EuiButtonIcon
+    aria-label="Collapse"
+    iconType="arrowUp"
+    onClick={[Function]}
+  />
+</Fragment>
+`;

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
@@ -1,0 +1,672 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Role view basic rendering when permission tab is selected 1`] = `
+<Fragment>
+  <EuiPageContentHeader>
+    <EuiPageContentHeaderSection>
+      <EuiTitle
+        size="l"
+      >
+        <h1>
+          role
+        </h1>
+      </EuiTitle>
+    </EuiPageContentHeaderSection>
+    <EuiPageContentHeaderSection>
+      <EuiFlexGroup
+        gutterSize="s"
+      >
+        <EuiFlexItem>
+          <EuiButtonEmpty
+            href="#/roles/duplicate/role"
+            key="duplicate"
+          >
+            duplicate
+          </EuiButtonEmpty>
+          <EuiButtonEmpty
+            color="danger"
+            data-test-subj="delete"
+            key="delete"
+            onClick={[Function]}
+          >
+            delete
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiButton
+            href="#/roles/edit/role"
+          >
+            Edit role
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPageContentHeaderSection>
+  </EuiPageContentHeader>
+  <EuiTabbedContent
+    autoFocus="initial"
+    initialSelectedTab={
+      Object {
+        "content": <React.Fragment>
+          <EuiSpacer
+            size="m"
+          />
+          <EuiSpacer
+            size="m"
+          />
+          <ClusterPermissionPanel
+            actionGroups={Object {}}
+            clusterPermissions={Array []}
+            isReserved={false}
+            loading={false}
+            roleName="role"
+          />
+          <EuiSpacer
+            size="m"
+          />
+          <IndexPermissionPanel
+            actionGroups={Object {}}
+            errorFlag={false}
+            indexPermissions={Array []}
+            isReserved={false}
+            loading={false}
+            roleName="role"
+          />
+          <EuiSpacer
+            size="m"
+          />
+          <TenantsPanel
+            coreStart={
+              Object {
+                "http": 1,
+              }
+            }
+            errorFlag={false}
+            isReserved={false}
+            loading={false}
+            roleName="role"
+            tenantPermissions={Array []}
+          />
+        </React.Fragment>,
+        "disabled": false,
+        "id": "permissions",
+        "name": "Permissions",
+      }
+    }
+    tabs={
+      Array [
+        Object {
+          "content": <React.Fragment>
+            <EuiSpacer
+              size="m"
+            />
+            <EuiSpacer
+              size="m"
+            />
+            <ClusterPermissionPanel
+              actionGroups={Object {}}
+              clusterPermissions={Array []}
+              isReserved={false}
+              loading={false}
+              roleName="role"
+            />
+            <EuiSpacer
+              size="m"
+            />
+            <IndexPermissionPanel
+              actionGroups={Object {}}
+              errorFlag={false}
+              indexPermissions={Array []}
+              isReserved={false}
+              loading={false}
+              roleName="role"
+            />
+            <EuiSpacer
+              size="m"
+            />
+            <TenantsPanel
+              coreStart={
+                Object {
+                  "http": 1,
+                }
+              }
+              errorFlag={false}
+              isReserved={false}
+              loading={false}
+              roleName="role"
+              tenantPermissions={Array []}
+            />
+          </React.Fragment>,
+          "disabled": false,
+          "id": "permissions",
+          "name": "Permissions",
+        },
+        Object {
+          "content": <React.Fragment>
+            <EuiSpacer />
+            <EuiPageContent>
+              <EuiPageContentHeader>
+                <EuiPageContentHeaderSection>
+                  <EuiTitle
+                    size="s"
+                  >
+                    <h3>
+                      Mapped users
+                      <span
+                        className="panel-header-count"
+                      >
+                         (
+                        0
+                        )
+                      </span>
+                    </h3>
+                  </EuiTitle>
+                  <EuiText
+                    className="panel-header-subtext"
+                    color="subdued"
+                    size="xs"
+                  >
+                    You can map two types of users: users and external identities. A user can have its own backend role and host for an external authentication and authorization. An external identity directly maps to roles through an external authentication system. 
+                    <ExternalLink
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
+                    />
+                  </EuiText>
+                </EuiPageContentHeaderSection>
+                <EuiPageContentHeaderSection>
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                      <EuiButton
+                        disabled={true}
+                        onClick={[MockFunction]}
+                      >
+                        Delete mapping
+                      </EuiButton>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiButton
+                        data-test-subj="manage-mapping"
+                        onClick={[Function]}
+                      >
+                        Manage mapping
+                      </EuiButton>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiPageContentHeaderSection>
+              </EuiPageContentHeader>
+              <EuiHorizontalRule
+                margin="s"
+              />
+              <EuiPageBody>
+                <EuiInMemoryTable
+                  columns={
+                    Array [
+                      Object {
+                        "field": "userType",
+                        "name": "User type",
+                        "sortable": true,
+                      },
+                      Object {
+                        "field": "userName",
+                        "name": "User",
+                        "sortable": true,
+                        "truncateText": true,
+                      },
+                    ]
+                  }
+                  data-test-subj="role-mapping-list"
+                  error=""
+                  itemId="userName"
+                  items={Array []}
+                  loading={false}
+                  message={
+                    <EuiEmptyPrompt
+                      actions={
+                        <EuiFlexGroup
+                          alignItems="center"
+                          gutterSize="s"
+                        >
+                          <EuiFlexItem>
+                            <ExternalLinkButton
+                              href="#/users/create"
+                              text="Create internal user"
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <EuiButton
+                              data-test-subj="map-users"
+                              fill={true}
+                              onClick={[Function]}
+                            >
+                              Map users
+                            </EuiButton>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      }
+                      body={
+                        <EuiText
+                          color="subdued"
+                          grow={false}
+                          size="s"
+                        >
+                          <p>
+                            You can map users or external identities to this role
+                          </p>
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No user has been mapped to this role
+                        </h2>
+                      }
+                      titleSize="s"
+                    />
+                  }
+                  pagination={true}
+                  responsive={true}
+                  selection={
+                    Object {
+                      "onSelectionChange": [Function],
+                    }
+                  }
+                  sorting={true}
+                  tableLayout="auto"
+                />
+              </EuiPageBody>
+            </EuiPageContent>
+          </React.Fragment>,
+          "disabled": false,
+          "id": "users",
+          "name": "Mapped users",
+        },
+      ]
+    }
+  />
+  <EuiSpacer />
+  <EuiGlobalToastList
+    dismissToast={[MockFunction]}
+    side="right"
+    toastLifeTimeMs={10000}
+    toasts={Array []}
+  />
+</Fragment>
+`;
+
+exports[`Role view renders when mapped user tab is selected 1`] = `
+<Fragment>
+  <EuiPageContentHeader>
+    <EuiPageContentHeaderSection>
+      <EuiTitle
+        size="l"
+      >
+        <h1>
+          role
+        </h1>
+      </EuiTitle>
+    </EuiPageContentHeaderSection>
+    <EuiPageContentHeaderSection>
+      <EuiFlexGroup
+        gutterSize="s"
+      >
+        <EuiFlexItem>
+          <EuiButtonEmpty
+            href="#/roles/duplicate/role"
+            key="duplicate"
+          >
+            duplicate
+          </EuiButtonEmpty>
+          <EuiButtonEmpty
+            color="danger"
+            data-test-subj="delete"
+            key="delete"
+            onClick={[Function]}
+          >
+            delete
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiButton
+            href="#/roles/edit/role"
+          >
+            Edit role
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPageContentHeaderSection>
+  </EuiPageContentHeader>
+  <EuiTabbedContent
+    autoFocus="initial"
+    initialSelectedTab={
+      Object {
+        "content": <React.Fragment>
+          <EuiSpacer />
+          <EuiPageContent>
+            <EuiPageContentHeader>
+              <EuiPageContentHeaderSection>
+                <EuiTitle
+                  size="s"
+                >
+                  <h3>
+                    Mapped users
+                    <span
+                      className="panel-header-count"
+                    >
+                       (
+                      0
+                      )
+                    </span>
+                  </h3>
+                </EuiTitle>
+                <EuiText
+                  className="panel-header-subtext"
+                  color="subdued"
+                  size="xs"
+                >
+                  You can map two types of users: users and external identities. A user can have its own backend role and host for an external authentication and authorization. An external identity directly maps to roles through an external authentication system. 
+                  <ExternalLink
+                    href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
+                  />
+                </EuiText>
+              </EuiPageContentHeaderSection>
+              <EuiPageContentHeaderSection>
+                <EuiFlexGroup>
+                  <EuiFlexItem>
+                    <EuiButton
+                      disabled={true}
+                      onClick={[MockFunction]}
+                    >
+                      Delete mapping
+                    </EuiButton>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiButton
+                      data-test-subj="manage-mapping"
+                      onClick={[Function]}
+                    >
+                      Manage mapping
+                    </EuiButton>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPageContentHeaderSection>
+            </EuiPageContentHeader>
+            <EuiHorizontalRule
+              margin="s"
+            />
+            <EuiPageBody>
+              <EuiInMemoryTable
+                columns={
+                  Array [
+                    Object {
+                      "field": "userType",
+                      "name": "User type",
+                      "sortable": true,
+                    },
+                    Object {
+                      "field": "userName",
+                      "name": "User",
+                      "sortable": true,
+                      "truncateText": true,
+                    },
+                  ]
+                }
+                data-test-subj="role-mapping-list"
+                error=""
+                itemId="userName"
+                items={Array []}
+                loading={false}
+                message={
+                  <EuiEmptyPrompt
+                    actions={
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <EuiFlexItem>
+                          <ExternalLinkButton
+                            href="#/users/create"
+                            text="Create internal user"
+                          />
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiButton
+                            data-test-subj="map-users"
+                            fill={true}
+                            onClick={[Function]}
+                          >
+                            Map users
+                          </EuiButton>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    }
+                    body={
+                      <EuiText
+                        color="subdued"
+                        grow={false}
+                        size="s"
+                      >
+                        <p>
+                          You can map users or external identities to this role
+                        </p>
+                      </EuiText>
+                    }
+                    title={
+                      <h2>
+                        No user has been mapped to this role
+                      </h2>
+                    }
+                    titleSize="s"
+                  />
+                }
+                pagination={true}
+                responsive={true}
+                selection={
+                  Object {
+                    "onSelectionChange": [Function],
+                  }
+                }
+                sorting={true}
+                tableLayout="auto"
+              />
+            </EuiPageBody>
+          </EuiPageContent>
+        </React.Fragment>,
+        "disabled": false,
+        "id": "users",
+        "name": "Mapped users",
+      }
+    }
+    tabs={
+      Array [
+        Object {
+          "content": <React.Fragment>
+            <EuiSpacer
+              size="m"
+            />
+            <EuiSpacer
+              size="m"
+            />
+            <ClusterPermissionPanel
+              actionGroups={Object {}}
+              clusterPermissions={Array []}
+              isReserved={false}
+              loading={false}
+              roleName="role"
+            />
+            <EuiSpacer
+              size="m"
+            />
+            <IndexPermissionPanel
+              actionGroups={Object {}}
+              errorFlag={false}
+              indexPermissions={Array []}
+              isReserved={false}
+              loading={false}
+              roleName="role"
+            />
+            <EuiSpacer
+              size="m"
+            />
+            <TenantsPanel
+              coreStart={
+                Object {
+                  "http": 1,
+                }
+              }
+              errorFlag={false}
+              isReserved={false}
+              loading={false}
+              roleName="role"
+              tenantPermissions={Array []}
+            />
+          </React.Fragment>,
+          "disabled": false,
+          "id": "permissions",
+          "name": "Permissions",
+        },
+        Object {
+          "content": <React.Fragment>
+            <EuiSpacer />
+            <EuiPageContent>
+              <EuiPageContentHeader>
+                <EuiPageContentHeaderSection>
+                  <EuiTitle
+                    size="s"
+                  >
+                    <h3>
+                      Mapped users
+                      <span
+                        className="panel-header-count"
+                      >
+                         (
+                        0
+                        )
+                      </span>
+                    </h3>
+                  </EuiTitle>
+                  <EuiText
+                    className="panel-header-subtext"
+                    color="subdued"
+                    size="xs"
+                  >
+                    You can map two types of users: users and external identities. A user can have its own backend role and host for an external authentication and authorization. An external identity directly maps to roles through an external authentication system. 
+                    <ExternalLink
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
+                    />
+                  </EuiText>
+                </EuiPageContentHeaderSection>
+                <EuiPageContentHeaderSection>
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                      <EuiButton
+                        disabled={true}
+                        onClick={[MockFunction]}
+                      >
+                        Delete mapping
+                      </EuiButton>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiButton
+                        data-test-subj="manage-mapping"
+                        onClick={[Function]}
+                      >
+                        Manage mapping
+                      </EuiButton>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiPageContentHeaderSection>
+              </EuiPageContentHeader>
+              <EuiHorizontalRule
+                margin="s"
+              />
+              <EuiPageBody>
+                <EuiInMemoryTable
+                  columns={
+                    Array [
+                      Object {
+                        "field": "userType",
+                        "name": "User type",
+                        "sortable": true,
+                      },
+                      Object {
+                        "field": "userName",
+                        "name": "User",
+                        "sortable": true,
+                        "truncateText": true,
+                      },
+                    ]
+                  }
+                  data-test-subj="role-mapping-list"
+                  error=""
+                  itemId="userName"
+                  items={Array []}
+                  loading={false}
+                  message={
+                    <EuiEmptyPrompt
+                      actions={
+                        <EuiFlexGroup
+                          alignItems="center"
+                          gutterSize="s"
+                        >
+                          <EuiFlexItem>
+                            <ExternalLinkButton
+                              href="#/users/create"
+                              text="Create internal user"
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <EuiButton
+                              data-test-subj="map-users"
+                              fill={true}
+                              onClick={[Function]}
+                            >
+                              Map users
+                            </EuiButton>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      }
+                      body={
+                        <EuiText
+                          color="subdued"
+                          grow={false}
+                          size="s"
+                        >
+                          <p>
+                            You can map users or external identities to this role
+                          </p>
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No user has been mapped to this role
+                        </h2>
+                      }
+                      titleSize="s"
+                    />
+                  }
+                  pagination={true}
+                  responsive={true}
+                  selection={
+                    Object {
+                      "onSelectionChange": [Function],
+                    }
+                  }
+                  sorting={true}
+                  tableLayout="auto"
+                />
+              </EuiPageBody>
+            </EuiPageContent>
+          </React.Fragment>,
+          "disabled": false,
+          "id": "users",
+          "name": "Mapped users",
+        },
+      ]
+    }
+  />
+  <EuiSpacer />
+  <EuiGlobalToastList
+    dismissToast={[MockFunction]}
+    side="right"
+    toastLifeTimeMs={10000}
+    toasts={Array []}
+  />
+</Fragment>
+`;

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/tenants-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/tenants-panel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Role view - tenant panel Tenant permission list render view dashboard column when tenant is invalid 1`] = `
+exports[`Role view - tenant panel Tenant permission list render view dashboard column when tenant permissions contains multiple tenants or tenant pattern 1`] = `
 <Fragment>
   <EuiText
     size="s"
@@ -10,7 +10,7 @@ exports[`Role view - tenant panel Tenant permission list render view dashboard c
 </Fragment>
 `;
 
-exports[`Role view - tenant panel Tenant permission list render view visualization column when tenant is invalid 1`] = `
+exports[`Role view - tenant panel Tenant permission list render view visualization column when tenant permissions contains multiple tenants or tenant pattern 1`] = `
 <Fragment>
   <EuiText
     size="s"

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/tenants-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/tenants-panel.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Role view - tenant panel Tenant permission list render view dashboard column when tenant is invalid 1`] = `
+<Fragment>
+  <EuiText
+    size="s"
+  >
+    N/A
+  </EuiText>
+</Fragment>
+`;
+
+exports[`Role view - tenant panel Tenant permission list render view visualization column when tenant is invalid 1`] = `
+<Fragment>
+  <EuiText
+    size="s"
+  >
+    N/A
+  </EuiText>
+</Fragment>
+`;

--- a/public/apps/configuration/panels/role-view/test/cluster-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/cluster-permission-panel.test.tsx
@@ -16,8 +16,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { ClusterPermissionPanel } from '../cluster-permission-panel';
-import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiButton, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
 import { PermissionTree } from '../../permission-tree';
+import { Action, ResourceType } from '../../../types';
+import { buildHashUrl } from '../../../utils/url-builder';
 
 describe('Role view - cluster permission panel', () => {
   const sampleRole = 'role';
@@ -36,6 +38,19 @@ describe('Role view - cluster permission panel', () => {
     expect(component.find(EuiEmptyPrompt).length).toBe(1);
   });
 
+  it('should show loading spinner when cluster permissions are loading', () => {
+    const component = shallow(
+      <ClusterPermissionPanel
+        roleName={sampleRole}
+        clusterPermissions={[]}
+        actionGroups={{}}
+        loading={true}
+        isReserved={false}
+      />
+    );
+    expect(component.find(EuiLoadingSpinner).length).toBe(1);
+  });
+
   it('Add cluster permission button is disabled for reserved role', () => {
     const wrapper = shallow(
       <ClusterPermissionPanel
@@ -50,6 +65,21 @@ describe('Role view - cluster permission panel', () => {
     expect(prompt.find(EuiButton)).toHaveLength(1);
     const button = prompt.find('[data-test-subj="addClusterPermission"]');
     expect(button.prop('disabled')).toBe(true);
+  });
+
+  it('should render to role edit page when click on Add cluster permission button', () => {
+    const wrapper = shallow(
+      <ClusterPermissionPanel
+        roleName={sampleRole}
+        clusterPermissions={[]}
+        actionGroups={{}}
+        loading={false}
+        isReserved={false}
+      />
+    );
+    const prompt = wrapper.find(EuiEmptyPrompt).dive();
+    prompt.find('[data-test-subj="addClusterPermission"]').simulate('click');
+    expect(window.location.hash).toBe(buildHashUrl(ResourceType.roles, Action.edit, sampleRole));
   });
 
   it('with cluster permission', () => {

--- a/public/apps/configuration/panels/role-view/test/tenants-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/tenants-panel.test.tsx
@@ -173,7 +173,7 @@ describe('Role view - tenant panel', () => {
       expect(mockTenantUtils.selectTenant).toHaveBeenCalled();
     });
 
-    it('render view dashboard column when tenant is invalid', () => {
+    it('render view dashboard column when tenant permissions contains multiple tenants or tenant pattern', () => {
       const tenantPermissions = [{ tenant_patterns: ['*'], permissionType: 'dummy' }];
       const wrapper = mount(
         <TenantsPanel
@@ -200,7 +200,7 @@ describe('Role view - tenant panel', () => {
       expect(result).toMatchSnapshot();
     });
 
-    it('render view visualization column when tenant is invalid', () => {
+    it('render view visualization column when tenant permissions contains multiple tenants or tenant pattern', () => {
       const tenantPermissions = [{ tenant_patterns: ['*'], permissionType: 'dummy' }];
       const wrapper = mount(
         <TenantsPanel

--- a/public/apps/configuration/panels/role-view/test/tenants-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/tenants-panel.test.tsx
@@ -16,7 +16,10 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { TenantsPanel } from '../tenants-panel';
-import { EuiEmptyPrompt, EuiInMemoryTable } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiInMemoryTable, EuiTableFieldDataColumnType } from '@elastic/eui';
+import { buildHashUrl } from '../../../utils/url-builder';
+import { Action, ResourceType, RoleTenantPermissionDetail } from '../../../types';
+import { RoleViewTenantInvalidText } from '../../../constants';
 
 jest.mock('../../../utils/tenant-utils');
 jest.mock('../../../../../utils/auth-info-utils');
@@ -89,6 +92,139 @@ describe('Role view - tenant panel', () => {
       const component = shallow(prompt);
       const button = component.find('[data-test-subj="addTenantPermission"]');
       expect(button.prop('disabled')).toBe(true);
+    });
+
+    it('should render to role edit page when click on Add tenant permission button', () => {
+      const wrapper = mount(
+        <TenantsPanel
+          roleName={sampleRoleName}
+          tenantPermissions={[]}
+          errorFlag={false}
+          coreStart={mockCoreStart as any}
+          loading={false}
+          isReserved={true}
+        />
+      );
+
+      const prompt = wrapper
+        .find('[data-test-subj="tenant-permission-container"] tbody EuiEmptyPrompt')
+        .first()
+        .getElement();
+      const component = shallow(prompt);
+      component.find('[data-test-subj="addTenantPermission"]').simulate('click');
+      expect(window.location.hash).toBe(
+        buildHashUrl(ResourceType.roles, Action.edit, sampleRoleName)
+      );
+    });
+
+    it('click on View Dashboard link', () => {
+      const tenantPermissions = [{ tenant_patterns: ['tenant1'], permissionType: 'dummy' }];
+      const wrapper = mount(
+        <TenantsPanel
+          roleName={sampleRoleName}
+          tenantPermissions={tenantPermissions}
+          errorFlag={false}
+          coreStart={mockCoreStart as any}
+          loading={false}
+          isReserved={true}
+        />
+      );
+
+      const prompt = wrapper
+        .find('[data-test-subj="tenant-permission-container"]')
+        .first()
+        .getElement();
+      const component = shallow(prompt);
+      const columns = component.prop<
+        Array<EuiTableFieldDataColumnType<RoleTenantPermissionDetail>>
+      >('columns');
+      const viewDashboardRenderer = columns[3].render as (tenant: string) => JSX.Element;
+      const Container = (props: { tenant: string }) => viewDashboardRenderer(props.tenant);
+      const result = shallow(<Container tenant={'tenant1'} />);
+      result.find('[data-test-subj="view-dashboard"]').simulate('click');
+      expect(mockTenantUtils.selectTenant).toHaveBeenCalled();
+    });
+
+    it('click on View Visualizations link', () => {
+      const tenantPermissions = [{ tenant_patterns: ['tenant1'], permissionType: 'dummy' }];
+      const wrapper = mount(
+        <TenantsPanel
+          roleName={sampleRoleName}
+          tenantPermissions={tenantPermissions}
+          errorFlag={false}
+          coreStart={mockCoreStart as any}
+          loading={false}
+          isReserved={true}
+        />
+      );
+
+      const prompt = wrapper
+        .find('[data-test-subj="tenant-permission-container"]')
+        .first()
+        .getElement();
+      const component = shallow(prompt);
+      const columns = component.prop<
+        Array<EuiTableFieldDataColumnType<RoleTenantPermissionDetail>>
+      >('columns');
+      const viewVisualizationRenderer = columns[4].render as (tenant: string) => JSX.Element;
+      const Container = (props: { tenant: string }) => viewVisualizationRenderer(props.tenant);
+      const result = shallow(<Container tenant={'tenant1'} />);
+      result.find('[data-test-subj="view-visualizations"]').simulate('click');
+      expect(mockTenantUtils.selectTenant).toHaveBeenCalled();
+    });
+
+    it('render view dashboard column when tenant is invalid', () => {
+      const tenantPermissions = [{ tenant_patterns: ['*'], permissionType: 'dummy' }];
+      const wrapper = mount(
+        <TenantsPanel
+          roleName={sampleRoleName}
+          tenantPermissions={tenantPermissions}
+          errorFlag={false}
+          coreStart={mockCoreStart as any}
+          loading={false}
+          isReserved={true}
+        />
+      );
+
+      const prompt = wrapper
+        .find('[data-test-subj="tenant-permission-container"]')
+        .first()
+        .getElement();
+      const component = shallow(prompt);
+      const columns = component.prop<
+        Array<EuiTableFieldDataColumnType<RoleTenantPermissionDetail>>
+      >('columns');
+      const viewDashboardRenderer = columns[3].render as (tenant: string) => JSX.Element;
+      const Container = (props: { tenant: string }) => viewDashboardRenderer(props.tenant);
+      const result = shallow(<Container tenant={RoleViewTenantInvalidText} />);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('render view visualization column when tenant is invalid', () => {
+      const tenantPermissions = [{ tenant_patterns: ['*'], permissionType: 'dummy' }];
+      const wrapper = mount(
+        <TenantsPanel
+          roleName={sampleRoleName}
+          tenantPermissions={tenantPermissions}
+          errorFlag={false}
+          coreStart={mockCoreStart as any}
+          loading={false}
+          isReserved={true}
+        />
+      );
+
+      const prompt = wrapper
+        .find('[data-test-subj="tenant-permission-container"]')
+        .first()
+        .getElement();
+      const component = shallow(prompt);
+      const columns = component.prop<
+        Array<EuiTableFieldDataColumnType<RoleTenantPermissionDetail>>
+      >('columns');
+      const viewVisualizationRenderer = columns[4].render as (tenant: string) => JSX.Element;
+      const Container = (props: { tenant: string }) => viewVisualizationRenderer(props.tenant);
+      const result = shallow(<Container tenant={RoleViewTenantInvalidText} />);
+      expect(result).toMatchSnapshot();
     });
 
     it('fetch data error', (done) => {

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -47,7 +47,7 @@ const TITLE_DICT: { [key: string]: string } = {
 
 export function TenantEditModal(props: TenantEditModalDeps) {
   const [tenantName, setTenantName] = useState<string>(props.tenantName);
-  const [tenantDescription, setTenantDescription] = useState<string>(props.tenantDescription);
+  const [tenantDescription, setTenantDescription] = React.useState<string>(props.tenantDescription);
 
   const [isFormValid, setIsFormValid] = useState<boolean>(true);
 
@@ -80,6 +80,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               optional
             >
               <EuiTextArea
+                data-test-subj="tenant-description"
                 fullWidth
                 placeholder="Describe the tenant"
                 value={tenantDescription}

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/edit-modal.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/edit-modal.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Permission edit modal Submit button text should be Create when user is creating tenant 1`] = `
+<button
+  className="euiButton euiButton--primary euiButton--fill"
+  disabled={false}
+  id="submit"
+  onClick={[Function]}
+  type="button"
+>
+  <span
+    className="euiButton__content"
+  >
+    <span
+      className="euiButton__text"
+    >
+      Create
+    </span>
+  </span>
+</button>
+`;
+
+exports[`Permission edit modal Submit button text should be Save when user is updating tenant 1`] = `
+<button
+  className="euiButton euiButton--primary euiButton--fill"
+  disabled={false}
+  id="submit"
+  onClick={[Function]}
+  type="button"
+>
+  <span
+    className="euiButton__content"
+  >
+    <span
+      className="euiButton__text"
+    >
+      Save
+    </span>
+  </span>
+</button>
+`;

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-instruction-view.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-instruction-view.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tenant instruction view renders 1`] = `
+<Fragment>
+  <EuiTitle
+    size="l"
+  >
+    <h1>
+      Tenants
+    </h1>
+  </EuiTitle>
+  <EuiSpacer
+    size="xxl"
+  />
+  <EuiText
+    textAlign="center"
+  >
+    <h2>
+      You have not enabled multi tenancy
+    </h2>
+  </EuiText>
+  <EuiText
+    className="instruction-text"
+    color="subdued"
+    size="xs"
+    textAlign="center"
+  >
+    Contact your administrator to enable multi tenancy.
+  </EuiText>
+</Fragment>
+`;

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
@@ -1,0 +1,373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tenant list Action menu click Duplicate click 1`] = `
+<Fragment>
+  <EuiPageHeader>
+    <EuiTitle
+      size="l"
+    >
+      <h1>
+        Tenants
+      </h1>
+    </EuiTitle>
+  </EuiPageHeader>
+  <EuiPageContent>
+    <EuiPageContentHeader>
+      <EuiPageContentHeaderSection>
+        <EuiTitle
+          size="s"
+        >
+          <h3>
+            Tenants
+            <span
+              className="panel-header-count"
+            >
+               
+              (
+              1
+              )
+            </span>
+          </h3>
+        </EuiTitle>
+        <EuiText
+          color="subdued"
+          size="xs"
+        >
+          Tenants in Kibana are spaces for saving index patterns, visualizations, dashboards, and other Kibana objects. Use tenants to safely share your work with other Kibana users. You can control which roles have access to a tenant and whether those roles have read or write access. The “Current” label indicates which tenant you are using now. Switch to another tenant anytime from your user profile, which is located on the top right of the screen. 
+          <ExternalLink
+            href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/multi-tenancy/"
+          />
+        </EuiText>
+      </EuiPageContentHeaderSection>
+      <EuiPageContentHeaderSection>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiButtonEmpty
+              disabled={false}
+              id="switchTenant"
+              key="switchTenant"
+              onClick={[Function]}
+            >
+              Switch to selected tenant
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="edit"
+              key="edit"
+              onClick={[Function]}
+            >
+              Edit
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="duplicate"
+              key="duplicate"
+              onClick={[Function]}
+            >
+              Duplicate
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="createDashboard"
+              key="createDashboard"
+              onClick={[Function]}
+            >
+              Create dashboard
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="createVisualizations"
+              key="createVisualizations"
+              onClick={[Function]}
+            >
+              Create visualizations
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              color="danger"
+              disabled={false}
+              id="delete"
+              key="delete"
+              onClick={[MockFunction]}
+            >
+              Delete
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiButton
+              fill={true}
+              id="createTenant"
+              onClick={[Function]}
+            >
+              Create tenant
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPageContentHeaderSection>
+    </EuiPageContentHeader>
+    <EuiPageBody>
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "field": "tenant",
+              "name": "Name",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "field": "description",
+              "name": "Description",
+              "truncateText": true,
+            },
+            Object {
+              "field": "tenantValue",
+              "name": "Dashboard",
+              "render": [Function],
+            },
+            Object {
+              "field": "tenantValue",
+              "name": "Visualizations",
+              "render": [Function],
+            },
+            Object {
+              "field": "reserved",
+              "name": "Customization",
+              "render": [Function],
+            },
+          ]
+        }
+        error="Load data failed, please check console log for more detail."
+        itemId="tenant"
+        items={
+          Array [
+            Object {
+              "description": "",
+              "reserved": false,
+              "tenant": "tenant_2",
+              "tenantValue": "tenant_2",
+            },
+          ]
+        }
+        loading={false}
+        message={false}
+        pagination={true}
+        responsive={true}
+        search={
+          Object {
+            "box": Object {
+              "placeholder": "Find tenant",
+            },
+            "onChange": [Function],
+          }
+        }
+        selection={
+          Object {
+            "onSelectionChange": [MockFunction],
+          }
+        }
+        sorting={true}
+        tableLayout="auto"
+      />
+    </EuiPageBody>
+  </EuiPageContent>
+  <TenantEditModal
+    action="duplicate"
+    handleClose={[Function]}
+    handleSave={[Function]}
+    tenantDescription=""
+    tenantName="tenant_2_copy"
+  />
+  <EuiGlobalToastList
+    dismissToast={[MockFunction]}
+    side="right"
+    toastLifeTimeMs={10000}
+    toasts={Array []}
+  />
+</Fragment>
+`;
+
+exports[`Tenant list Action menu click Edit click 1`] = `
+<Fragment>
+  <EuiPageHeader>
+    <EuiTitle
+      size="l"
+    >
+      <h1>
+        Tenants
+      </h1>
+    </EuiTitle>
+  </EuiPageHeader>
+  <EuiPageContent>
+    <EuiPageContentHeader>
+      <EuiPageContentHeaderSection>
+        <EuiTitle
+          size="s"
+        >
+          <h3>
+            Tenants
+            <span
+              className="panel-header-count"
+            >
+               
+              (
+              1
+              )
+            </span>
+          </h3>
+        </EuiTitle>
+        <EuiText
+          color="subdued"
+          size="xs"
+        >
+          Tenants in Kibana are spaces for saving index patterns, visualizations, dashboards, and other Kibana objects. Use tenants to safely share your work with other Kibana users. You can control which roles have access to a tenant and whether those roles have read or write access. The “Current” label indicates which tenant you are using now. Switch to another tenant anytime from your user profile, which is located on the top right of the screen. 
+          <ExternalLink
+            href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/multi-tenancy/"
+          />
+        </EuiText>
+      </EuiPageContentHeaderSection>
+      <EuiPageContentHeaderSection>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiButtonEmpty
+              disabled={false}
+              id="switchTenant"
+              key="switchTenant"
+              onClick={[Function]}
+            >
+              Switch to selected tenant
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="edit"
+              key="edit"
+              onClick={[Function]}
+            >
+              Edit
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="duplicate"
+              key="duplicate"
+              onClick={[Function]}
+            >
+              Duplicate
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="createDashboard"
+              key="createDashboard"
+              onClick={[Function]}
+            >
+              Create dashboard
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              disabled={false}
+              id="createVisualizations"
+              key="createVisualizations"
+              onClick={[Function]}
+            >
+              Create visualizations
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              color="danger"
+              disabled={false}
+              id="delete"
+              key="delete"
+              onClick={[MockFunction]}
+            >
+              Delete
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiButton
+              fill={true}
+              id="createTenant"
+              onClick={[Function]}
+            >
+              Create tenant
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPageContentHeaderSection>
+    </EuiPageContentHeader>
+    <EuiPageBody>
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "field": "tenant",
+              "name": "Name",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "field": "description",
+              "name": "Description",
+              "truncateText": true,
+            },
+            Object {
+              "field": "tenantValue",
+              "name": "Dashboard",
+              "render": [Function],
+            },
+            Object {
+              "field": "tenantValue",
+              "name": "Visualizations",
+              "render": [Function],
+            },
+            Object {
+              "field": "reserved",
+              "name": "Customization",
+              "render": [Function],
+            },
+          ]
+        }
+        error="Load data failed, please check console log for more detail."
+        itemId="tenant"
+        items={
+          Array [
+            Object {
+              "description": "",
+              "reserved": false,
+              "tenant": "tenant_2",
+              "tenantValue": "tenant_2",
+            },
+          ]
+        }
+        loading={false}
+        message={false}
+        pagination={true}
+        responsive={true}
+        search={
+          Object {
+            "box": Object {
+              "placeholder": "Find tenant",
+            },
+            "onChange": [Function],
+          }
+        }
+        selection={
+          Object {
+            "onSelectionChange": [MockFunction],
+          }
+        }
+        sorting={true}
+        tableLayout="auto"
+      />
+    </EuiPageBody>
+  </EuiPageContent>
+  <TenantEditModal
+    action="edit"
+    handleClose={[Function]}
+    handleSave={[Function]}
+    tenantDescription=""
+    tenantName="tenant_2"
+  />
+  <EuiGlobalToastList
+    dismissToast={[MockFunction]}
+    side="right"
+    toastLifeTimeMs={10000}
+    toasts={Array []}
+  />
+</Fragment>
+`;

--- a/public/apps/configuration/panels/tenant-list/test/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/edit-modal.test.tsx
@@ -19,9 +19,13 @@ import { TenantEditModal } from '../edit-modal';
 import { Action } from '../../../types';
 
 describe('Permission edit modal', () => {
-  it('Submit change', () => {
-    const handleSave = jest.fn();
-    const component = shallow(
+  let component;
+  const handleSave = jest.fn();
+  const setState = jest.fn();
+  const useState = jest.spyOn(React, 'useState');
+  beforeEach(() => {
+    useState.mockImplementation((initialValue) => [initialValue, setState]);
+    component = shallow(
       <TenantEditModal
         tenantName={'tenant1'}
         tenantDescription={'description1'}
@@ -30,8 +34,37 @@ describe('Permission edit modal', () => {
         handleSave={handleSave}
       />
     );
+  });
+  it('Submit change', () => {
     component.find('#submit').simulate('click');
 
     expect(handleSave).toBeCalled();
+  });
+
+  it('handle tenant description change', () => {
+    const event = {
+      target: { value: 'dummy' },
+    } as React.ChangeEvent<HTMLTextAreaElement>;
+    component.find('[data-test-subj="tenant-description"]').simulate('change', event);
+    expect(setState).toBeCalledWith('dummy');
+  });
+
+  it('Submit button text should be Create when user is creating tenant', () => {
+    const submitButton = component.find('#submit').dive();
+    expect(submitButton).toMatchSnapshot();
+  });
+
+  it('Submit button text should be Save when user is updating tenant', () => {
+    const component1 = shallow(
+      <TenantEditModal
+        tenantName={'tenant1'}
+        tenantDescription={'description1'}
+        action={Action.edit}
+        handleClose={jest.fn()}
+        handleSave={handleSave}
+      />
+    );
+    const submitButton = component1.find('#submit').dive();
+    expect(submitButton).toMatchSnapshot();
   });
 });

--- a/public/apps/configuration/panels/tenant-list/test/tenant-instruction-view.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/tenant-instruction-view.test.tsx
@@ -1,0 +1,25 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { TenantInstructionView } from '../tenant-instruction-view';
+
+describe('Tenant instruction view', () => {
+  it('renders', () => {
+    const component = shallow(<TenantInstructionView />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Role list Render columns render Customization column 1`] = `
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="xs"
+>
+  <EuiFlexItem
+    grow={false}
+  >
+    <EuiIcon
+      type="lock"
+    />
+  </EuiFlexItem>
+  <EuiFlexItem
+    grow={false}
+  >
+    <EuiText
+      className="table-items"
+    >
+      Reserved
+    </EuiText>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`Role list Render columns render role name column 1`] = `
+<a
+  href="#/roles/view/role1"
+>
+  role1
+</a>
+`;

--- a/public/apps/configuration/panels/test/role-list.test.tsx
+++ b/public/apps/configuration/panels/test/role-list.test.tsx
@@ -14,13 +14,27 @@
  */
 
 import { RoleList } from '../role-list';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
-import { EuiInMemoryTable } from '@elastic/eui';
+import { EuiInMemoryTable, EuiTableFieldDataColumnType } from '@elastic/eui';
+import { buildHashUrl } from '../../utils/url-builder';
+import { Action, ResourceType } from '../../types';
+import { RoleListing } from '../../utils/role-list-utils';
+import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
 
 jest.mock('../../utils/role-list-utils');
-jest.mock('../../utils/url-builder');
-jest.mock('../../utils/display-utils');
+jest.mock('../../utils/display-utils', () => ({
+  ...jest.requireActual('../../utils/display-utils'),
+  ExternalLink: jest.fn(),
+}));
+jest.mock('../../utils/context-menu', () => ({
+  useContextMenuState: jest
+    .fn()
+    .mockImplementation((buttonText, buttonProps, children) => [children, jest.fn()]),
+}));
+jest.mock('../../utils/delete-confirm-modal-utils', () => ({
+  useDeleteConfirmState: jest.fn().mockReturnValue([jest.fn(), '']),
+}));
 // eslint-disable-next-line
 const mockRoleListUtils = require('../../utils/role-list-utils');
 
@@ -117,6 +131,122 @@ describe('Role list', () => {
       expect(mockRoleListUtils.transformRoleData).toHaveBeenCalledTimes(1);
       expect(setState).toHaveBeenCalledWith(mockRoleListingData);
       done();
+    });
+  });
+
+  it('delete role', (done) => {
+    shallow(
+      <RoleList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+    const deleteFunc = useDeleteConfirmState.mock.calls[0][0];
+
+    deleteFunc();
+
+    process.nextTick(() => {
+      expect(mockRoleListUtils.requestDeleteRoles).toBeCalled();
+      done();
+    });
+  });
+
+  it('error occurred while deleting the role', () => {
+    (mockRoleListUtils.requestDeleteRoles as jest.Mock).mockImplementationOnce(() => {
+      throw new Error();
+    });
+    const spy = jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+    shallow(
+      <RoleList
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+    const deleteFunc = useDeleteConfirmState.mock.calls[0][0];
+
+    deleteFunc();
+    expect(spy).toBeCalled();
+  });
+
+  describe('Action menu click', () => {
+    let component;
+    const mockRoleListingData: RoleListing = {
+      roleName: 'role_1',
+      reserved: true,
+      clusterPermissions: ['readonly'],
+      indexPermissions: ['data1'],
+      tenantPermissions: ['tenant1'],
+      internalUsers: [],
+      backendRoles: [],
+    };
+    beforeEach(() => {
+      jest.spyOn(React, 'useState').mockImplementation(() => [[mockRoleListingData], jest.fn()]);
+      component = shallow(
+        <RoleList
+          coreStart={mockCoreStart as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+    });
+
+    it('Edit click', () => {
+      component.find('[data-test-subj="edit"]').simulate('click');
+      expect(window.location.hash).toBe(
+        buildHashUrl(ResourceType.roles, Action.edit, mockRoleListingData.roleName)
+      );
+    });
+
+    it('Duplicate click', () => {
+      component.find('[data-test-subj="duplicate"]').simulate('click');
+      expect(window.location.hash).toBe(
+        buildHashUrl(ResourceType.roles, Action.duplicate, mockRoleListingData.roleName)
+      );
+    });
+  });
+
+  describe('Render columns', () => {
+    it('render role name column', () => {
+      const wrapper = shallow(
+        <RoleList
+          coreStart={mockCoreStart as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+      const roleList = wrapper.find('[data-test-subj="role-list"]');
+      const component = mount(<>{roleList}</>);
+      const columns = component.prop<Array<EuiTableFieldDataColumnType<RoleListing>>>('columns');
+
+      const roleNameRenderer = columns[0].render as (roleName: string) => JSX.Element;
+      const Container = (props: { roleName: string }) => roleNameRenderer(props.roleName);
+      const result = shallow(<Container roleName={'role1'} />);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('render Customization column', () => {
+      const wrapper = shallow(
+        <RoleList
+          coreStart={mockCoreStart as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={{} as any}
+        />
+      );
+      const roleList = wrapper.find('[data-test-subj="role-list"]');
+      const component = mount(<>{roleList}</>);
+      const columns = component.prop<Array<EuiTableFieldDataColumnType<RoleListing>>>('columns');
+
+      const customizationRenderer = columns[6].render as (reserved: boolean) => JSX.Element;
+      const Container = (props: { reserved: boolean }) => customizationRenderer(props.reserved);
+      const result = shallow(<Container reserved={true} />);
+      expect(result).toMatchSnapshot();
     });
   });
 });

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -93,7 +93,7 @@ export function getColumns(currentUsername: string) {
 export function UserList(props: AppDependencies) {
   const [userData, setUserData] = React.useState<InternalUsersListing[]>([]);
   const [errorFlag, setErrorFlag] = React.useState(false);
-  const [selection, setSelection] = useState<InternalUsersListing[]>([]);
+  const [selection, setSelection] = React.useState<InternalUsersListing[]>([]);
   const [currentUsername, setCurrentUsername] = useState('');
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState<Query | null>(null);
@@ -139,6 +139,7 @@ export function UserList(props: AppDependencies) {
 
   const actionsMenuItems = [
     <EuiButtonEmpty
+      data-test-subj="edit"
       key="edit"
       onClick={() => {
         window.location.href = buildHashUrl(ResourceType.users, Action.edit, selection[0].username);
@@ -148,6 +149,7 @@ export function UserList(props: AppDependencies) {
       Edit
     </EuiButtonEmpty>,
     <EuiButtonEmpty
+      data-test-subj="duplicate"
       key="duplicate"
       onClick={() => {
         window.location.href = buildHashUrl(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adds more functional test cases for role-view
- Adds more functional test cases for role-list
- Adds more functional test cases for user-list
- Adds more functional test cases for tenant-list

Folder level coverage:
File                                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s      
-----------------------------------------------------|---------|----------|---------|---------|--------------------
 public/apps/configuration/panels/role-view          |    92.7 |    76.19 |   86.49 |   93.38 |                        
  cluster-permission-panel.tsx                       |     100 |      100 |     100 |     100 |                        
  index-permission-panel.tsx                         |    96.3 |    83.33 |     100 |    96.3 | 53                     
  role-view.tsx                                      |   86.36 |    58.33 |   58.33 |   87.69 | ...148-149,151-152,371 
  tenants-panel.tsx                                  |     100 |       75 |     100 |     100 | 204-208  
public/apps/configuration/panels/tenant-list        |      88 |    81.25 |   71.88 |   88.78 |                        
  edit-modal.tsx                                     |     100 |      100 |     100 |     100 |                        
  tenant-instruction-view.tsx                        |     100 |      100 |     100 |     100 |                        
  tenant-list.tsx                                    |   86.81 |    78.57 |   67.86 |   87.64 | ...180-223,298,379-380
public/apps/configuration/panels                    |   92.16 |    92.31 |   84.62 |   93.88 |                        
  expression-modal.tsx                               |     100 |      100 |     100 |     100 |                        
  get-started.tsx                                    |   88.89 |      100 |    87.5 |   88.89 | 233                    
  nav-panel.tsx                                      |     100 |      100 |     100 |     100 |                        
  role-list.tsx                                      |   90.24 |       90 |      75 |    92.5 | 189-192 

Coverage before this PR: 67.44%
Coverage after this PR: 72.32%
The change in coverage: +4.88%

Codecov report: https://codecov.io/gh/opendistro-for-elasticsearch/security-kibana-plugin/commits


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
