### PR TITLE
Fix github integration test for 1.13.0.1

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,14 +44,14 @@ jobs:
       - name: Get Opendistro version
         id: opendistro_version
         run: |
-          echo "::set-output name=opendistro_version::$(jq -r '.version' ./kibana/plugins/opendistro_security/package.json)"
+          echo "::set-output name=opendistro_version::$(jq -r '.version' ./kibana/plugins/opendistro_security/package.json | sed 's/[0-9]*$/0/')"
 
       - name: Run elasticsearch with plugin
         run: |
           wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${{ steps.kbn_version.outputs.kbn_version }}-linux-x86_64.tar.gz
           tar -xzf elasticsearch-oss-${{ steps.kbn_version.outputs.kbn_version }}-linux-x86_64.tar.gz
           cd elasticsearch-${{ steps.kbn_version.outputs.kbn_version }}/
-          bin/elasticsearch-plugin install -b https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-security/opendistro_security-${{ steps.opendistro_version.outputs.opendistro_version }}.zip
+          bin/elasticsearch-plugin install -b https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-security/opendistro-security-${{ steps.opendistro_version.outputs.opendistro_version }}.zip
           bash plugins/opendistro_security/tools/install_demo_configuration.sh -y -i
           echo 'opendistro_security.unsupported.restapi.allow_securityconfig_modification: true' >> config/elasticsearch.yml
           echo $(curl -s -o /dev/null -w ''%{http_code}'' https://localhost:9200 -u admin:admin -k)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix github integration test for 1.13.0.1. The (ES) security plugin link is using `1.13.0.0` rather than `1.13.0.1`. This change replace the Build number to 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
