### PR TITLE
Add config for OIDC refresh token

### DIFF
--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -150,12 +150,16 @@ export class OpenIdAuthRoutes {
             username: user.username,
             credentials: {
               authHeaderValue: `Bearer ${tokenResponse.idToken}`,
-              refresh_token: tokenResponse.refreshToken,
               expires_at: Date.now() + tokenResponse.expiresIn! * 1000, // expiresIn is in second
             },
             authType: 'openid',
             expiryTime: Date.now() + this.config.session.ttl,
           };
+          if (this.config.openid?.refresh_tokens && tokenResponse.refreshToken) {
+            Object.assign(sessionStorage.credentials, {
+              refresh_token: tokenResponse.refreshToken,
+            });
+          }
           this.sessionStorageFactory.asScoped(request).set(sessionStorage);
           return response.redirected({
             headers: {

--- a/server/index.ts
+++ b/server/index.ts
@@ -132,6 +132,7 @@ export const configSchema = schema.object({
       logout_url: schema.string({ defaultValue: '' }),
       root_ca: schema.string({ defaultValue: '' }),
       verify_hostnames: schema.boolean({ defaultValue: true }),
+      refresh_tokens: schema.boolean({ defaultValue: true }),
     })
   ),
   proxycache: schema.maybe(


### PR DESCRIPTION
*Issue #, if available:* #516 

*Description of changes:* Add a config to allow users to choose whether to use `refresh_token` to refresh `id_token`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
