### PR TITLE
Clear old version cookies before logging in

### DIFF
--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -44,7 +44,17 @@ export class BasicAuthRoutes {
       },
       async (context, request, response) => {
         this.sessionStorageFactory.asScoped(request).clear();
-        return response.renderAnonymousCoreApp();
+        let clearOldVersionCookie: string;
+        if (this.config.cookie.secure) {
+          clearOldVersionCookie = 'security_authentication=; Secure; HttpOnly; Path=/';
+        } else {
+          clearOldVersionCookie = 'security_authentication=; HttpOnly; Path=/';
+        }
+        return response.renderAnonymousCoreApp({
+          headers: {
+            'set-cookie': clearOldVersionCookie,
+          },
+        });
       }
     );
 

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -15,7 +15,10 @@
 
 import { schema } from '@kbn/config-schema';
 import { IRouter, SessionStorageFactory, CoreSetup } from 'kibana/server';
-import { SecuritySessionCookie } from '../../../session/security_cookie';
+import {
+  SecuritySessionCookie,
+  clearOldVersionCookieValue,
+} from '../../../session/security_cookie';
 import { SecurityPluginConfigType } from '../../..';
 import { User } from '../../user';
 import { SecurityClient } from '../../../backend/opendistro_security_client';
@@ -44,12 +47,7 @@ export class BasicAuthRoutes {
       },
       async (context, request, response) => {
         this.sessionStorageFactory.asScoped(request).clear();
-        let clearOldVersionCookie: string;
-        if (this.config.cookie.secure) {
-          clearOldVersionCookie = 'security_authentication=; Secure; HttpOnly; Path=/';
-        } else {
-          clearOldVersionCookie = 'security_authentication=; HttpOnly; Path=/';
-        }
+        const clearOldVersionCookie = clearOldVersionCookieValue(this.config);
         return response.renderAnonymousCoreApp({
           headers: {
             'set-cookie': clearOldVersionCookie,

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -27,7 +27,10 @@ import {
   IKibanaResponse,
   AuthResult,
 } from '../../../../../../src/core/server';
-import { SecuritySessionCookie } from '../../../session/security_cookie';
+import {
+  SecuritySessionCookie,
+  clearOldVersionCookieValue,
+} from '../../../session/security_cookie';
 import { SamlAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
 
@@ -55,12 +58,7 @@ export class SamlAuthentication extends AuthenticationType {
 
   private redirectToLoginUri(request: KibanaRequest, toolkit: AuthToolkit) {
     const nextUrl = this.generateNextUrl(request);
-    let clearOldVersionCookie: string;
-    if (this.config.cookie.secure) {
-      clearOldVersionCookie = 'security_authentication=; Secure; HttpOnly; Path=/';
-    } else {
-      clearOldVersionCookie = 'security_authentication=; HttpOnly; Path=/';
-    }
+    const clearOldVersionCookie = clearOldVersionCookieValue(this.config);
     return toolkit.redirected({
       location: `${this.coreSetup.http.basePath.serverBasePath}/auth/saml/login?nextUrl=${nextUrl}`,
       'set-cookie': clearOldVersionCookie,

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -55,8 +55,15 @@ export class SamlAuthentication extends AuthenticationType {
 
   private redirectToLoginUri(request: KibanaRequest, toolkit: AuthToolkit) {
     const nextUrl = this.generateNextUrl(request);
+    let clearOldVersionCookie: string;
+    if (this.config.cookie.secure) {
+      clearOldVersionCookie = 'security_authentication=; Secure; HttpOnly; Path=/';
+    } else {
+      clearOldVersionCookie = 'security_authentication=; HttpOnly; Path=/';
+    }
     return toolkit.redirected({
       location: `${this.coreSetup.http.basePath.serverBasePath}/auth/saml/login?nextUrl=${nextUrl}`,
+      'set-cookie': clearOldVersionCookie,
     });
   }
 

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -75,8 +75,8 @@ export function getSecurityCookieOptions(
 
 export function clearOldVersionCookieValue(config: SecurityPluginConfigType): string {
   if (config.cookie.secure) {
-      return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Path=/';
+    return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Path=/';
   } else {
-      return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/';
+    return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/';
   }
 }

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -72,3 +72,11 @@ export function getSecurityCookieOptions(
     sameSite: config.cookie.isSameSite || undefined,
   };
 }
+
+export function clearOldVersionCookieValue(config: SecurityPluginConfigType): string {
+  if (config.cookie.secure) {
+      return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Path=/';
+  } else {
+      return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/';
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Clear `security_authentication` cookie that always use path `/`, and cannot be cleared by the version 7.9 and above.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
