### PR TITLE
Fix github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         id: build_zip
         run: |
           cd ./kibana/plugins/opendistro_security
-          yarn build
+          yarn build --kibana-version {{ steps.kbn_version.outputs.kbn_version }}
           artifact_path=`ls $(pwd)/build/opendistroSecurityKibana-*.zip`
           artifact_name=`basename $artifact_path`
           echo "::set-output name=ARTIFACT_PATH::$artifact_path"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,6 @@ jobs:
         run: |
           cd ./kibana/plugins/opendistro_security
           yarn lint
-      - name: Hack step to update kibana source to unblock tsc
-        run: |
-          cd ./kibana
-          sed -i '170d' src/core/server/http/router/request.ts
-      - name: Run check
-        run: |
-          cd ./kibana/plugins/opendistro_security
-          yarn tsc
       - name: Run unit test
         run: |
           cd ./kibana/plugins/opendistro_security
@@ -79,8 +71,8 @@ jobs:
         id: build_zip
         run: |
           cd ./kibana/plugins/opendistro_security
-          node build_tools/build_plugin.js
-          artifact_path=`ls $(pwd)/build/opendistro_security_kibana_plugin-*.zip`
+          yarn build
+          artifact_path=`ls $(pwd)/build/opendistroSecurityKibana-*.zip`
           artifact_name=`basename $artifact_path`
           echo "::set-output name=ARTIFACT_PATH::$artifact_path"
           echo "::set-output name=ARTIFACT_NAME::$artifact_name"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         id: build_zip
         run: |
           cd ./kibana/plugins/opendistro_security
-          yarn build --kibana-version {{ steps.kbn_version.outputs.kbn_version }}
+          yarn build --kibana-version ${{ steps.kbn_version.outputs.kbn_version }}
           artifact_path=`ls $(pwd)/build/opendistroSecurityKibana-*.zip`
           artifact_name=`basename $artifact_path`
           echo "::set-output name=ARTIFACT_PATH::$artifact_path"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Remove typescript compilation since it has some conflict with current version.
2. Also remove the hack for typescript compilation
3. Update the generated zip file name in CI workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
