### PR TITLE
Making sure SAML cookie uses saml session timeout value if it is avai…

### DIFF
--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -119,13 +119,22 @@ export class SamlAuthRoutes {
             'authorization',
             credentials.authorization
           );
+
+          let expiryTime = Date.now() + this.config.session.ttl;
+          const tokenPayload = JSON.parse(
+            Buffer.from(credentials.authorization.split(`·`)[1], 'base64').toString()
+          );
+
+          if (tokenPayload.exp) {
+            expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
+          }
           const cookie: SecuritySessionCookie = {
             username: user.username,
             credentials: {
               authHeaderValue: credentials.authorization,
             },
             authType: 'saml', // TODO: create constant
-            expiryTime: Date.now() + this.config.session.ttl,
+            expiryTime,
           };
           this.sessionStorageFactory.asScoped(request).set(cookie);
           return response.redirected({
@@ -166,13 +175,23 @@ export class SamlAuthRoutes {
             'authorization',
             credentials.authorization
           );
+
+          let expiryTime = Date.now() + this.config.session.ttl;
+          const tokenPayload = JSON.parse(
+            Buffer.from(credentials.authorization.split(`·`)[1], 'base64').toString()
+          );
+
+          if (tokenPayload.exp) {
+            expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
+          }
+
           const cookie: SecuritySessionCookie = {
             username: user.username,
             credentials: {
               authHeaderValue: credentials.authorization,
             },
             authType: 'saml', // TODO: create constant
-            expiryTime: Date.now() + this.config.session.ttl,
+            expiryTime,
           };
           this.sessionStorageFactory.asScoped(request).set(cookie);
           return response.redirected({


### PR DESCRIPTION
…lable

*Issue #, if available:* We want to use the SAML token expiry value for cookie expiry if it is available. Otherwise we will default to using session timeout.

This is to make sure 7.9+ versions behave the same as older 7.x versions - https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/blob/opendistro-1.4/lib/auth/types/saml/Saml.js#L69-L72

*Description of changes:* Tested on local desktop


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
