### PR TITLE
Revert name of external identity back to backend role

### DIFF
--- a/public/apps/account/role-info-panel.tsx
+++ b/public/apps/account/role-info-panel.tsx
@@ -63,10 +63,10 @@ export function RoleInfoPanel(props: { coreStart: CoreStart; handleClose: () => 
           ))}
           <EuiHorizontalRule />
           <EuiTitle>
-            <h4>External identities ({backendRoles.length})</h4>
+            <h4>Backend roles ({backendRoles.length})</h4>
           </EuiTitle>
           <EuiText color="subdued">
-            External identities you are currently mapped to by your administrator.
+            Backend roles you are currently mapped to by your administrator.
           </EuiText>
           <EuiSpacer />
           {backendRoles.map((item) => (

--- a/public/apps/account/test/__snapshots__/role-info-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/role-info-panel.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Account menu - Role info panel renders 1`] = `
       <EuiHorizontalRule />
       <EuiTitle>
         <h4>
-          External identities (
+          Backend roles (
           2
           )
         </h4>
@@ -44,7 +44,7 @@ exports[`Account menu - Role info panel renders 1`] = `
       <EuiText
         color="subdued"
       >
-        External identities you are currently mapped to by your administrator.
+        Backend roles you are currently mapped to by your administrator.
       </EuiText>
       <EuiSpacer />
       <EuiText

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -95,7 +95,7 @@ export function AuthorizationPanel(props: { authz: []; loading: boolean }) {
   return (
     <PanelWithHeader
       headerText={headerText}
-      headerSubText="After the user authenticates, the security plugin can collect external identities, such as LDAP groups, from authorization backends. These backends have no execution order; the plugin tries to collect external identities from all of them."
+      headerSubText="After the user authenticates, the security plugin can collect backend roles, such as LDAP groups, from authorization backends. These backends have no execution order; the plugin tries to collect backend roles from all of them."
       helpLink={DocLinks.BackendConfigurationAuthorizationDoc}
       count={Query.execute(query || '', items).length}
     >

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -45,9 +45,8 @@ const setOfSteps = [
           information to<EuiCode>plugins/opendistro_security/securityconfig/config.yml</EuiCode>.
           The <EuiCode>authc</EuiCode> section contains the backends to check user credentials
           against. The <EuiCode>authz</EuiCode>
-          section contains any backends to fetch backend roles from. The most common example
-          of an backend role is an LDAP group.{' '}
-          <ExternalLink href={DocLinks.AuthenticationFlowDoc} />
+          section contains any backends to fetch backend roles from. The most common example of an
+          backend role is an LDAP group. <ExternalLink href={DocLinks.AuthenticationFlowDoc} />
         </EuiText>
 
         <EuiSpacer size="m" />

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -45,8 +45,8 @@ const setOfSteps = [
           information to<EuiCode>plugins/opendistro_security/securityconfig/config.yml</EuiCode>.
           The <EuiCode>authc</EuiCode> section contains the backends to check user credentials
           against. The <EuiCode>authz</EuiCode>
-          section contains any backends to fetch external identities from. The most common example
-          of an external identity is an LDAP group.{' '}
+          section contains any backends to fetch backend roles from. The most common example
+          of an backend role is an LDAP group.{' '}
           <ExternalLink href={DocLinks.AuthenticationFlowDoc} />
         </EuiText>
 
@@ -122,7 +122,7 @@ const setOfSteps = [
       <>
         <EuiText size="s" color="subdued">
           After a user successfully authenticates, the security plugin retrieves that user’s roles.
-          You can map roles directly to users, but you can also map them to external identities.{' '}
+          You can map roles directly to users, but you can also map them to backend roles.{' '}
           <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
         </EuiText>
 

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -45,7 +45,7 @@ const setOfSteps = [
           information to<EuiCode>plugins/opendistro_security/securityconfig/config.yml</EuiCode>.
           The <EuiCode>authc</EuiCode> section contains the backends to check user credentials
           against. The <EuiCode>authz</EuiCode>
-          section contains any backends to fetch backend roles from. The most common example of an
+          section contains any backends to fetch backend roles from. The most common example of a
           backend role is an LDAP group. <ExternalLink href={DocLinks.AuthenticationFlowDoc} />
         </EuiText>
 

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -82,7 +82,7 @@ const columns: Array<EuiBasicTableColumn<RoleListing>> = [
   },
   {
     field: 'backendRoles',
-    name: 'External indentities',
+    name: 'Backend roles',
     render: truncatedListView(tableItemsUIProps),
   },
   {
@@ -216,7 +216,7 @@ export function RoleList(props: AppDependencies) {
         {
           type: 'field_value_selection',
           field: 'backendRoles',
-          name: 'External identities',
+          name: 'Backend roles',
           multiSelect: 'or',
           options: buildSearchFilterOptions(roleData, 'backendRoles'),
         },

--- a/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
@@ -71,7 +71,7 @@ export function ExternalIdentitiesPanel(props: {
       <Fragment key={`externalIdentity-${arrayIndex}`}>
         <EuiFlexGroup>
           <EuiFlexItem style={{ maxWidth: '400px' }}>
-            <FormRow headerText={arrayIndex === 0 ? 'backend roles' : ''}>
+            <FormRow headerText={arrayIndex === 0 ? 'Backend roles' : ''}>
               <EuiFieldText
                 id={`externalIdentity-${arrayIndex}`}
                 value={externalIdentity.externalIdentity}

--- a/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
@@ -71,12 +71,12 @@ export function ExternalIdentitiesPanel(props: {
       <Fragment key={`externalIdentity-${arrayIndex}`}>
         <EuiFlexGroup>
           <EuiFlexItem style={{ maxWidth: '400px' }}>
-            <FormRow headerText={arrayIndex === 0 ? 'External identities' : ''}>
+            <FormRow headerText={arrayIndex === 0 ? 'backend roles' : ''}>
               <EuiFieldText
                 id={`externalIdentity-${arrayIndex}`}
                 value={externalIdentity.externalIdentity}
                 onChange={(e) => onValueChangeHandler('externalIdentity')(e.target.value)}
-                placeholder="Type in external identity"
+                placeholder="Type in backend role"
               />
             </FormRow>
           </EuiFlexItem>
@@ -98,8 +98,8 @@ export function ExternalIdentitiesPanel(props: {
 
   return (
     <PanelWithHeader
-      headerText="External identities"
-      headerSubText="Use an external identity to directly map to roles through an external authentication system."
+      headerText="Backend roles"
+      headerSubText="Use a backend role to directly map to roles through an external authentication system."
       helpLink={DocLinks.CreateUsersDoc}
     >
       {panel}
@@ -110,7 +110,7 @@ export function ExternalIdentitiesPanel(props: {
           appendElementToArray(setExternalIdentities, [], getEmptyExternalIdentity());
         }}
       >
-        Add another external identity
+        Add another backend role
       </EuiButton>
     </PanelWithHeader>
   );

--- a/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
+++ b/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
@@ -97,7 +97,7 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
 
   const updateRoleMappingHandler = async () => {
     try {
-      // Remove empty External Identities
+      // Remove empty backend roles
       const validExternalIdentities = externalIdentities.filter(
         (v: ExternalIdentityStateClass) => v.externalIdentity !== ''
       );
@@ -141,7 +141,7 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
             <h1>Map user</h1>
           </EuiTitle>
           Map users to this role to inherit role permissions. Two types of users are supported:
-          user, and external identity. <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
+          user, and backend role. <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
         </EuiText>
       </EuiPageHeader>
       <EuiSpacer size="m" />

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -284,10 +284,10 @@ export function RoleView(props: RoleViewProps) {
                   </h3>
                 </EuiTitle>
                 <EuiText size="xs" color="subdued" className="panel-header-subtext">
-                  You can map two types of users: users and backend roles. A user can have its
-                  own backend role and host for an external authentication and authorization. A
-                  backend role directly maps to roles through an external authentication
-                  system. <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
+                  You can map two types of users: users and backend roles. A user can have its own
+                  backend role and host for an external authentication and authorization. A backend
+                  role directly maps to roles through an external authentication system.{' '}
+                  <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
                 </EuiText>
               </EuiPageContentHeaderSection>
               <EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -175,7 +175,7 @@ export function RoleView(props: RoleViewProps) {
       titleSize="s"
       body={
         <EuiText size="s" color="subdued" grow={false}>
-          <p>You can map users or external identities to this role</p>
+          <p>You can map users or backend roles to this role</p>
         </EuiText>
       }
       actions={
@@ -284,9 +284,9 @@ export function RoleView(props: RoleViewProps) {
                   </h3>
                 </EuiTitle>
                 <EuiText size="xs" color="subdued" className="panel-header-subtext">
-                  You can map two types of users: users and external identities. A user can have its
-                  own backend role and host for an external authentication and authorization. An
-                  external identity directly maps to roles through an external authentication
+                  You can map two types of users: users and backend roles. A user can have its
+                  own backend role and host for an external authentication and authorization. A
+                  backend role directly maps to roles through an external authentication
                   system. <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
                 </EuiText>
               </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
@@ -165,7 +165,8 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                     color="subdued"
                     size="xs"
                   >
-                    You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system. 
+                    You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system.
+                     
                     <ExternalLink
                       href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
                     />
@@ -360,7 +361,8 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                   color="subdued"
                   size="xs"
                 >
-                  You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system. 
+                  You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system.
+                   
                   <ExternalLink
                     href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
                   />
@@ -546,7 +548,8 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                     color="subdued"
                     size="xs"
                   >
-                    You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system. 
+                    You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system.
+                     
                     <ExternalLink
                       href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
                     />

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                     color="subdued"
                     size="xs"
                   >
-                    You can map two types of users: users and external identities. A user can have its own backend role and host for an external authentication and authorization. An external identity directly maps to roles through an external authentication system. 
+                    You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system. 
                     <ExternalLink
                       href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
                     />
@@ -248,7 +248,7 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                           size="s"
                         >
                           <p>
-                            You can map users or external identities to this role
+                            You can map users or backend roles to this role
                           </p>
                         </EuiText>
                       }
@@ -360,7 +360,7 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                   color="subdued"
                   size="xs"
                 >
-                  You can map two types of users: users and external identities. A user can have its own backend role and host for an external authentication and authorization. An external identity directly maps to roles through an external authentication system. 
+                  You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system. 
                   <ExternalLink
                     href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
                   />
@@ -443,7 +443,7 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                         size="s"
                       >
                         <p>
-                          You can map users or external identities to this role
+                          You can map users or backend roles to this role
                         </p>
                       </EuiText>
                     }
@@ -546,7 +546,7 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                     color="subdued"
                     size="xs"
                   >
-                    You can map two types of users: users and external identities. A user can have its own backend role and host for an external authentication and authorization. An external identity directly maps to roles through an external authentication system. 
+                    You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system. 
                     <ExternalLink
                       href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"
                     />
@@ -629,7 +629,7 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                           size="s"
                         >
                           <p>
-                            You can map users or external identities to this role
+                            You can map users or backend roles to this role
                           </p>
                         </EuiText>
                       }

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -69,8 +69,7 @@ exports[`Get started (landing page) renders 1`] = `
                   <EuiCode>
                     authz
                   </EuiCode>
-                  section contains any backends to fetch backend roles from. The most common example of an backend role is an LDAP group.
-                   
+                  section contains any backends to fetch backend roles from. The most common example of an backend role is an LDAP group. 
                   <ExternalLink
                     href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/concepts/"
                   />

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`Get started (landing page) renders 1`] = `
                   <EuiCode>
                     authz
                   </EuiCode>
-                  section contains any backends to fetch backend roles from. The most common example of an backend role is an LDAP group. 
+                  section contains any backends to fetch backend roles from. The most common example of a backend role is an LDAP group. 
                   <ExternalLink
                     href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/concepts/"
                   />

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`Get started (landing page) renders 1`] = `
                   <EuiCode>
                     authz
                   </EuiCode>
-                  section contains any backends to fetch external identities from. The most common example of an external identity is an LDAP group.
+                  section contains any backends to fetch backend roles from. The most common example of an backend role is an LDAP group.
                    
                   <ExternalLink
                     href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/concepts/"
@@ -160,7 +160,7 @@ exports[`Get started (landing page) renders 1`] = `
                   color="subdued"
                   size="s"
                 >
-                  After a user successfully authenticates, the security plugin retrieves that user’s roles. You can map roles directly to users, but you can also map them to external identities.
+                  After a user successfully authenticates, the security plugin retrieves that user’s roles. You can map roles directly to users, but you can also map them to backend roles.
                    
                   <ExternalLink
                     href="https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#map-users-to-roles"

--- a/public/apps/configuration/utils/role-mapping-utils.tsx
+++ b/public/apps/configuration/utils/role-mapping-utils.tsx
@@ -27,7 +27,7 @@ export interface MappedUsersListing {
 
 export enum UserType {
   internal = 'User',
-  external = 'External identity',
+  external = 'Backend role',
 }
 
 export async function getRoleMappingData(http: HttpStart, roleName: string) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert name of external identity back to backend role for backward compatibility.

Screenshots:
![image](https://user-images.githubusercontent.com/63078162/99002847-f8833a00-24f1-11eb-8c98-1e2ca00bbd8a.png)
![image](https://user-images.githubusercontent.com/63078162/99002914-16509f00-24f2-11eb-9bf2-26f03fc43efd.png)
![image](https://user-images.githubusercontent.com/63078162/99002970-2ff1e680-24f2-11eb-86fc-97b78310d6c5.png)
![image](https://user-images.githubusercontent.com/63078162/99003148-73e4eb80-24f2-11eb-8e7a-69e34ebd3dd3.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
