### PR TITLE
Return 401 for ajax calls session when timeout for SAML and OpenID

### DIFF
--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -171,6 +171,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
           if (request.url.pathname && request.url.pathname.startsWith('/bundles/')) {
             return toolkit.notHandled();
           }
+          this.sessionStorageFactory.asScoped(request).clear();
           return this.handleUnauthedRequest(request, response, toolkit);
         }
         throw error;
@@ -221,6 +222,11 @@ export abstract class AuthenticationType implements IAuthenticationType {
       cookie
     );
     return selectedTenant;
+  }
+
+  isPageRequest(request: KibanaRequest) {
+    const path = request.url.pathname || '/';
+    return path.startsWith('/app/') || path === '/' || path.startsWith('/goto/');
   }
 
   // abstract functions for concrete auth types to implement

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -104,10 +104,7 @@ export class BasicAuthentication extends AuthenticationType {
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit
   ): KibanaResponse {
-    // TODO: do the samething for other auth types?
-    // return 302 for /app
-    const pathname = request.url.pathname || '';
-    if (pathname.startsWith('/app/') || pathname === '/') {
+    if (this.isPageRequest(request)) {
       const nextUrlParam = composeNextUrlQeuryParam(
         request,
         this.coreSetup.http.basePath.serverBasePath

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -180,8 +180,7 @@ export class OpenIdAuthentication extends AuthenticationType {
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit
   ): IKibanaResponse {
-    this.sessionStorageFactory.asScoped(request).clear();
-    if (request.url.pathname!.startsWith('/app/') || request.url.pathname === '/') {
+    if (this.isPageRequest(request)) {
       // nextUrl is a key value pair
       const nextUrl = composeNextUrlQeuryParam(
         request,

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -104,7 +104,11 @@ export class SamlAuthentication extends AuthenticationType {
     response: LifecycleResponseFactory,
     toolkit: AuthToolkit
   ): IKibanaResponse | AuthResult {
-    return this.redirectToLoginUri(request, toolkit);
+    if (this.isPageRequest(request)) {
+      return this.redirectToLoginUri(request, toolkit);
+    } else {
+      return response.unauthorized();
+    }
   }
 
   buildAuthHeaderFromCookie(cookie: SecuritySessionCookie): any {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When session timed out for SAML and OpenID, security plugin returns 302 to redirect the request to IDP for logging in, but this doesn't work for ajax request.

This change returns 401 for ajax request, thus let the browser to handle page refresh, so that it can redirect the browser to login.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
