### PR TITLE
Add new unauthenticated route for reporting stats API

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -69,7 +69,7 @@ export const configSchema = schema.object({
       },
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status'] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status', '/api/reporting/stats'] }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),

--- a/server/index.ts
+++ b/server/index.ts
@@ -69,7 +69,7 @@ export const configSchema = schema.object({
       },
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status', '/api/reporting/stats'] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status', '/api/reporting/stats'], }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),

--- a/server/index.ts
+++ b/server/index.ts
@@ -69,7 +69,9 @@ export const configSchema = schema.object({
       },
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status', '/api/reporting/stats'], }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), {
+      defaultValue: ['/api/status', '/api/reporting/stats']
+    }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,7 +70,7 @@ export const configSchema = schema.object({
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
     unauthenticated_routes: schema.arrayOf(schema.string(), {
-      defaultValue: ['/api/status', '/api/reporting/stats']
+      defaultValue: ['/api/status', '/api/reporting/stats'],
     }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change introduces new unauthenticated route for Kibana reporting stats API **api/reporting/stats**.
The API exposes operational and business metrics for Kibana Reporting plugin. 
See https://github.com/opendistro-for-elasticsearch/kibana-reports/pull/277

Sample response:
```
  {
  "report": {  
    "create": {  # POST /api/reporting/generateReport
      "count": 0,
      "system_error": 0,
      "user_error": 3,
      "total": 0
    },
    "create_from_definition": {  # POST /api/reporting/gemerateReport/{reportDefinitionId}
      "count": 1,
      "system_error": 0,
      "user_error": 0,
      "total": 1
    },
    "download": {  # GET /api/reporting/generateReport/{reportId}
      "count": 5,
      "system_error": 0,
      "user_error": 0,
      "total": 5
    },
    "list": {  # GET /api/reporting/reports
      "count": 7,
      "system_error": 0,
      "user_error": 0,
      "total": 7
    },
    "info": {  # GET /api/reporting/reports/{reportId}
      "count": 1,
      "system_error": 0,
      "user_error": 0,
      "total": 1
    }
  },
  "report_definition": {
    "create": {  # POST /api/reporting/reportDefinition
      "count": 0,
      "system_error": 0,
      "user_error": 0,
      "total": 0
    },
    "list": {  # GET /api/reporting/reportDefinitions
      "count": 7,
      "system_error": 0,
      "user_error": 0,
      "total": 7
    },
    "info": {  # GET /api/reporting/reportDefinition/{reportDefinitionId}
      "count": 3,
      "system_error": 0,
      "user_error": 0,
      "total": 3
    },
    "update": {   # PUT /api/reporting/reportDefinition/{reportDefinitionId}
      "count": 0,
      "system_error": 0,
      "user_error": 0,
      "total": 0
    },
    "delete": {   # DELETE /api/reporting/reportDefinition/{reportDefinitionId}
      "count": 1,
      "system_error": 0,
      "user_error": 0,
      "total": 1
    }
  },
  "report_source": {   # GET /api/reporting/reportSource/{reportSourceType}
    "list": {
      "count": 3,
      "system_error": 0,
      "user_error": 0,
      "total": 3
    }
  },
  "dashboard": {
    "pdf": {
      "download": {
        "count": 1,
        "total": 1
      }
    },
    "png": {
      "download": {
        "count": 1,
        "total": 1
      }
    }
  },
  "visualization": {
    "pdf": {
      "download": {
        "count": 0,
        "total": 0
      }
    },
    "png": {
      "download": {
        "count": 0,
        "total": 0
      }
    }
  },
  "saved_search": {
    "csv": {
      "download": {
        "count": 4,
        "total": 4
      }
    }
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
