### PR TITLE
explicitly set main branch as default for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,2 @@
-coverage:
+codecov:
   branch: main


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
explicitly sets main branch as default for codecov


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
