### PR TITLE
Change release workflows to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Upload Artifacts to S3
         shell: bash
         run: |
-          zip=${{ env.ARTIFACT_PATH }}
+          zip=${{ steps.build_zip.outputs.ARTIFACT_PATH }}
 
           # Inject the build number before the suffix
           zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,7 +82,7 @@ jobs:
           # Inject the build number before the suffix
           zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
 
-          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/kibana-plugins/security/"
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/security/"
 
           echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
           aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,6 +75,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: Upload Artifacts to S3
+        shell: bash
         run: |
           zip=${{ env.ARTIFACT_PATH }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,7 +82,8 @@ jobs:
           # Rename
           mv ${{ steps.build_zip.outputs.ARTIFACT_PATH }} opendistroSecurityKibana-${{ steps.plugin_version.outputs.plugin_version }}.zip
           ls -ltr
-          zip=`ls $(pwd)/build/opendistroSecurityKibana*.zip`
+          pwd
+          zip=`ls opendistroSecurityKibana*.zip`
           echo $zip
 
           # Inject the build number before the suffix

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,12 @@
 name: CD
 
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
+    branches:
+      - "release-workflow-patch"
 
 jobs:
   build:
@@ -68,11 +71,17 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: Upload Artifacts to S3
         run: |
-          s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp ${{ steps.build_zip.outputs.ARTIFACT_PATH }} $s3_path/kibana-plugins/opendistro-security/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
+          zip=${{ env.ARTIFACT_PATH }}
+
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/kibana-plugins/security/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,9 @@
 name: CD
 
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -81,10 +78,7 @@ jobs:
 
           # Rename
           mv ${{ steps.build_zip.outputs.ARTIFACT_PATH }} opendistroSecurityKibana-${{ steps.plugin_version.outputs.plugin_version }}.zip
-          ls -ltr
-          pwd
           zip=`ls opendistroSecurityKibana*.zip`
-          echo $zip
 
           # Inject the build number before the suffix
           zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,8 @@ jobs:
 
           # Rename
           mv ${{ steps.build_zip.outputs.ARTIFACT_PATH }} opendistroSecurityKibana-${{ steps.plugin_version.outputs.plugin_version }}.zip
-          zip=`ls $(pwd)/build/opendistroSecurity*.zip`
+          ls -ltr
+          zip=`ls $(pwd)/build/opendistroSecurityKibana*.zip`
           echo $zip
 
           # Inject the build number before the suffix

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,3 +85,4 @@ jobs:
 
           echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
           aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+          


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations. This PR changes the CD workflow to add a build number and write the zip artifact to staging.artifacts.opendistroforelasticsearch.amazon.com.

Test Results: 
https://github.com/gaiksaya/security-kibana-plugin/actions/runs/483512658

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
