### PR TITLE
Update CI/CD workflow and ES and security plugin version for IT

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,13 +57,14 @@ jobs:
           cd ./kibana
           sed -i '170d' src/core/server/http/router/request.ts
       - name: build security plugin
+        id: build_zip
         run: |
           cd ./kibana/plugins/opendistro_security
           node build_tools/build_plugin.js
           artifact_path=`ls $(pwd)/build/opendistro_security_kibana_plugin-*.zip`
           artifact_name=`basename $artifact_path`
-          echo ::set-env name=ARTIFACT_PATH::$artifact_path
-          echo ::set-env name=ARTIFACT_NAME::$artifact_name
+          echo "::set-output name=ARTIFACT_PATH::$artifact_path"
+          echo "::set-output name=ARTIFACT_NAME::$artifact_name"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -73,5 +74,5 @@ jobs:
       - name: Upload Artifacts to S3
         run: |
           s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp ${{ env.ARTIFACT_PATH }} $s3_path/kibana-plugins/opendistro-security/
+          aws s3 cp ${{ steps.build_zip.outputs.ARTIFACT_PATH }} $s3_path/kibana-plugins/opendistro-security/
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,14 @@ jobs:
           node build_tools/build_plugin.js
           artifact_path=`ls $(pwd)/build/opendistro_security_kibana_plugin-*.zip`
           artifact_name=`basename $artifact_path`
-          echo name=ARTIFACT_PATH::$artifact_path >> $GITHUB_ENV
-          echo name=ARTIFACT_NAME::$artifact_name >> $GITHUB_ENV
+          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=$artifact_name" >> $GITHUB_ENV
+      - name: Test
+        run: 
+          echo $ARTIFACT_PATH
+          echo $ARTIFACT_NAME
       - name: Upload Workflow Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.ARTIFACT_PATH }}
+          name: $ARTIFACT_NAME
+          path: $ARTIFACT_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
           node build_tools/build_plugin.js
           artifact_path=`ls $(pwd)/build/opendistro_security_kibana_plugin-*.zip`
           artifact_name=`basename $artifact_path`
-          echo ::set-env name=ARTIFACT_PATH::$artifact_path
-          echo ::set-env name=ARTIFACT_NAME::$artifact_name
+          echo name=ARTIFACT_PATH::$artifact_path >> $GITHUB_ENV
+          echo name=ARTIFACT_NAME::$artifact_name >> $GITHUB_ENV
       - name: Upload Workflow Artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,19 +76,16 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: build security plugin
+        id: build_zip
         run: |
           cd ./kibana/plugins/opendistro_security
           node build_tools/build_plugin.js
           artifact_path=`ls $(pwd)/build/opendistro_security_kibana_plugin-*.zip`
           artifact_name=`basename $artifact_path`
-          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
-          echo "ARTIFACT_NAME=$artifact_name" >> $GITHUB_ENV
-      - name: Test
-        run: 
-          echo $ARTIFACT_PATH
-          echo $ARTIFACT_NAME
+          echo "::set-output name=ARTIFACT_PATH::$artifact_path"
+          echo "::set-output name=ARTIFACT_NAME::$artifact_name"
       - name: Upload Workflow Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ $ARTIFACT_NAME }}
-          path: ${{ $ARTIFACT_PATH }}
+          name: ${{ steps.build_zip.outputs.ARTIFACT_NAME }}
+          path: ${{ steps.build_zip.outputs.ARTIFACT_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,5 @@ jobs:
       - name: Upload Workflow Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: $ARTIFACT_NAME
-          path: $ARTIFACT_PATH
+          name: ${{ $ARTIFACT_NAME }}
+          path: ${{ $ARTIFACT_PATH }}

--- a/test/constant.ts
+++ b/test/constant.ts
@@ -16,8 +16,9 @@
 export const KIBANA_SERVER_USER: string = 'kibanaserver';
 export const KIBANA_SERVER_PASSWORD: string = 'kibanaserver';
 
-export const ELASTICSEARCH_VERSION: string = '7.8.0';
-export const SECURITY_ES_PLUGIN_VERSION: string = '1.9.0.0';
+// TODO: Parse this from package.json
+export const ELASTICSEARCH_VERSION: string = '7.9.1';
+export const SECURITY_ES_PLUGIN_VERSION: string = '1.11.0.0';
 
 export const ADMIN_USER: string = 'admin';
 export const ADMIN_PASSWORD: string = 'admin';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updates ES and Security plugin version in Constant file for integration testing.
- Uses `set-output` in place of `set-env` in CI/CD workflow.

*Testing:*
```
  opendistro_security %  yarn test:jest_server --coverage
  Test Suites: 5 passed, 5 total
  Tests:       41 passed, 41 total
  Snapshots:   0 total
  Time:        323.295s
  Ran all test suites.
  ✨  Done in 328.02s.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
