### PR TITLE
Make graphics on get started page center aligned

### DIFF
--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -185,11 +185,13 @@ export function GetStarted(props: AppDependencies) {
 
           <EuiSpacer size="l" />
           {props.config.ui.backend_configurable && (
-            <EuiImage
-              size="xl"
-              alt="Three steps to set up your security"
-              url={securityStepsDiagram}
-            />
+            <div className="text-center">
+              <EuiImage
+                size="xl"
+                alt="Three steps to set up your security"
+                url={securityStepsDiagram}
+              />
+            </div>
           )}
 
           <EuiSpacer size="l" />

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -233,11 +233,15 @@ exports[`Get started (landing page) renders when backend configuration is enable
       <EuiSpacer
         size="l"
       />
-      <EuiImage
-        alt="Three steps to set up your security"
-        size="xl"
-        url="test-file-stub"
-      />
+      <div
+        className="text-center"
+      >
+        <EuiImage
+          alt="Three steps to set up your security"
+          size="xl"
+          url="test-file-stub"
+        />
+      </div>
       <EuiSpacer
         size="l"
       />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Makes graphics on get started page center aligned

Screenshot:
![image](https://user-images.githubusercontent.com/63824432/99131451-073c2080-25c8-11eb-9487-3043d771c3e6.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
