### PR TITLE
Update deployment process for 1.12

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,7 +63,7 @@ jobs:
         id: build_zip
         run: |
           cd ./kibana/plugins/opendistro_security
-          yarn build
+          yarn build --kibana-version ${{ steps.kbn_version.outputs.kbn_version }}
           artifact_path=`ls $(pwd)/build/opendistroSecurity-*.zip`
           artifact_name=`basename $artifact_path`
           echo "::set-output name=ARTIFACT_PATH::$artifact_path"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - opendistro-1.12
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - opendistro-1.12
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,10 @@ jobs:
         id: kbn_version
         run: |
           echo "::set-output name=kbn_version::$(jq -r '.kibana.version' ./kibana/plugins/opendistro_security/package.json)"
+      - name: Get plugin version
+        id: plugin_version
+        run: |
+          echo "::set-output name=plugin_version::$(jq -r .version ./kibana/plugins/opendistro_security/kibana.json)"
       - name: Use kibana release commit
         run: |
           cd ./kibana
@@ -52,16 +56,12 @@ jobs:
         run: |
           cd ./kibana
           yarn kbn bootstrap --oss
-      - name: Hack step to update kibana source to unblock tsc
-        run: |
-          cd ./kibana
-          sed -i '170d' src/core/server/http/router/request.ts
       - name: build security plugin
         id: build_zip
         run: |
           cd ./kibana/plugins/opendistro_security
-          node build_tools/build_plugin.js
-          artifact_path=`ls $(pwd)/build/opendistro_security_kibana_plugin-*.zip`
+          yarn build
+          artifact_path=`ls $(pwd)/build/opendistroSecurity-*.zip`
           artifact_name=`basename $artifact_path`
           echo "::set-output name=ARTIFACT_PATH::$artifact_path"
           echo "::set-output name=ARTIFACT_NAME::$artifact_name"
@@ -74,5 +74,5 @@ jobs:
       - name: Upload Artifacts to S3
         run: |
           s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp ${{ steps.build_zip.outputs.ARTIFACT_PATH }} $s3_path/kibana-plugins/opendistro-security/
+          aws s3 cp ${{ steps.build_zip.outputs.ARTIFACT_PATH }} $s3_path/kibana-plugins/opendistro-security/opendistroSecurityKibana-${{ steps.plugin_version.output.plugin_version }}.zip
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'

--- a/kibana.json
+++ b/kibana.json
@@ -1,6 +1,6 @@
 {
   "id": "opendistroSecurity",
-  "version": "1.12.0",
+  "version": "1.12.0.0",
   "kibanaVersion": "kibana",
   "configPath": ["opendistro_security"],
   "requiredPlugins": ["navigation"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Move to new build process `yarn build`
* Remove the hack for kibana since the new process that does not do typescript check
* Change the name from `opendistro_security_kibana_plugin-{version}.zip` to `opendistroSecurityKibana-{version}.zip` to be consistent with other opendistro plugins
* Update version number to 4 sections (1.12.0 -> 1.12.0.0)

*Test:*
It succeeded in build and failed in "Configure AWS Credentials" due to permission.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
