### PR TITLE
Update build cmd in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ To build the security-kibana plugin from source follow these instructions:
 │   └── plugins
 │       └── opendistro_security
 ```
-* run the build script to build the plugin inside `kibana/plugins/opendistro_security` directory
-`node build_tools/build_plugin.js`
+* run `yarn build` to build the plugin inside `kibana/plugins/opendistro_security` directory
 
 The above builds the final artifacts in zip format. The artifacts can be found in the `kibana/plugins/opendistro_security/build` directory
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update build cmd in readme. The build cmd for 1.12 has been updated in https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/pull/627.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
