### PR TITLE
Allow accessing legacy landing page for readonly user

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -69,7 +69,13 @@ const APP_ID_DASHBOARDS = 'dashboards';
 // Kibana app is for legacy url migration
 const APP_ID_KIBANA = 'kibana';
 const APP_ID_SHORT_URL_REDIRECT = '"short_url_redirect"';
-const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_KIBANA, APP_ID_SHORT_URL_REDIRECT, APP_ID_MULTITENANCY];
+const APP_LIST_FOR_READONLY_ROLE = [
+  APP_ID_HOME,
+  APP_ID_DASHBOARDS,
+  APP_ID_KIBANA,
+  APP_ID_SHORT_URL_REDIRECT,
+  APP_ID_MULTITENANCY,
+];
 
 export class OpendistroSecurityPlugin
   implements Plugin<OpendistroSecurityPluginSetup, OpendistroSecurityPluginStart> {
@@ -147,11 +153,7 @@ export class OpendistroSecurityPlugin
 
     core.application.registerAppUpdater(
       new BehaviorSubject<AppUpdater>((app) => {
-        if (
-          !apiPermission &&
-          isReadonly &&
-          !APP_LIST_FOR_READONLY_ROLE.includes(app.id)
-        ) {
+        if (!apiPermission && isReadonly && !APP_LIST_FOR_READONLY_ROLE.includes(app.id)) {
           return {
             status: AppStatus.inaccessible,
           };

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -66,6 +66,10 @@ async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
 const DEFAULT_READONLY_ROLES = ['kibana_read_only'];
 const APP_ID_HOME = 'home';
 const APP_ID_DASHBOARDS = 'dashboards';
+// Kibana app is for legacy url migration
+const APP_ID_KIBANA = 'kibana';
+const APP_ID_SHORT_URL_REDIRECT = '"short_url_redirect"';
+const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_KIBANA, APP_ID_SHORT_URL_REDIRECT, APP_ID_MULTITENANCY];
 
 export class OpendistroSecurityPlugin
   implements Plugin<OpendistroSecurityPluginSetup, OpendistroSecurityPluginStart> {
@@ -146,7 +150,7 @@ export class OpendistroSecurityPlugin
         if (
           !apiPermission &&
           isReadonly &&
-          ![APP_ID_DASHBOARDS, APP_ID_HOME, APP_ID_MULTITENANCY].includes(app.id)
+          !APP_LIST_FOR_READONLY_ROLE.includes(app.id)
         ) {
           return {
             status: AppStatus.inaccessible,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -68,12 +68,10 @@ const APP_ID_HOME = 'home';
 const APP_ID_DASHBOARDS = 'dashboards';
 // Kibana app is for legacy url migration
 const APP_ID_KIBANA = 'kibana';
-const APP_ID_SHORT_URL_REDIRECT = '"short_url_redirect"';
 const APP_LIST_FOR_READONLY_ROLE = [
   APP_ID_HOME,
   APP_ID_DASHBOARDS,
   APP_ID_KIBANA,
-  APP_ID_SHORT_URL_REDIRECT,
   APP_ID_MULTITENANCY,
 ];
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/639

*Description of changes:*
Allow accessing legacy landing page for readonly user.

With this change, readonly is able to access `/app/kibana` which redirects to `/app/home`.

'short_url_redirect' (`/goto`) is not needed since it is handled by server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
