### PR TITLE
Omit password field when not updating user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - opendistro-1.*
   push:
     branches:
       - main

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -98,14 +98,24 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         return;
       }
 
+      if (password === '' && props.action !== 'edit') {
+        addToast(createErrorToast('emptyPassword', 'Update error', 'Password is required.'));
+        return;
+      }
+
       // Remove attributes with empty key
       const validAttributes = attributes.filter((v: UserAttributeStateClass) => v.key !== '');
 
       const updateObject: InternalUserUpdate = {
-        password,
         backend_roles: backendRoles,
         attributes: unbuildAttributeState(validAttributes),
       };
+
+      // Password field should be omitted if not updating password.
+      if (password !== '') {
+        updateObject.password = password;
+      }
+
       await updateUser(props.coreStart.http, userName, updateObject);
 
       setCrossPageToast(buildUrl(ResourceType.users), {

--- a/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
@@ -15,6 +15,7 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
+import { InternalUserUpdate } from '../../../types';
 import { getUserDetail, updateUser } from '../../../utils/internal-user-detail-utils';
 import { createErrorToast } from '../../../utils/toast-utils';
 import { AttributePanel } from '../attribute-panel';
@@ -81,6 +82,27 @@ describe('Internal user edit', () => {
     expect(getUserDetail).toBeCalledWith(mockCoreStart.http, sampleUsername);
   });
 
+  it('should not submit if password is empty on creation', () => {
+    const action = 'create';
+    useState.mockImplementation((initialValue) => [initialValue, setState]);
+
+    const component = shallow(
+      <InternalUserEdit
+        action={action}
+        sourceUserName={sampleUsername}
+        buildBreadcrumbs={buildBreadcrumbs}
+        coreStart={mockCoreStart as any}
+        navigation={{} as any}
+        params={{} as any}
+        config={{} as any}
+      />
+    );
+    component.find('#submit').simulate('click');
+
+    expect(createErrorToast).toBeCalled();
+    expect(updateUser).toBeCalledTimes(0);
+  });
+
   it('submit change', () => {
     const action = 'edit';
 
@@ -98,6 +120,8 @@ describe('Internal user edit', () => {
     component.find('#submit').simulate('click');
 
     expect(updateUser).toBeCalled();
+    const userUpdateObj: InternalUserUpdate = updateUser.mock.calls[0][0];
+    expect(userUpdateObj.password).toEqual(undefined);
   });
 
   it('should create error toast when password is invalid', () => {

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -133,7 +133,7 @@ export interface InternalUser {
 }
 
 export interface InternalUserUpdate extends InternalUser {
-  password: string;
+  password?: string;
 }
 
 export interface ActionGroupUpdate {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -21,7 +21,7 @@ import { API_PREFIX, CONFIGURATION_API_PREFIX, isValidResourceName } from '../..
 export function defineRoutes(router: IRouter) {
   const internalUserSchema = schema.object({
     description: schema.maybe(schema.string()),
-    password: schema.string(),
+    password: schema.maybe(schema.string()),
     backend_roles: schema.arrayOf(schema.string(), { defaultValue: [] }),
     attributes: schema.any({ defaultValue: {} }),
   });


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/security/issues/996

*Description of changes:*
Omit password field when not updating internal user. 
When updating an internal user, in prior to 1.12, we submit empty password to indicate we're not updating password. Since 1.12, ES security plugin blocks empty password due to deserialization, which causes following error.
![image](https://user-images.githubusercontent.com/63078162/106217200-96011800-6189-11eb-9654-989383010600.png)

This change is to fix this issue.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
