### PR TITLE
Fix a bug that logo size is improper on login page for some browsers

### DIFF
--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -93,7 +93,7 @@ export function LoginPage(props: LoginPageDeps) {
   return (
     <EuiListGroup className="login-wrapper">
       {props.config.showbrandimage && (
-        <EuiImage alt="" url={props.config.brandimage || defaultBrandImage} />
+        <EuiImage size="fullWidth" alt="" url={props.config.brandimage || defaultBrandImage} />
       )}
       <EuiSpacer size="s" />
       <EuiText size="m" textAlign="center">

--- a/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
+++ b/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Login page renders renders with config value 1`] = `
 >
   <EuiImage
     alt=""
+    size="fullWidth"
     url="http://localhost:5601/images/test.png"
   />
   <EuiSpacer


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a bug that logo size is improper on login page for some browsers.
Different browser has various default width value for svg image. This change set explicit full width for logo image.

Screenshots:
|Browser|Before|After|
|--|--|--|
|Chrome|![image](https://user-images.githubusercontent.com/63078162/100810494-7a79cb00-33ed-11eb-81d6-6dd50a7821b5.png)|![image](https://user-images.githubusercontent.com/63078162/100810292-07705480-33ed-11eb-98a2-214eb539d5d0.png)|
|Firefox|![image](https://user-images.githubusercontent.com/63078162/100810543-93827c00-33ed-11eb-9df8-5fbf11ac7a6b.png)|![image](https://user-images.githubusercontent.com/63078162/100810309-10f9bc80-33ed-11eb-9c2b-205701a07c42.png)|
|Safari|![image](https://user-images.githubusercontent.com/63078162/100810564-9ed5a780-33ed-11eb-9952-c4541633a510.png)|![image](https://user-images.githubusercontent.com/63078162/100810317-16ef9d80-33ed-11eb-890b-91acfc697a59.png)|

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
