### PR TITLE
Updated logic for splitting SAML JWT token. This should not throw the…

### DIFF
--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -121,9 +121,11 @@ export class SamlAuthRoutes {
           );
 
           let expiryTime = Date.now() + this.config.session.ttl;
-          const tokenPayload = JSON.parse(
-            Buffer.from(credentials.authorization.split(`·`)[1], 'base64').toString()
-          );
+          const [headerEncoded, payloadEncoded, signature] = credentials.authorization.split('.');
+          if (!payloadEncoded) {
+            context.security_plugin.logger.error('JWT token payload not found');
+          }
+          const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
 
           if (tokenPayload.exp) {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
@@ -177,9 +179,11 @@ export class SamlAuthRoutes {
           );
 
           let expiryTime = Date.now() + this.config.session.ttl;
-          const tokenPayload = JSON.parse(
-            Buffer.from(credentials.authorization.split(`·`)[1], 'base64').toString()
-          );
+          const [headerEncoded, payloadEncoded, signature] = credentials.authorization.split('.');
+          if (!payloadEncoded) {
+            context.security_plugin.logger.error('JWT token payload not found');
+          }
+          const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
 
           if (tokenPayload.exp) {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;


### PR DESCRIPTION
Updated logic for splitting SAML JWT token. This should not throw the parsing error for saml/acs api

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.