### PR TITLE
Fix a bug of page crash when server turn empty response body

### DIFF
--- a/public/apps/configuration/utils/request-utils.ts
+++ b/public/apps/configuration/utils/request-utils.ts
@@ -49,7 +49,7 @@ export async function requestWithIgnores<T>(
   try {
     return await request<T>(requestFunc, url, body);
   } catch (e) {
-    if (!ignores.includes(e?.body.statusCode)) {
+    if (!ignores.includes(e?.response?.status)) {
       throw e;
     }
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Page crashes when server turn empty response body with header `application/json`, it throws a JSON parsing exception and thus body is null. This change is to fix it.

Code referred to:
https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/blob/9274ab16113a18a6fe504dfbf1970463cf3f25da/public/plugin.ts#L172

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
